### PR TITLE
[codex] Improve autoresearch workflow controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For direct CLI use from the repository root:
 node plugins/codex-autoresearch/scripts/autoresearch.mjs setup --cwd /path/to/project --name "test speed" --metric-name seconds --metric-unit s --direction lower --benchmark-command "npm test -- --runInBand" --checks-command "npm test" --max-iterations 50
 node plugins/codex-autoresearch/scripts/autoresearch.mjs doctor --cwd /path/to/project --check-benchmark
 node plugins/codex-autoresearch/scripts/autoresearch.mjs next --cwd /path/to/project
-node plugins/codex-autoresearch/scripts/autoresearch.mjs log --cwd /path/to/project --metric 12.3 --status keep --description "Use worker pool" --commit-paths "src,test"
+node plugins/codex-autoresearch/scripts/autoresearch.mjs log --cwd /path/to/project --from-last --status keep --description "Use worker pool" --commit-paths "src,test"
 node plugins/codex-autoresearch/scripts/autoresearch.mjs export --cwd /path/to/project
 ```
 
@@ -131,10 +131,10 @@ finalize Split the kept fixture change into a review branch when the noisy loop 
 
 | Part | What it does |
 | --- | --- |
-| MCP tools | `setup_session`, `setup_research_session`, `init_experiment`, `run_experiment`, `next_experiment`, `log_experiment`, `read_state`, `measure_quality_gap`, `doctor_session`, `export_dashboard`, `clear_session` |
+| MCP tools | `setup_session`, `setup_research_session`, `configure_session`, `init_experiment`, `run_experiment`, `next_experiment`, `log_experiment`, `read_state`, `measure_quality_gap`, `doctor_session`, `export_dashboard`, `clear_session` |
 | Skills | Create/resume loops, turn deep research into quality gaps, export dashboards, finalize noisy branches |
 | Commands | `/autoresearch` and `/autoresearch-finalize` workflow docs |
-| Dashboard | Static HTML report generated from `autoresearch.jsonl` |
+| Dashboard | HTML operator cockpit generated from `autoresearch.jsonl`, with embedded snapshot data, live refresh, and copyable commands |
 | Templates | Starter `autoresearch.md`, shell/PowerShell benchmark scripts, and checks scripts |
 
 ## MCP Tools
@@ -143,6 +143,7 @@ finalize Split the kept fixture change into a review branch when the noisy loop 
 | --- | --- |
 | `setup_session` | Creates `autoresearch.md`, benchmark/check scripts, `autoresearch.ideas.md`, optional max-iteration config, and the initial JSONL config header |
 | `setup_research_session` | Creates `autoresearch.research/<slug>/`, initializes a `quality_gap` session, and writes a benchmark script that measures open gaps |
+| `configure_session` | Updates runtime config such as autonomy mode, checks policy, keep policy, dashboard refresh, scoped paths, and max iterations |
 | `init_experiment` | Writes the session config header: name, metric, unit, and direction |
 | `run_experiment` | Runs the benchmark command, times it, captures output, and parses `METRIC name=value` lines |
 | `next_experiment` | Runs preflight and benchmark in one packet, then returns allowed log decisions and a next-run notes template |
@@ -199,6 +200,7 @@ Then it creates:
 | `autoresearch.sh` or `autoresearch.ps1` | Benchmark script that prints `METRIC name=value` lines |
 | `autoresearch.checks.sh` or `autoresearch.checks.ps1` | Optional correctness checks after a passing benchmark |
 | `autoresearch.jsonl` | Append-only run log |
+| last-run packet | Latest `next` packet for quick keep/discard logging with `--from-last`; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json` |
 | `autoresearch.ideas.md` | Optional backlog for promising ideas |
 
 The deterministic setup path is available as MCP `setup_session` and CLI `setup`. It is the fastest way to create a fresh, resumable Codex session without hand-copying templates.
@@ -216,6 +218,12 @@ Kept results are committed. If Git cannot add or commit the kept change, logging
 For tighter keep commits and safer discard cleanup, pass `--commit-paths "src,test"` or configure `commitPaths` through setup. Discarded, crashed, or checks-failed results use those paths as the cleanup boundary. Without scoped paths, the helper refuses broad discard cleanup in a dirty Git tree unless `--allow-dirty-revert` is passed explicitly.
 
 Every run should include next-run notes, stored as ASI (actionable side information). This is structured context for the next session: what was tried, what failed, what surprised Codex, and what to try next.
+
+After `next`, the helper persists a last-run packet. Use `log --from-last` to reuse the parsed primary metric, secondary metrics, and ASI template instead of retyping them:
+
+```bash
+node plugins/codex-autoresearch/scripts/autoresearch.mjs log --cwd /path/to/project --from-last --status keep --description "Use worker pool"
+```
 
 Minimum useful ASI is one compact JSON object:
 
@@ -262,11 +270,13 @@ To draft the grouping file first:
 node plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs plan --output groups.json --goal short-goal
 ```
 
+Use `--collapse-overlap` when overlapping draft groups should become one review branch automatically.
+
 Finalization writes a local review packet under `.git/autoresearch-finalize/` with branch stats, suggested PR titles/bodies, review commands, verification status, and cleanup notes.
 
 ## Dashboard
 
-Generate a static dashboard with:
+Generate the dashboard with:
 
 ```bash
 node plugins/codex-autoresearch/scripts/autoresearch.mjs export --cwd /path/to/project
@@ -283,6 +293,8 @@ The dashboard shows:
 - baseline vs. best
 - improvement percentage
 - kept run count
+- live refresh status plus `Refresh` and `Live on` controls that try to read the adjacent `autoresearch.jsonl`
+- copyable operator commands for doctor, next, keep/discard last packet, export, and extend
 - operator readout with best kept change, recent failures, next action, and confidence explanation
 - segment selector for multi-phase sessions
 - ready-to-finalize readout

--- a/plugins/codex-autoresearch/.gitignore
+++ b/plugins/codex-autoresearch/.gitignore
@@ -8,6 +8,7 @@ tmp/
 /autoresearch.ideas.md
 /autoresearch.research/
 /autoresearch.config.json
+/autoresearch.last-run.json
 /autoresearch.sh
 /autoresearch.ps1
 /autoresearch.checks.sh

--- a/plugins/codex-autoresearch/.mcp.json
+++ b/plugins/codex-autoresearch/.mcp.json
@@ -7,7 +7,7 @@
         "--mcp"
       ],
       "cwd": ".",
-      "note": "Local no-dependency MCP server exposing setup_session, setup_research_session, init_experiment, run_experiment, next_experiment, log_experiment, read_state, measure_quality_gap, doctor_session, export_dashboard, and clear_session tools for Codex autoresearch loops."
+      "note": "Local no-dependency MCP server exposing setup_session, setup_research_session, configure_session, init_experiment, run_experiment, next_experiment, log_experiment, read_state, measure_quality_gap, doctor_session, export_dashboard, and clear_session tools for Codex autoresearch loops."
     }
   }
 }

--- a/plugins/codex-autoresearch/README.md
+++ b/plugins/codex-autoresearch/README.md
@@ -110,7 +110,7 @@ For direct CLI use from this plugin folder:
 node scripts/autoresearch.mjs setup --cwd /path/to/project --name "test speed" --metric-name seconds --metric-unit s --direction lower --benchmark-command "npm test -- --runInBand" --checks-command "npm test" --max-iterations 50
 node scripts/autoresearch.mjs doctor --cwd /path/to/project --check-benchmark
 node scripts/autoresearch.mjs next --cwd /path/to/project
-node scripts/autoresearch.mjs log --cwd /path/to/project --metric 12.3 --status keep --description "Use worker pool" --commit-paths "src,test"
+node scripts/autoresearch.mjs log --cwd /path/to/project --from-last --status keep --description "Use worker pool" --commit-paths "src,test"
 node scripts/autoresearch.mjs export --cwd /path/to/project
 ```
 
@@ -131,10 +131,10 @@ finalize Split the kept fixture change into a review branch when the noisy loop 
 
 | Part | What it does |
 | --- | --- |
-| MCP tools | `setup_session`, `setup_research_session`, `init_experiment`, `run_experiment`, `next_experiment`, `log_experiment`, `read_state`, `measure_quality_gap`, `doctor_session`, `export_dashboard`, `clear_session` |
+| MCP tools | `setup_session`, `setup_research_session`, `configure_session`, `init_experiment`, `run_experiment`, `next_experiment`, `log_experiment`, `read_state`, `measure_quality_gap`, `doctor_session`, `export_dashboard`, `clear_session` |
 | Skills | Create/resume loops, turn deep research into quality gaps, export dashboards, finalize noisy branches |
 | Commands | `/autoresearch` and `/autoresearch-finalize` workflow docs |
-| Dashboard | Static HTML report generated from `autoresearch.jsonl` |
+| Dashboard | HTML operator cockpit generated from `autoresearch.jsonl`, with embedded snapshot data, live refresh, and copyable commands |
 | Templates | Starter `autoresearch.md`, shell/PowerShell benchmark scripts, and checks scripts |
 
 ## MCP Tools
@@ -143,6 +143,7 @@ finalize Split the kept fixture change into a review branch when the noisy loop 
 | --- | --- |
 | `setup_session` | Creates `autoresearch.md`, benchmark/check scripts, `autoresearch.ideas.md`, optional max-iteration config, and the initial JSONL config header |
 | `setup_research_session` | Creates `autoresearch.research/<slug>/`, initializes a `quality_gap` session, and writes a benchmark script that measures open gaps |
+| `configure_session` | Updates runtime config such as autonomy mode, checks policy, keep policy, dashboard refresh, scoped paths, and max iterations |
 | `init_experiment` | Writes the session config header: name, metric, unit, and direction |
 | `run_experiment` | Runs the benchmark command, times it, captures output, and parses `METRIC name=value` lines |
 | `next_experiment` | Runs preflight and benchmark in one packet, then returns allowed log decisions and a next-run notes template |
@@ -199,6 +200,7 @@ Then it creates:
 | `autoresearch.sh` or `autoresearch.ps1` | Benchmark script that prints `METRIC name=value` lines |
 | `autoresearch.checks.sh` or `autoresearch.checks.ps1` | Optional correctness checks after a passing benchmark |
 | `autoresearch.jsonl` | Append-only run log |
+| last-run packet | Latest `next` packet for quick keep/discard logging with `--from-last`; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json` |
 | `autoresearch.ideas.md` | Optional backlog for promising ideas |
 
 The deterministic setup path is available as MCP `setup_session` and CLI `setup`. It is the fastest way to create a fresh, resumable Codex session without hand-copying templates.
@@ -216,6 +218,12 @@ Kept results are committed. If Git cannot add or commit the kept change, logging
 For tighter keep commits and safer discard cleanup, pass `--commit-paths "src,test"` or configure `commitPaths` through setup. Discarded, crashed, or checks-failed results use those paths as the cleanup boundary. Without scoped paths, the helper refuses broad discard cleanup in a dirty Git tree unless `--allow-dirty-revert` is passed explicitly.
 
 Every run should include next-run notes, stored as ASI (actionable side information). This is structured context for the next session: what was tried, what failed, what surprised Codex, and what to try next.
+
+After `next`, the helper persists a last-run packet. Use `log --from-last` to reuse the parsed primary metric, secondary metrics, and ASI template instead of retyping them:
+
+```bash
+node scripts/autoresearch.mjs log --cwd /path/to/project --from-last --status keep --description "Use worker pool"
+```
 
 Minimum useful ASI is one compact JSON object:
 
@@ -262,11 +270,13 @@ To draft the grouping file first:
 node scripts/finalize-autoresearch.mjs plan --output groups.json --goal short-goal
 ```
 
+Use `--collapse-overlap` when overlapping draft groups should become one review branch automatically.
+
 Finalization writes a local review packet under `.git/autoresearch-finalize/` with branch stats, suggested PR titles/bodies, review commands, verification status, and cleanup notes.
 
 ## Dashboard
 
-Generate a static dashboard with:
+Generate the dashboard with:
 
 ```bash
 node scripts/autoresearch.mjs export --cwd /path/to/project
@@ -283,6 +293,8 @@ The dashboard shows:
 - baseline vs. best
 - improvement percentage
 - kept run count
+- live refresh status plus `Refresh` and `Live on` controls that try to read the adjacent `autoresearch.jsonl`
+- copyable operator commands for doctor, next, keep/discard last packet, export, and extend
 - operator readout with best kept change, recent failures, next action, and confidence explanation
 - segment selector for multi-phase sessions
 - ready-to-finalize readout

--- a/plugins/codex-autoresearch/assets/template.html
+++ b/plugins/codex-autoresearch/assets/template.html
@@ -105,6 +105,44 @@ h1 {
   padding: 8px 10px;
   font: inherit;
 }
+.live-strip {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  margin: 18px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+.live-status {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+.live-status strong {
+  display: block;
+  color: var(--ink);
+  font-size: 14px;
+}
+.tool-button {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f9fafb;
+  color: var(--ink);
+  min-height: 38px;
+  padding: 8px 11px;
+  font: inherit;
+  font-weight: 750;
+  cursor: pointer;
+}
+.tool-button:hover { border-color: var(--graph); }
+.tool-button[aria-pressed="true"] {
+  background: var(--graph);
+  color: #fff;
+  border-color: var(--graph);
+}
 .score {
   background: var(--surface);
   border: 1px solid var(--line);
@@ -290,11 +328,37 @@ th {
   color: var(--muted);
   text-align: center;
 }
+.command-grid {
+  display: grid;
+  gap: 8px;
+  padding: 14px 18px 18px;
+}
+.command-row {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  border-top: 1px solid var(--soft-line);
+  padding-top: 8px;
+}
+.command-label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+.command-code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 12px;
+}
 @media (max-width: 940px) {
   .wrap { padding: 18px; }
   .masthead, .layout { grid-template-columns: 1fr; }
   .readout-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .control-strip { align-items: stretch; flex-direction: column; }
+  .live-strip, .command-row { grid-template-columns: 1fr; }
   .metric-tag { justify-self: stretch; }
   .score-strip { grid-template-columns: repeat(2, minmax(130px, 1fr)); }
   svg { height: 280px; }
@@ -331,6 +395,15 @@ th {
       <select id="segment-select"></select>
     </label>
     <span class="panel-note" id="segment-note">Latest segment</span>
+  </section>
+
+  <section class="live-strip" aria-label="Live dashboard controls">
+    <div class="live-status">
+      <strong id="live-title">Snapshot loaded</strong>
+      <span id="live-detail">Static export</span>
+    </div>
+    <button class="tool-button" id="refresh-now" type="button">Refresh</button>
+    <button class="tool-button" id="live-toggle" type="button" aria-pressed="false">Live off</button>
   </section>
 
   <section class="panel readout" aria-label="Operator readout">
@@ -387,6 +460,14 @@ th {
     </aside>
   </section>
 
+  <section class="panel" aria-label="Command shortcuts">
+    <div class="panel-head">
+      <h2 class="panel-title">Commands</h2>
+      <span class="panel-note" id="command-note">Copy and run from a terminal</span>
+    </div>
+    <div class="command-grid" id="command-grid"></div>
+  </section>
+
   <section class="panel ledger" aria-label="Experiment ledger">
     <table>
       <thead>
@@ -407,7 +488,8 @@ th {
 </main>
 
 <script>
-const entries = __AUTORESEARCH_DATA__;
+let entries = __AUTORESEARCH_DATA__;
+const meta = __AUTORESEARCH_META__;
 const validStatuses = new Set(["keep", "discard", "crash", "checks_failed"]);
 const palette = {
   line: "#d7ded9",
@@ -465,14 +547,17 @@ function normalize() {
   };
 }
 
-const normalized = normalize();
+let normalized = normalize();
 let activeSegment = normalized.latestSegment;
 let session = selectSegment(activeSegment);
 let metricValues = [];
 let baseline = null;
 let best = null;
+let liveEnabled = false;
+let liveTimer = null;
 
 render();
+initLiveControls();
 
 function selectSegment(segment) {
   return normalized.segments.find((item) => item.segment === Number(segment))
@@ -505,7 +590,64 @@ function render() {
   renderReadout();
   renderChart();
   renderRail();
+  renderCommands();
   renderLedger();
+}
+
+function initLiveControls() {
+  updateLiveStatus("Snapshot loaded", meta.generatedAt ? "Generated " + meta.generatedAt : "Static export");
+  const refreshButton = document.getElementById("refresh-now");
+  const liveButton = document.getElementById("live-toggle");
+  if (refreshButton) refreshButton.onclick = () => refreshEntries();
+  if (liveButton) {
+    liveButton.onclick = () => {
+      liveEnabled = !liveEnabled;
+      liveButton.setAttribute("aria-pressed", liveEnabled ? "true" : "false");
+      liveButton.textContent = liveEnabled ? "Live on" : "Live off";
+      if (liveEnabled) {
+        refreshEntries();
+        if (typeof setInterval === "function" && !liveTimer) {
+          liveTimer = setInterval(refreshEntries, Number(meta.refreshMs || 5000));
+        }
+      } else if (typeof clearInterval === "function" && liveTimer) {
+        clearInterval(liveTimer);
+        liveTimer = null;
+      }
+    };
+  }
+}
+
+function updateLiveStatus(title, detail) {
+  const titleEl = document.getElementById("live-title");
+  const detailEl = document.getElementById("live-detail");
+  if (titleEl) titleEl.textContent = title;
+  if (detailEl) detailEl.textContent = detail;
+}
+
+function parseJsonl(text) {
+  return text.split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function refreshEntries() {
+  if (typeof fetch !== "function") {
+    updateLiveStatus("Live refresh unavailable", "This browser context does not expose fetch.");
+    return;
+  }
+  try {
+    const response = await fetch((meta.jsonlName || "autoresearch.jsonl") + "?t=" + Date.now(), { cache: "no-store" });
+    if (!response.ok) throw new Error("HTTP " + response.status);
+    const nextEntries = parseJsonl(await response.text());
+    entries = nextEntries;
+    normalized = normalize();
+    if (!selectSegment(activeSegment).runs.length) activeSegment = normalized.latestSegment;
+    render();
+    updateLiveStatus("Live data refreshed", new Date().toLocaleTimeString());
+  } catch (error) {
+    updateLiveStatus("Live refresh failed", error.message || String(error));
+  }
 }
 
 function renderSegmentSelector() {
@@ -730,6 +872,42 @@ function renderRail() {
       '<div class="status-pill ' + statusClass(run.status) + '">' + escapeHtml(run.status) + '</div>' +
       '</div>';
   }).join("");
+}
+
+function renderCommands() {
+  const grid = document.getElementById("command-grid");
+  const commands = Array.isArray(meta.commands) ? meta.commands : [];
+  if (!grid) return;
+  if (!commands.length) {
+    grid.innerHTML = '<div class="empty">No command shortcuts were embedded in this export.</div>';
+    return;
+  }
+  grid.innerHTML = commands.map((item, index) => {
+    return '<div class="command-row">' +
+      '<span class="command-label">' + escapeHtml(item.label || "Command") + '</span>' +
+      '<code class="command-code" title="' + escapeHtml(item.command || "") + '">' + escapeHtml(item.command || "") + '</code>' +
+      '<button class="tool-button copy-command" type="button" data-command-index="' + index + '">Copy</button>' +
+      '</div>';
+  }).join("");
+  for (const button of grid.querySelectorAll ? grid.querySelectorAll(".copy-command") : []) {
+    button.onclick = async () => {
+      const command = commands[Number(button.dataset.commandIndex)]?.command || "";
+      try {
+        const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : null;
+        if (!clipboard?.writeText) {
+          button.textContent = "Select";
+          return;
+        }
+        await clipboard.writeText(command);
+        button.textContent = "Copied";
+        if (typeof setTimeout === "function") {
+          setTimeout(() => { button.textContent = "Copy"; }, 1200);
+        }
+      } catch {
+        button.textContent = "Select";
+      }
+    };
+  }
 }
 
 function renderLedger() {

--- a/plugins/codex-autoresearch/commands/autoresearch.md
+++ b/plugins/codex-autoresearch/commands/autoresearch.md
@@ -13,6 +13,7 @@ When this repository is the target, use the local plugin over any globally insta
 - Empty or `help`: summarize available actions.
 - `doctor`: run `node <plugin-root>/scripts/autoresearch.mjs doctor --cwd <current-project> --check-benchmark` when a benchmark is configured, then report issues, warnings, and next action.
 - `next`: run `node <plugin-root>/scripts/autoresearch.mjs next --cwd <current-project>`, then report doctor status, metric, allowed log statuses, ASI template, and next action.
+- `config ...`: run `node <plugin-root>/scripts/autoresearch.mjs config --cwd <current-project> ...` for runtime settings such as `--autonomy-mode`, `--checks-policy`, `--keep-policy`, `--extend`, and `--dashboard-refresh-seconds`.
 - `status`: run `node <plugin-root>/scripts/autoresearch.mjs state --cwd <current-project>` and summarize.
 - `export`: use the `autoresearch-dashboard` skill or run `node <plugin-root>/scripts/autoresearch.mjs export --cwd <current-project>`.
 - `off`: stop continuing the loop in this conversation. Do not delete files; report where the session can be resumed.
@@ -27,6 +28,8 @@ Before `clear`, show the absolute files that will be deleted and ask for confirm
 Before starting a new loop, check git status. If the worktree is dirty, ask whether to branch from the current state, commit first, or stop.
 
 Before logging a kept result in a dirty tree, prefer scoped commit paths from the session scope or ask the user to confirm broad staging.
+
+After `next`, prefer `log --from-last` so Codex does not retype parsed metrics from the previous packet. Still choose `keep` or `discard` deliberately based on the metric and ASI.
 
 Before logging a discard/crash/checks-failed result, use configured `commitPaths`/`revertPaths`. Do not pass `--allow-dirty-revert` unless the user explicitly accepts broad cleanup.
 

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -224,6 +224,8 @@ function renderSessionDocument(args) {
   const scope = listOption(args.files_in_scope ?? args.filesInScope ?? args.scope);
   const offLimits = listOption(args.off_limits ?? args.offLimits);
   const constraints = listOption(args.constraints);
+  const constraintsPlaceholder = "- <Correctness, compatibility, dependency,"
+    + " or budget constraints>";
   const secondary = listOption(args.secondary_metrics ?? args.secondaryMetrics);
   const benchmarkCommand = args.benchmark_command || args.benchmarkCommand || "./autoresearch.sh";
   const metricUnit = args.metric_unit ?? args.metricUnit ?? "";
@@ -237,7 +239,7 @@ function renderSessionDocument(args) {
     "`<benchmark command>` prints `METRIC name=value` lines.": `\`${benchmarkCommand}\` prints \`METRIC name=value\` lines.`,
     "- `<path>`: <why it matters>": markdownList(scope, "TBD: add files after initial inspection"),
     "- `<path or behavior>`: <reason>": markdownList(offLimits, "TBD: add off-limits files or behaviors if needed"),
-    "- <Correctness, compatibility, dependency, or budget constraints>": markdownList(constraints, "TBD: add correctness and compatibility constraints"),
+    [constraintsPlaceholder]: markdownList(constraints, "TBD: add correctness and compatibility constraints"),
     "- Baseline: <initial metric and notes>": "- Baseline: pending",
   });
 }
@@ -643,7 +645,7 @@ async function defaultBenchmarkCommand(workDir) {
   if (await pathExists(path.join(workDir, "autoresearch.sh"))) {
     return "bash ./autoresearch.sh";
   }
-  throw new Error("No command provided and no autoresearch.ps1 or autoresearch.sh exists.");
+  throw new Error("No command provided; expected autoresearch.ps1 or autoresearch.sh in the work directory.");
 }
 
 async function defaultChecksCommand(workDir) {
@@ -1045,7 +1047,8 @@ async function runExperiment(args) {
   const metricError = benchmarkPassed && !primaryPresent
     ? `Benchmark completed but did not print primary metric METRIC ${state.config.metricName}=<number>.`
     : null;
-  const passed = benchmarkPassed && primaryPresent && (checksPassed === null || checksPassed);
+  const checksPassedOrSkipped = checksPassed === null || checksPassed;
+  const passed = benchmarkPassed && primaryPresent && checksPassedOrSkipped;
   const failedStatus = benchmarkPassed && primaryPresent ? "checks_failed" : "crash";
   const allowedStatuses = passed ? ["keep", "discard"] : [failedStatus];
   return {
@@ -1490,7 +1493,7 @@ const toolSchemas = [
   },
   {
     name: "log_experiment",
-    description: "Append an experiment result and keep/commit or discard/revert changes.",
+    description: "Append an experiment result, then keep/commit or discard/revert changes.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1660,6 +1663,10 @@ async function handleMcpMessage(message) {
   }
 }
 
+function isObjectArgument(value) {
+  return typeof value === "object" && !Array.isArray(value);
+}
+
 function validateToolArguments(name, args) {
   const schema = toolSchemas.find((tool) => tool.name === name)?.inputSchema;
   if (!schema) throw new Error(`Unknown tool: ${name}`);
@@ -1670,7 +1677,7 @@ function validateToolArguments(name, args) {
     const property = schema.properties?.[key];
     if (!property || value == null) continue;
     if (property.type === "array" && !Array.isArray(value)) throw new Error(`Argument ${key} must be an array.`);
-    if (property.type === "object" && (typeof value !== "object" || Array.isArray(value))) throw new Error(`Argument ${key} must be an object.`);
+    if (property.type === "object" && !isObjectArgument(value)) throw new Error(`Argument ${key} must be an object.`);
     if (property.type === "number" && typeof value !== "number") throw new Error(`Argument ${key} must be a number.`);
     if (property.type === "boolean" && typeof value !== "boolean") throw new Error(`Argument ${key} must be a boolean.`);
     if (property.type === "string" && typeof value !== "string") throw new Error(`Argument ${key} must be a string.`);

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -798,6 +798,18 @@ async function cleanupDiscardChanges(workDir, args, config) {
   throw new Error("Refusing broad discard cleanup in a dirty Git tree without scoped revert paths. Configure commitPaths/revertPaths or pass --allow-dirty-revert.");
 }
 
+async function appendRuntimeConfigFile(files, sessionCwd, updates) {
+  if (Object.keys(updates).length === 0) return;
+  const configPath = path.join(sessionCwd, "autoresearch.config.json");
+  const existing = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+  const nextConfig = { ...existing, ...updates };
+  files.push(await writeSessionFile(
+    configPath,
+    JSON.stringify(nextConfig, null, 2),
+    { overwrite: true },
+  ));
+}
+
 async function setupSession(args) {
   const { sessionCwd, workDir } = resolveWorkDir(args.working_dir || args.cwd);
   if (!args.name) throw new Error("name is required");
@@ -835,25 +847,11 @@ async function setupSession(args) {
 
   const maxIterations = numberOption(args.max_iterations ?? args.maxIterations, null);
   if (maxIterations != null) {
-    const configPath = path.join(sessionCwd, "autoresearch.config.json");
-    const existing = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    const nextConfig = { ...existing, maxIterations: Math.floor(maxIterations) };
-    files.push(await writeSessionFile(
-      configPath,
-      JSON.stringify(nextConfig, null, 2),
-      { overwrite: true },
-    ));
+    await appendRuntimeConfigFile(files, sessionCwd, { maxIterations: Math.floor(maxIterations) });
   }
   const commitPaths = normalizeRelativePaths(args.commit_paths ?? args.commitPaths, "commitPaths");
   if (commitPaths.length > 0) {
-    const configPath = path.join(sessionCwd, "autoresearch.config.json");
-    const existing = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    const nextConfig = { ...existing, commitPaths };
-    files.push(await writeSessionFile(
-      configPath,
-      JSON.stringify(nextConfig, null, 2),
-      { overwrite: true },
-    ));
+    await appendRuntimeConfigFile(files, sessionCwd, { commitPaths });
   }
 
   let init = null;
@@ -940,12 +938,10 @@ async function setupResearchSession(args) {
   const maxIterations = numberOption(args.max_iterations ?? args.maxIterations, null);
   const commitPaths = normalizeRelativePaths(args.commit_paths ?? args.commitPaths, "commitPaths");
   if (maxIterations != null || commitPaths.length > 0) {
-    const configPath = path.join(sessionCwd, "autoresearch.config.json");
-    const existing = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    const nextConfig = { ...existing };
+    const nextConfig = {};
     if (maxIterations != null) nextConfig.maxIterations = Math.floor(maxIterations);
     if (commitPaths.length > 0) nextConfig.commitPaths = commitPaths;
-    files.push(await writeSessionFile(configPath, JSON.stringify(nextConfig, null, 2), { overwrite: true }));
+    await appendRuntimeConfigFile(files, sessionCwd, nextConfig);
   }
 
   let init = null;

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -297,11 +297,12 @@ function renderResearchBenchmarkScript(slug, shellKind) {
   ].join("\n");
 }
 
-function renderResearchFile(fileName, args, slug) {
-  const goal = args.goal || args.name || slug;
-  const title = goal.replace(/\s+/g, " ").trim();
-  if (fileName === "brief.md") {
-    return `# Research Brief: ${title}
+function researchTitle(value) {
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function renderResearchBrief({ title, goal, args }) {
+  return `# Research Brief: ${title}
 
 ## Request
 ${goal}
@@ -321,9 +322,10 @@ ${markdownList(listOption(args.constraints), "TBD: add constraints as they are d
 ## Known Unknowns
 - TBD: add unresolved questions before delegating or implementing.
 `;
-  }
-  if (fileName === "plan.md") {
-    return `# Research Plan: ${title}
+}
+
+function renderResearchPlan({ title }) {
+  return `# Research Plan: ${title}
 
 ## Workstreams
 - Project essence and audience
@@ -337,9 +339,10 @@ ${markdownList(listOption(args.constraints), "TBD: add constraints as they are d
 - Convert actionable findings into \`quality-gaps.md\`.
 - Iterate with \`/autoresearch next\` until \`quality_gap=0\`.
 `;
-  }
-  if (fileName === "tasks.md") {
-    return `# Research Tasks: ${title}
+}
+
+function renderResearchTasks({ title }) {
+  return `# Research Tasks: ${title}
 
 ## queued
 - Capture project essence from repo evidence.
@@ -355,17 +358,19 @@ ${markdownList(listOption(args.constraints), "TBD: add constraints as they are d
 ## blockers
 - None.
 `;
-  }
-  if (fileName === "sources.md") {
-    return `# Research Sources: ${title}
+}
+
+function renderResearchSources({ title }) {
+  return `# Research Sources: ${title}
 
 | Source | Date Checked | Claim Supported | Confidence |
 | --- | --- | --- | --- |
 | TBD | TBD | TBD | TBD |
 `;
-  }
-  if (fileName === "synthesis.md") {
-    return `# Research Synthesis: ${title}
+}
+
+function renderResearchSynthesis({ title }) {
+  return `# Research Synthesis: ${title}
 
 ## Project Essence
 - TBD: summarize what the project is trying to become.
@@ -379,9 +384,10 @@ ${markdownList(listOption(args.constraints), "TBD: add constraints as they are d
 ## Confidence And Gaps
 - TBD: record confidence, contradictions, and unresolved questions.
 `;
-  }
-  if (fileName === "quality-gaps.md") {
-    return `# Quality Gaps: ${title}
+}
+
+function renderResearchQualityGaps({ title }) {
+  return `# Quality Gaps: ${title}
 
 - [ ] Project essence is accurate and source-backed.
 - [ ] Sources are logged with dates, claims, and confidence.
@@ -390,7 +396,21 @@ ${markdownList(listOption(args.constraints), "TBD: add constraints as they are d
 - [ ] Correctness checks pass after kept changes.
 - [ ] Final handoff includes dashboard or state evidence.
 `;
-  }
+}
+
+const RESEARCH_FILE_RENDERERS = {
+  "brief.md": renderResearchBrief,
+  "plan.md": renderResearchPlan,
+  "tasks.md": renderResearchTasks,
+  "sources.md": renderResearchSources,
+  "synthesis.md": renderResearchSynthesis,
+  "quality-gaps.md": renderResearchQualityGaps,
+};
+
+function renderResearchFile(fileName, args, slug) {
+  const goal = args.goal || args.name || slug;
+  const renderer = RESEARCH_FILE_RENDERERS[fileName];
+  if (renderer) return renderer({ title: researchTitle(goal), goal, args });
   throw new Error(`Unknown research file template: ${fileName}`);
 }
 

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -15,10 +15,14 @@ const SESSION_FILES = [
   "autoresearch.checks.sh",
   "autoresearch.checks.ps1",
   "autoresearch.config.json",
+  "autoresearch.last-run.json",
 ];
 const RESEARCH_DIR = "autoresearch.research";
 
 const STATUS_VALUES = new Set(["keep", "discard", "crash", "checks_failed"]);
+const AUTONOMY_MODES = new Set(["guarded", "owner-autonomous", "manual"]);
+const CHECKS_POLICIES = new Set(["always", "on-improvement", "manual"]);
+const KEEP_POLICIES = new Set(["primary-only", "primary-or-risk-reduction"]);
 const DENIED_METRIC_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 const METRIC_NAME_PATTERN = /^[^=\s]+$/;
 const DEFAULT_TIMEOUT_SECONDS = 600;
@@ -40,9 +44,10 @@ Usage:
   node scripts/autoresearch.mjs init --cwd <project> --name <name> --metric-name <name> [--metric-unit <unit>] [--direction lower|higher]
   node scripts/autoresearch.mjs run --cwd <project> [--command <cmd>] [--timeout-seconds <n>]
   node scripts/autoresearch.mjs next --cwd <project> [--command <cmd>] [--timeout-seconds <n>]
+  node scripts/autoresearch.mjs config --cwd <project> [--autonomy-mode guarded|owner-autonomous|manual] [--checks-policy always|on-improvement|manual] [--extend <n>]
   node scripts/autoresearch.mjs research-setup --cwd <project> --slug <slug> --goal <goal> [--checks-command <cmd>] [--max-iterations <n>]
   node scripts/autoresearch.mjs quality-gap --cwd <project> --research-slug <slug>
-  node scripts/autoresearch.mjs log --cwd <project> --metric <n> --status keep|discard|crash|checks_failed --description <text> [--metrics <json>] [--asi <json>] [--commit-paths <paths>] [--revert-paths <paths>]
+  node scripts/autoresearch.mjs log --cwd <project> (--metric <n>|--from-last) --status keep|discard|crash|checks_failed --description <text> [--metrics <json>] [--asi <json>] [--commit-paths <paths>] [--revert-paths <paths>]
   node scripts/autoresearch.mjs state --cwd <project>
   node scripts/autoresearch.mjs doctor --cwd <project> [--command <cmd>] [--check-benchmark]
   node scripts/autoresearch.mjs export --cwd <project> [--output <html>]
@@ -95,6 +100,15 @@ function boolOption(value, fallback = false) {
   if (value == null || value === "") return fallback;
   if (typeof value === "boolean") return value;
   return ["1", "true", "yes", "y"].includes(String(value).toLowerCase());
+}
+
+function enumOption(value, allowed, fallback, optionName) {
+  if (value == null || value === "") return fallback;
+  const normalized = String(value).toLowerCase();
+  if (!allowed.has(normalized)) {
+    throw new Error(`${optionName} must be one of ${[...allowed].join(", ")}. Got ${value}`);
+  }
+  return normalized;
 }
 
 function listOption(value) {
@@ -174,6 +188,10 @@ function readConfig(sessionCwd) {
   const configPath = path.join(sessionCwd, "autoresearch.config.json");
   if (!fs.existsSync(configPath)) return {};
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
+}
+
+function runtimeConfigPath(sessionCwd) {
+  return path.join(sessionCwd, "autoresearch.config.json");
 }
 
 function resolveWorkDir(cwdArg) {
@@ -658,6 +676,17 @@ async function defaultChecksCommand(workDir) {
   return null;
 }
 
+function checksPolicyFromArgs(args, config) {
+  return enumOption(args.checks_policy ?? args.checksPolicy ?? config.checksPolicy, CHECKS_POLICIES, "always", "checksPolicy");
+}
+
+function shouldRunChecks(policy, context) {
+  if (!context.benchmarkPassed || !context.primaryPresent || !context.checksCommand) return false;
+  if (policy === "always") return true;
+  if (policy === "on-improvement") return context.improvesPrimary || context.explicitChecksCommand;
+  return context.explicitChecksCommand;
+}
+
 async function runProcess(command, args, cwd, options = {}) {
   return await new Promise((resolve) => {
     const child = spawn(command, args, {
@@ -692,6 +721,13 @@ function gitOutput(result, fallback) {
 async function insideGitRepo(cwd) {
   const result = await git(["rev-parse", "--is-inside-work-tree"], cwd);
   return result.code === 0 && result.stdout.trim() === "true";
+}
+
+async function gitPrivatePath(cwd, relativePath) {
+  const result = await git(["rev-parse", "--git-path", relativePath], cwd);
+  if (result.code !== 0) throw new Error(`Git path lookup failed: ${gitOutput(result, "unknown error")}`);
+  const filePath = result.stdout.trim();
+  return path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
 }
 
 async function shortHead(cwd) {
@@ -749,6 +785,20 @@ async function restoreSessionFiles(workDir, saved) {
   }
 }
 
+async function appendSessionRunNote(workDir, experiment, state, messages = {}) {
+  const filePath = path.join(workDir, "autoresearch.md");
+  if (!(await pathExists(filePath))) return;
+  const parts = [
+    `- Run ${experiment.run} ${experiment.status}: ${experiment.description}`,
+    `metric=${experiment.metric}`,
+    `best=${state.best ?? "unknown"}`,
+  ];
+  if (experiment.commit) parts.push(`commit=${experiment.commit}`);
+  if (messages.revertMessage) parts.push(messages.revertMessage);
+  if (messages.gitMessage && experiment.status === "keep") parts.push(messages.gitMessage);
+  await fsp.appendFile(filePath, `\n${parts.join("; ")}.\n`, "utf8");
+}
+
 async function revertExceptSessionFiles(workDir) {
   if (!(await insideGitRepo(workDir))) return "Git: not a repo, skipped revert.";
   const saved = await preserveSessionFiles(workDir);
@@ -802,7 +852,7 @@ async function cleanupDiscardChanges(workDir, args, config) {
 
 async function appendRuntimeConfigFile(files, sessionCwd, updates) {
   if (Object.keys(updates).length === 0) return;
-  const configPath = path.join(sessionCwd, "autoresearch.config.json");
+  const configPath = runtimeConfigPath(sessionCwd);
   const existing = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
   const nextConfig = { ...existing, ...updates };
   files.push(await writeSessionFile(
@@ -810,6 +860,28 @@ async function appendRuntimeConfigFile(files, sessionCwd, updates) {
     JSON.stringify(nextConfig, null, 2),
     { overwrite: true },
   ));
+}
+
+async function writeRuntimeConfig(sessionCwd, updates) {
+  if (Object.keys(updates).length === 0) return readConfig(sessionCwd);
+  const configPath = runtimeConfigPath(sessionCwd);
+  const existing = readConfig(sessionCwd);
+  const nextConfig = { ...existing, ...updates };
+  await fsp.writeFile(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
+  return nextConfig;
+}
+
+function runtimeConfigUpdatesFromArgs(args) {
+  const updates = {};
+  const autonomyMode = enumOption(args.autonomy_mode ?? args.autonomyMode, AUTONOMY_MODES, null, "autonomyMode");
+  const checksPolicy = enumOption(args.checks_policy ?? args.checksPolicy, CHECKS_POLICIES, null, "checksPolicy");
+  const keepPolicy = enumOption(args.keep_policy ?? args.keepPolicy, KEEP_POLICIES, null, "keepPolicy");
+  const dashboardRefreshSeconds = numberOption(args.dashboard_refresh_seconds ?? args.dashboardRefreshSeconds, null);
+  if (autonomyMode) updates.autonomyMode = autonomyMode;
+  if (checksPolicy) updates.checksPolicy = checksPolicy;
+  if (keepPolicy) updates.keepPolicy = keepPolicy;
+  if (dashboardRefreshSeconds != null) updates.dashboardRefreshSeconds = Math.max(1, Math.floor(dashboardRefreshSeconds));
+  return updates;
 }
 
 async function setupSession(args) {
@@ -854,6 +926,10 @@ async function setupSession(args) {
   const commitPaths = normalizeRelativePaths(args.commit_paths ?? args.commitPaths, "commitPaths");
   if (commitPaths.length > 0) {
     await appendRuntimeConfigFile(files, sessionCwd, { commitPaths });
+  }
+  const runtimeUpdates = runtimeConfigUpdatesFromArgs(args);
+  if (Object.keys(runtimeUpdates).length > 0) {
+    await appendRuntimeConfigFile(files, sessionCwd, runtimeUpdates);
   }
 
   let init = null;
@@ -939,8 +1015,9 @@ async function setupResearchSession(args) {
 
   const maxIterations = numberOption(args.max_iterations ?? args.maxIterations, null);
   const commitPaths = normalizeRelativePaths(args.commit_paths ?? args.commitPaths, "commitPaths");
-  if (maxIterations != null || commitPaths.length > 0) {
-    const nextConfig = {};
+  const runtimeUpdates = runtimeConfigUpdatesFromArgs(args);
+  if (maxIterations != null || commitPaths.length > 0 || Object.keys(runtimeUpdates).length > 0) {
+    const nextConfig = { ...runtimeUpdates };
     if (maxIterations != null) nextConfig.maxIterations = Math.floor(maxIterations);
     if (commitPaths.length > 0) nextConfig.commitPaths = commitPaths;
     await appendRuntimeConfigFile(files, sessionCwd, nextConfig);
@@ -1003,6 +1080,30 @@ async function measureQualityGap(args) {
   };
 }
 
+async function configureSession(args) {
+  const { sessionCwd, workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
+  const updates = runtimeConfigUpdatesFromArgs(args);
+  const maxIterations = numberOption(args.max_iterations ?? args.maxIterations, null);
+  const extend = numberOption(args.extend ?? args.extendLimit, null);
+  const commitPaths = normalizeRelativePaths(args.commit_paths ?? args.commitPaths, "commitPaths");
+  if (maxIterations != null) updates.maxIterations = Math.floor(maxIterations);
+  if (extend != null) {
+    const state = currentState(workDir);
+    const activeRuns = state.current.length;
+    const currentMax = Number.isFinite(Number(config.maxIterations)) ? Math.floor(Number(config.maxIterations)) : activeRuns;
+    updates.maxIterations = Math.max(currentMax, activeRuns) + Math.floor(extend);
+  }
+  if (commitPaths.length > 0) updates.commitPaths = commitPaths;
+  const nextConfig = await writeRuntimeConfig(sessionCwd, updates);
+  return {
+    ok: true,
+    workDir,
+    sessionCwd,
+    config: nextConfig,
+    updates,
+  };
+}
+
 async function initExperiment(args) {
   const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
   if (!args.name) throw new Error("name is required");
@@ -1038,9 +1139,13 @@ async function runExperiment(args) {
   const parsedMetrics = parseMetricLines(benchmark.output);
   const primary = parsedMetrics[state.config.metricName] ?? null;
   const primaryPresent = finiteMetric(primary) != null;
+  const primaryMetric = finiteMetric(primary);
+  const improvesPrimary = primaryMetric != null && (state.best == null || isBetter(primaryMetric, state.best, state.config.bestDirection));
   let checks = null;
   const checksCommand = args.checks_command || args.checksCommand || await defaultChecksCommand(workDir);
-  if (benchmarkPassed && primaryPresent && checksCommand) {
+  const checksPolicy = checksPolicyFromArgs(args, config);
+  const explicitChecksCommand = Boolean(args.checks_command || args.checksCommand);
+  if (shouldRunChecks(checksPolicy, { benchmarkPassed, primaryPresent, checksCommand, improvesPrimary, explicitChecksCommand })) {
     checks = await runShell(checksCommand, workDir, numberOption(args.checks_timeout_seconds ?? args.checksTimeoutSeconds, DEFAULT_CHECKS_TIMEOUT_SECONDS));
   }
   const checksPassed = checks ? checks.exitCode === 0 && !checks.timedOut : null;
@@ -1061,6 +1166,8 @@ async function runExperiment(args) {
     parsedMetrics,
     parsedPrimary: primary,
     metricError,
+    checksPolicy,
+    improvesPrimary,
     outputTruncated: Boolean(benchmark.outputTruncated || checks?.outputTruncated),
     metricName: state.config.metricName,
     metricUnit: state.config.metricUnit,
@@ -1086,10 +1193,15 @@ async function runExperiment(args) {
 
 async function logExperiment(args) {
   const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
-  const metric = numberOption(args.metric, null);
+  const lastPacket = boolOption(args.from_last ?? args.fromLast, false) ? await readLastRunPacket(workDir) : null;
+  const metric = numberOption(args.metric ?? lastPacket?.decision?.metric, null);
   if (metric == null) throw new Error("metric is required");
-  if (!STATUS_VALUES.has(args.status)) throw new Error(`status must be one of ${[...STATUS_VALUES].join(", ")}`);
-  if (!args.description) throw new Error("description is required");
+  const status = args.status || lastPacket?.decision?.suggestedStatus;
+  if (!STATUS_VALUES.has(status)) throw new Error(`status must be one of ${[...STATUS_VALUES].join(", ")}`);
+  const description = args.description || lastPacket?.run?.description || "";
+  if (!description) throw new Error("description is required");
+  const metrics = args.metrics ?? lastPacket?.decision?.metrics ?? {};
+  const asi = args.asi ?? lastPacket?.decision?.asiTemplate ?? {};
 
   const stateBefore = currentState(workDir);
   const inGit = await insideGitRepo(workDir);
@@ -1097,11 +1209,11 @@ async function logExperiment(args) {
   let gitMessage = inGit ? "Git: no commit created." : "Git: not a repo.";
   let revertMessage = "";
 
-  if (args.status === "keep" && inGit) {
+  if (status === "keep" && inGit) {
     const resultData = {
-      status: args.status,
+      status,
       [stateBefore.config.metricName || "metric"]: metric,
-      ...(args.metrics || {}),
+      ...metrics,
     };
     const commitPaths = normalizeRelativePaths(args.commit_paths ?? args.commitPaths ?? config.commitPaths, "commitPaths");
     let addResult;
@@ -1117,7 +1229,7 @@ async function logExperiment(args) {
       const commitResult = await git([
         "commit",
         "-m",
-        args.description,
+        description,
         "-m",
         `Result: ${JSON.stringify(resultData)}`,
       ], workDir);
@@ -1130,7 +1242,7 @@ async function logExperiment(args) {
     } else {
       gitMessage = "Git: nothing to commit.";
     }
-  } else if (args.status !== "keep") {
+  } else if (status !== "keep") {
     revertMessage = await cleanupDiscardChanges(workDir, args, config);
   }
 
@@ -1139,19 +1251,20 @@ async function logExperiment(args) {
     run: stateBefore.results.length + 1,
     commit: String(commit || "").slice(0, 12),
     metric,
-    metrics: args.metrics || {},
-    status: args.status,
-    description: args.description,
+    metrics,
+    status,
+    description,
     timestamp: Date.now(),
     segment: stateBefore.segment,
     confidence: null,
   };
-  if (args.asi && Object.keys(args.asi).length > 0) experiment.asi = args.asi;
+  if (asi && Object.keys(asi).length > 0) experiment.asi = asi;
   experiment.confidence = computeConfidence([...currentRuns, experiment], stateBefore.config.bestDirection);
   appendJsonl(workDir, experiment);
 
   const stateAfter = currentState(workDir);
   const limit = iterationLimitInfo(stateAfter, config);
+  await appendSessionRunNote(workDir, experiment, stateAfter, { gitMessage, revertMessage });
   return {
     ok: true,
     workDir,
@@ -1166,11 +1279,22 @@ async function logExperiment(args) {
 }
 
 async function exportDashboard(args) {
-  const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
+  const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
   const entries = readJsonl(workDir);
   if (entries.length === 0) throw new Error(`No autoresearch.jsonl found in ${workDir}`);
   const output = resolveOutputInside(workDir, args.output || "autoresearch-dashboard.html");
-  const html = dashboardHtml(entries);
+  const html = dashboardHtml(entries, {
+    workDir,
+    generatedAt: new Date().toISOString(),
+    jsonlName: "autoresearch.jsonl",
+    refreshMs: Math.max(1, Number(config.dashboardRefreshSeconds || 5)) * 1000,
+    commands: dashboardCommands(workDir),
+    settings: {
+      autonomyMode: config.autonomyMode || "guarded",
+      checksPolicy: config.checksPolicy || "always",
+      keepPolicy: config.keepPolicy || "primary-only",
+    },
+  });
   await fsp.writeFile(output, html, "utf8");
   return { ok: true, workDir, output };
 }
@@ -1182,6 +1306,7 @@ async function clearSession(args) {
   const { sessionCwd, workDir } = resolveWorkDir(args.working_dir || args.cwd);
   const targets = new Set([
     ...SESSION_FILES.map((file) => path.join(workDir, file)),
+    await resolveLastRunPath(workDir),
     path.join(workDir, RESEARCH_DIR),
     path.join(workDir, "autoresearch-dashboard.html"),
     path.join(sessionCwd, "autoresearch.config.json"),
@@ -1205,13 +1330,38 @@ async function clearSession(args) {
   };
 }
 
-function dashboardHtml(entries) {
+function dashboardHtml(entries, meta = {}) {
   const data = JSON.stringify(entries).replace(/</g, "\\u003c");
+  const metaData = JSON.stringify(meta).replace(/</g, "\\u003c");
   const template = fs.readFileSync(DASHBOARD_TEMPLATE_PATH, "utf8");
   if (!template.includes(DASHBOARD_DATA_PLACEHOLDER)) {
     throw new Error(`Dashboard template is missing ${DASHBOARD_DATA_PLACEHOLDER}`);
   }
-  return template.replace(DASHBOARD_DATA_PLACEHOLDER, data);
+  return template
+    .replace(DASHBOARD_DATA_PLACEHOLDER, data)
+    .replace("__AUTORESEARCH_META__", metaData);
+}
+
+async function resolveLastRunPath(workDir) {
+  if (await insideGitRepo(workDir)) {
+    return await gitPrivatePath(workDir, "autoresearch/last-run.json");
+  }
+  return path.join(workDir, "autoresearch.last-run.json");
+}
+
+async function writeLastRunPacket(workDir, packet, filePath = null) {
+  const target = filePath || await resolveLastRunPath(workDir);
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  await fsp.writeFile(target, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  return target;
+}
+
+async function readLastRunPacket(workDir) {
+  const filePath = await resolveLastRunPath(workDir);
+  const legacyPath = path.join(workDir, "autoresearch.last-run.json");
+  const readablePath = fs.existsSync(filePath) ? filePath : legacyPath;
+  if (!fs.existsSync(readablePath)) throw new Error(`No last-run packet found for ${workDir}. Run next before using --from-last.`);
+  return JSON.parse(fs.readFileSync(readablePath, "utf8"));
 }
 
 function publicState(args) {
@@ -1236,7 +1386,28 @@ function publicState(args) {
     best: state.best,
     confidence: state.confidence,
     limit: iterationLimitInfo(state, config),
+    settings: {
+      autonomyMode: config.autonomyMode || "guarded",
+      checksPolicy: config.checksPolicy || "always",
+      keepPolicy: config.keepPolicy || "primary-only",
+      dashboardRefreshSeconds: config.dashboardRefreshSeconds || 5,
+      commitPaths: config.commitPaths || [],
+    },
+    commands: dashboardCommands(workDir),
   };
+}
+
+function dashboardCommands(workDir) {
+  const cwd = shellQuote(workDir);
+  const script = shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"));
+  return [
+    { label: "Doctor", command: `node ${script} doctor --cwd ${cwd} --check-benchmark` },
+    { label: "Next run", command: `node ${script} next --cwd ${cwd}` },
+    { label: "Keep last", command: `node ${script} log --cwd ${cwd} --from-last --status keep --description "Describe the kept change"` },
+    { label: "Discard last", command: `node ${script} log --cwd ${cwd} --from-last --status discard --description "Describe the discarded change"` },
+    { label: "Export dashboard", command: `node ${script} export --cwd ${cwd}` },
+    { label: "Extend limit", command: `node ${script} config --cwd ${cwd} --extend 10` },
+  ];
 }
 
 async function doctorSession(args) {
@@ -1345,9 +1516,11 @@ async function nextExperiment(args) {
           next_action_hint: "",
         },
   };
-  return {
+  const lastRunFile = await resolveLastRunPath(run.workDir);
+  const packet = {
     ok: doctor.ok && run.ok,
     workDir: run.workDir,
+    lastRunPath: lastRunFile,
     doctor,
     run,
     decision,
@@ -1355,11 +1528,14 @@ async function nextExperiment(args) {
       ? "Log this run with status keep or discard, include ASI, then continue with the next hypothesis."
       : `Log this run as ${run.logHint.status} with rollback ASI before trying another change.`,
   };
+  await writeLastRunPacket(run.workDir, packet, lastRunFile);
+  return packet;
 }
 
 async function callTool(name, args) {
   if (name === "setup_session") return await setupSession(args);
   if (name === "setup_research_session") return await setupResearchSession(args);
+  if (name === "configure_session") return await configureSession(args);
   if (name === "init_experiment") return await initExperiment(args);
   if (name === "run_experiment") {
     requireUnsafeCommandGate(name, args);
@@ -1371,8 +1547,8 @@ async function callTool(name, args) {
   }
   if (name === "log_experiment") return await logExperiment({
     ...args,
-    metrics: parseJsonOption(args.metrics, {}),
-    asi: parseJsonOption(args.asi, {}),
+    metrics: parseJsonOption(args.metrics, null),
+    asi: parseJsonOption(args.asi, null),
   });
   if (name === "export_dashboard") return await exportDashboard(args);
   if (name === "clear_session") return await clearSession(args);
@@ -1414,6 +1590,10 @@ const toolSchemas = [
         secondary_metrics: { type: "array", items: { type: "string" } },
         commit_paths: { type: "array", items: { type: "string" } },
         max_iterations: { type: "number" },
+        autonomy_mode: { type: "string", enum: ["guarded", "owner-autonomous", "manual"] },
+        checks_policy: { type: "string", enum: ["always", "on-improvement", "manual"] },
+        keep_policy: { type: "string", enum: ["primary-only", "primary-or-risk-reduction"] },
+        dashboard_refresh_seconds: { type: "number" },
         overwrite: { type: "boolean" },
         create_checks: { type: "boolean" },
         skip_init: { type: "boolean" },
@@ -1437,11 +1617,33 @@ const toolSchemas = [
         constraints: { type: "array", items: { type: "string" } },
         commit_paths: { type: "array", items: { type: "string" } },
         max_iterations: { type: "number" },
+        autonomy_mode: { type: "string", enum: ["guarded", "owner-autonomous", "manual"] },
+        checks_policy: { type: "string", enum: ["always", "on-improvement", "manual"] },
+        keep_policy: { type: "string", enum: ["primary-only", "primary-or-risk-reduction"] },
+        dashboard_refresh_seconds: { type: "number" },
         overwrite: { type: "boolean" },
         create_checks: { type: "boolean" },
         skip_init: { type: "boolean" },
       },
       required: ["working_dir", "slug", "goal"],
+    },
+  },
+  {
+    name: "configure_session",
+    description: "Update runtime settings such as autonomy mode, checks policy, keep policy, dashboard refresh, commit paths, or iteration limit.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        working_dir: { type: "string" },
+        autonomy_mode: { type: "string", enum: ["guarded", "owner-autonomous", "manual"] },
+        checks_policy: { type: "string", enum: ["always", "on-improvement", "manual"] },
+        keep_policy: { type: "string", enum: ["primary-only", "primary-or-risk-reduction"] },
+        dashboard_refresh_seconds: { type: "number" },
+        max_iterations: { type: "number" },
+        extend: { type: "number" },
+        commit_paths: { type: "array", items: { type: "string" } },
+      },
+      required: ["working_dir"],
     },
   },
   {
@@ -1470,6 +1672,7 @@ const toolSchemas = [
         timeout_seconds: { type: "number" },
         checks_command: { type: "string" },
         checks_timeout_seconds: { type: "number" },
+        checks_policy: { type: "string", enum: ["always", "on-improvement", "manual"] },
         allow_unsafe_command: { type: "boolean" },
       },
       required: ["working_dir"],
@@ -1486,6 +1689,7 @@ const toolSchemas = [
         timeout_seconds: { type: "number" },
         checks_command: { type: "string" },
         checks_timeout_seconds: { type: "number" },
+        checks_policy: { type: "string", enum: ["always", "on-improvement", "manual"] },
         allow_unsafe_command: { type: "boolean" },
       },
       required: ["working_dir"],
@@ -1507,8 +1711,9 @@ const toolSchemas = [
         commit_paths: { type: "array", items: { type: "string" } },
         revert_paths: { type: "array", items: { type: "string" } },
         allow_dirty_revert: { type: "boolean" },
+        from_last: { type: "boolean" },
       },
-      required: ["working_dir", "metric", "status", "description"],
+      required: ["working_dir", "description"],
     },
   },
   {
@@ -1719,6 +1924,10 @@ async function main() {
       secondaryMetrics: args.secondaryMetrics,
       commitPaths: args.commitPaths,
       maxIterations: args.maxIterations,
+      autonomyMode: args.autonomyMode,
+      checksPolicy: args.checksPolicy,
+      keepPolicy: args.keepPolicy,
+      dashboardRefreshSeconds: args.dashboardRefreshSeconds,
       overwrite: args.overwrite,
       createChecks: args.createChecks,
       skipInit: args.skipInit,
@@ -1735,9 +1944,24 @@ async function main() {
       constraints: args.constraints,
       commitPaths: args.commitPaths,
       maxIterations: args.maxIterations,
+      autonomyMode: args.autonomyMode,
+      checksPolicy: args.checksPolicy,
+      keepPolicy: args.keepPolicy,
+      dashboardRefreshSeconds: args.dashboardRefreshSeconds,
       overwrite: args.overwrite,
       createChecks: args.createChecks,
       skipInit: args.skipInit,
+    });
+  } else if (command === "config") {
+    result = await configureSession({
+      cwd: args.cwd,
+      autonomyMode: args.autonomyMode,
+      checksPolicy: args.checksPolicy,
+      keepPolicy: args.keepPolicy,
+      dashboardRefreshSeconds: args.dashboardRefreshSeconds,
+      maxIterations: args.maxIterations,
+      extend: args.extend,
+      commitPaths: args.commitPaths,
     });
   } else if (command === "quality-gap") {
     result = await measureQualityGap({
@@ -1762,6 +1986,7 @@ async function main() {
       timeoutSeconds: args.timeoutSeconds,
       checksCommand: args.checksCommand,
       checksTimeoutSeconds: args.checksTimeoutSeconds,
+      checksPolicy: args.checksPolicy,
     });
   } else if (command === "next") {
     result = await nextExperiment({
@@ -1770,6 +1995,7 @@ async function main() {
       timeoutSeconds: args.timeoutSeconds,
       checksCommand: args.checksCommand,
       checksTimeoutSeconds: args.checksTimeoutSeconds,
+      checksPolicy: args.checksPolicy,
     });
   } else if (command === "log") {
     result = await logExperiment({
@@ -1778,11 +2004,12 @@ async function main() {
       metric: args.metric,
       status: args.status,
       description: args.description,
-      metrics: parseJsonOption(args.metrics, {}),
-      asi: parseJsonOption(args.asi, {}),
+      metrics: parseJsonOption(args.metrics, null),
+      asi: parseJsonOption(args.asi, null),
       commitPaths: args.commitPaths,
       revertPaths: args.revertPaths,
       allowDirtyRevert: args.allowDirtyRevert,
+      fromLast: args.fromLast,
     });
   } else if (command === "state") {
     result = publicState({ cwd: args.cwd });

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs
@@ -7,7 +7,7 @@ function usage() {
   return `Finalize an autoresearch branch into independent review branches.
 
 Usage:
-  node scripts/finalize-autoresearch.mjs plan --output groups.json [--goal short-slug] [--trunk main]
+  node scripts/finalize-autoresearch.mjs plan --output groups.json [--goal short-slug] [--trunk main] [--collapse-overlap]
   node scripts/finalize-autoresearch.mjs groups.json
 
 groups.json:
@@ -33,6 +33,7 @@ const SESSION_FILES = new Set([
   "autoresearch.md",
   "autoresearch.ideas.md",
   "autoresearch.config.json",
+  "autoresearch.last-run.json",
   "autoresearch.sh",
   "autoresearch.ps1",
   "autoresearch.checks.sh",
@@ -423,9 +424,45 @@ async function draftGroupsPlan(args, cwd) {
   };
 }
 
+async function collapseOverlappingDraftGroups(plan, cwd) {
+  if (plan.groups.length <= 1) return plan;
+  let prev = plan.base;
+  const seen = new Set();
+  const overlapping = new Set();
+  for (const group of plan.groups) {
+    const last = await fullHash(group.last_commit, cwd);
+    const files = await changedFiles(prev, last, cwd);
+    for (const file of files) {
+      if (seen.has(file)) overlapping.add(file);
+      seen.add(file);
+    }
+    prev = last;
+  }
+  if (overlapping.size === 0) return plan;
+  const lastGroup = plan.groups.at(-1);
+  const overlapList = [...overlapping].sort().slice(0, 12);
+  return {
+    ...plan,
+    groups: [{
+      title: `Consolidated ${plan.goal} changes`,
+      body: [
+        "Autoresearch kept changes were collapsed into one review branch because multiple draft groups touched the same files.",
+        "",
+        `Overlapping files: ${overlapList.join(", ")}${overlapping.size > overlapList.length ? ", ..." : ""}`,
+      ].join("\n"),
+      last_commit: lastGroup.last_commit,
+      slug: safeSlug(`${plan.goal}-changes`),
+    }],
+  };
+}
+
 async function writeDraftPlan(args, cwd) {
-  const plan = await draftGroupsPlan(args, cwd);
+  let plan = await draftGroupsPlan(args, cwd);
+  if (args.collapseOverlap) {
+    plan = await collapseOverlappingDraftGroups(plan, cwd);
+  }
   const output = args.output ? path.resolve(args.output) : path.resolve(cwd, "autoresearch.groups.json");
+  await fsp.mkdir(path.dirname(output), { recursive: true });
   await fsp.writeFile(output, `${JSON.stringify(plan, null, 2)}\n`, "utf8");
   console.log(`Wrote draft groups: ${output}`);
   console.log(`Groups: ${plan.groups.length}`);

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs
@@ -184,8 +184,13 @@ async function readKeptRuns(cwd) {
 function runEvidenceForCommit(keptRuns, hash) {
   return keptRuns.find((run) => {
     const commit = String(run.commit || "");
-    return commit && (hash.startsWith(commit) || commit.startsWith(hash.slice(0, 12)));
+    return commitMatchesHash(commit, hash);
   });
+}
+
+function commitMatchesHash(commit, hash) {
+  if (!commit) return false;
+  return hash.startsWith(commit) || commit.startsWith(hash.slice(0, 12));
 }
 
 function draftBodyForCommit(run) {

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.mjs
@@ -217,7 +217,8 @@ async function reviewSummaryPath(config, cwd) {
   return path.join(dir, `${stamp}-${safeSlug(config.goal)}.md`);
 }
 
-async function writeReviewSummary(file, { config, groups, results, sourceBranch, status, error }) {
+async function writeReviewSummary(file, context) {
+  const { config, groups, results, sourceBranch, status, error } = context;
   const lines = [
     `# Autoresearch Finalize Review Summary`,
     "",

--- a/plugins/codex-autoresearch/skills/autoresearch-create/SKILL.md
+++ b/plugins/codex-autoresearch/skills/autoresearch-create/SKILL.md
@@ -19,6 +19,7 @@ Use this skill to run a measured optimization loop:
 - `autoresearch.sh` or `autoresearch.ps1`: benchmark entrypoint.
 - `autoresearch.checks.sh` or `autoresearch.checks.ps1`: optional correctness checks.
 - `autoresearch.jsonl`: append-only run log.
+- last-run packet: latest `next` packet for fast keep/discard logging; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json`.
 - `autoresearch.ideas.md`: optional backlog for promising ideas not tried yet.
 
 Starter templates live in the plugin `assets/` directory:
@@ -48,14 +49,18 @@ Starter templates live in the plugin `assets/` directory:
   "benchmark_command": "command that prints or can be wrapped into METRIC output",
   "checks_command": "optional correctness command",
   "commit_paths": ["src", "tests"],
-  "max_iterations": 50
+  "max_iterations": 50,
+  "autonomy_mode": "owner-autonomous",
+  "checks_policy": "on-improvement",
+  "keep_policy": "primary-or-risk-reduction",
+  "dashboard_refresh_seconds": 5
 }
 ```
 
 If MCP tools are not loaded, use the CLI from the plugin root:
 
 ```bash
-node scripts/autoresearch.mjs setup --cwd /absolute/project/path --name "short session name" --goal "what is being optimized" --metric-name seconds --metric-unit s --direction lower --benchmark-command "benchmark command" --checks-command "optional correctness command" --commit-paths "src,tests" --max-iterations 50
+node scripts/autoresearch.mjs setup --cwd /absolute/project/path --name "short session name" --goal "what is being optimized" --metric-name seconds --metric-unit s --direction lower --benchmark-command "benchmark command" --checks-command "optional correctness command" --commit-paths "src,tests" --max-iterations 50 --autonomy-mode owner-autonomous --checks-policy on-improvement --keep-policy primary-or-risk-reduction
 ```
 
 6. Review generated files and tighten `autoresearch.md`, the benchmark script, and checks before the first run. The benchmark must print the primary metric as `METRIC <name>=<number>`.
@@ -86,6 +91,12 @@ Then log the result every time with MCP `log_experiment` or:
 node scripts/autoresearch.mjs log --cwd /absolute/project/path --metric 12.3 --status keep --description "Short description" --metrics "{}" --asi "{\"hypothesis\":\"what changed\"}"
 ```
 
+After `next`, prefer `--from-last` so the metric, secondary metrics, and ASI template are reused from the last-run packet:
+
+```bash
+node scripts/autoresearch.mjs log --cwd /absolute/project/path --from-last --status keep --description "Short description"
+```
+
 Rules:
 
 - Primary metric decides keep/discard. Lower or higher depends on the active session config.
@@ -99,6 +110,19 @@ Rules:
 - Update `autoresearch.md` after meaningful results so future agents do not repeat stale ideas.
 - Append deferred ideas to `autoresearch.ideas.md`.
 - Stop when `read_state` or `run_experiment` reports `limit.limitReached`.
+
+## Autonomy and Runtime Config
+
+Use `config` to tune a live session without rewriting the JSONL history:
+
+```bash
+node scripts/autoresearch.mjs config --cwd /absolute/project/path --autonomy-mode owner-autonomous --checks-policy on-improvement --keep-policy primary-or-risk-reduction --extend 10
+```
+
+- `autonomy_mode=guarded` is the default; use `owner-autonomous` when the owner explicitly asks Codex to keep iterating independently.
+- `checks_policy=always` runs checks after successful metrics; `on-improvement` runs checks for improving runs; `manual` only runs checks when explicitly passed.
+- `keep_policy=primary-only` keeps decisions tied to the primary metric; `primary-or-risk-reduction` allows a kept result when primary movement is neutral but ASI documents reduced risk or operational quality.
+- `--extend N` increases `maxIterations` from the current progress, useful when a session is productive but capped.
 
 ## Benchmark Script Guidance
 

--- a/plugins/codex-autoresearch/skills/autoresearch-dashboard/SKILL.md
+++ b/plugins/codex-autoresearch/skills/autoresearch-dashboard/SKILL.md
@@ -5,7 +5,7 @@ description: Export and inspect a Codex autoresearch dashboard from autoresearch
 
 # Autoresearch Dashboard
 
-Use this skill to turn `autoresearch.jsonl` into a self-contained HTML dashboard.
+Use this skill to turn `autoresearch.jsonl` into an HTML dashboard with embedded snapshot data, optional live refresh from disk, and copyable operator commands.
 
 ## Workflow
 
@@ -18,7 +18,8 @@ node scripts/autoresearch.mjs export --cwd /absolute/project/path
 ```
 
 4. Report the generated `autoresearch-dashboard.html` path.
-5. If the user asked for a summary, also run:
+5. If the user has the dashboard open, re-export after meaningful new runs so the embedded command metadata stays current.
+6. If the user asked for a summary, also run:
 
 ```bash
 node scripts/autoresearch.mjs state --cwd /absolute/project/path
@@ -36,8 +37,14 @@ Use this review readout pattern when summarizing:
 - Which segment is active when multiple segments exist.
 - Whether the dashboard says the branch is ready to finalize.
 
+## Live Dashboard Behavior
+
+The dashboard can be opened directly from disk and does not require a dev server. It embeds the current JSONL snapshot, then the `Refresh` and `Live on` controls try to refetch `autoresearch.jsonl` next to the HTML file. If the browser blocks local `fetch` for `file://`, the embedded snapshot remains usable and the status strip reports that live refresh is unavailable.
+
+The command panel includes copyable commands for doctor, next run, keep/discard last packet, dashboard export, and iteration-limit extension. Use those commands as operator shortcuts, not as a substitute for reading the current run output before keeping a change.
+
 ## Notes
 
-The dashboard is static and self-contained. It can be opened directly from disk and does not require a dev server. The operator readout, segment selector, and ready-to-finalize card are designed to make exported dashboards useful in PRs and status updates, not just local charts.
+The operator readout, segment selector, command panel, live status strip, and ready-to-finalize card are designed to make exported dashboards useful in PRs and status updates, not just local charts.
 
 If no `autoresearch.jsonl` exists, say that there is no session to export yet and point the user to `autoresearch-create`.

--- a/plugins/codex-autoresearch/skills/autoresearch-finalize/SKILL.md
+++ b/plugins/codex-autoresearch/skills/autoresearch-finalize/SKILL.md
@@ -33,13 +33,14 @@ Prefer the draft planner first, then inspect and tighten the result:
 node /absolute/path/to/codex-autoresearch/scripts/finalize-autoresearch.mjs plan --output /absolute/path/to/groups.json --goal short-goal
 ```
 
+- Add `--collapse-overlap` when the user wants an owner-autonomous cleanup and overlapping draft groups should become one review branch instead of causing a manual regrouping loop.
 - Preserve application order.
 - No two groups may touch the same file. If groups overlap, merge them.
 - If one group depends on another, merge them or explicitly flag that they must be reviewed together.
 - Keep groups focused on one idea.
 - Do not force a fixed number of groups.
 
-Present the groups to the user and wait for approval before creating branches.
+Present the groups to the user and wait for approval before creating branches, unless the user has already explicitly approved independent finalization or asked you to keep iterating to completion.
 
 Example:
 
@@ -80,7 +81,8 @@ Rules:
 
 - `last_commit` must be a full hash.
 - `goal` and `slug` should be short; the script sanitizes branch names before creating branches.
-- Root session files such as `autoresearch.jsonl`, `autoresearch.md`, and benchmark/check scripts are excluded from review branches.
+- Root session files such as `autoresearch.jsonl`, `autoresearch.md`, fallback `autoresearch.last-run.json`, and benchmark/check scripts are excluded from review branches.
+- Parent directories for `--output` are created automatically by the draft planner.
 
 ## Step 4: Run
 

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
@@ -66,6 +66,17 @@ async function git(cwd, args) {
   return result.stdout.trim();
 }
 
+const createDashboardElement = (id) => ({ id, textContent: "", innerHTML: "", className: "", onchange: null });
+
+const createDashboardDocument = (elements) => ({
+  getElementById(id) {
+    if (!elements.has(id)) {
+      elements.set(id, createDashboardElement(id));
+    }
+    return elements.get(id);
+  },
+});
+
 test("run reports missing primary metric as a failed experiment", async () => {
   await withTempDir("missing-metric", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "missing metric", "--metric-name", "seconds"]);
@@ -225,14 +236,7 @@ test("dashboard script renders zero and negative metric points", async () => {
     assert.ok(script);
 
     const elements = new Map();
-    const document = {
-      getElementById(id) {
-        if (!elements.has(id)) {
-          elements.set(id, { id, textContent: "", innerHTML: "", className: "", onchange: null });
-        }
-        return elements.get(id);
-      },
-    };
+    const document = createDashboardDocument(elements);
     vm.runInNewContext(script, { document, console });
 
     const chart = elements.get("trend-chart").innerHTML;

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
@@ -11,43 +11,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(__dirname, "..");
 const cli = path.join(pluginRoot, "scripts", "autoresearch.mjs");
 
-function quoteForShell(value) {
+const quoteForShell = (value) => {
   return `"${String(value).replace(/"/g, '\\"')}"`;
-}
+};
 
-function runCli(args, options = {}) {
+const processResult = (code, stdout, stderr) => ({ code, stdout, stderr });
+
+const runProcess = (command, args, cwd) => {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [cli, ...args], {
-      cwd: options.cwd || pluginRoot,
-      windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function withTempDir(name, fn) {
-  const dir = await mkdtemp(path.join(tmpdir(), `autoresearch-${name}-`));
-  try {
-    return await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
-
-async function git(cwd, args) {
-  const result = await new Promise((resolve) => {
-    const child = spawn("git", args, {
+    const child = spawn(command, args, {
       cwd,
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
@@ -60,21 +32,40 @@ async function git(cwd, args) {
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString("utf8");
     });
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("close", (code) => resolve(processResult(code, stdout, stderr)));
   });
+};
+
+const runCli = (args, options = {}) => {
+  return runProcess(process.execPath, [cli, ...args], options.cwd || pluginRoot);
+};
+
+const withTempDir = async (name, fn) => {
+  const dir = await mkdtemp(path.join(tmpdir(), `autoresearch-${name}-`));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+const git = async (cwd, args) => {
+  const result = await runProcess("git", args, cwd);
   assert.equal(result.code, 0, `git ${args.join(" ")} failed\n${result.stderr}${result.stdout}`);
   return result.stdout.trim();
-}
+};
 
 const createDashboardElement = (id) => ({ id, textContent: "", innerHTML: "", className: "", onchange: null });
 
+const getDashboardElement = (elements, id) => {
+  if (!elements.has(id)) {
+    elements.set(id, createDashboardElement(id));
+  }
+  return elements.get(id);
+};
+
 const createDashboardDocument = (elements) => ({
-  getElementById(id) {
-    if (!elements.has(id)) {
-      elements.set(id, createDashboardElement(id));
-    }
-    return elements.get(id);
-  },
+  getElementById: (id) => getDashboardElement(elements, id),
 });
 
 test("run reports missing primary metric as a failed experiment", async () => {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
@@ -55,7 +55,21 @@ const git = async (cwd, args) => {
   return result.stdout.trim();
 };
 
-const createDashboardElement = (id) => ({ id, textContent: "", innerHTML: "", className: "", onchange: null });
+const createDashboardElement = (id) => ({
+  id,
+  textContent: "",
+  innerHTML: "",
+  className: "",
+  onchange: null,
+  onclick: null,
+  dataset: {},
+  setAttribute(name, value) {
+    this[name] = value;
+  },
+  querySelectorAll() {
+    return [];
+  },
+});
 
 const getDashboardElement = (elements, id) => {
   if (!elements.has(id)) {
@@ -209,8 +223,129 @@ test("dashboard includes segment and finalize-readiness cockpit controls", async
     const dashboard = await readFile(path.join(dir, "autoresearch-dashboard.html"), "utf8");
 
     assert.match(dashboard, /id="segment-select"/);
+    assert.match(dashboard, /id="live-toggle"/);
+    assert.match(dashboard, /id="command-grid"/);
+    assert.match(dashboard, /const meta = \{/);
+    assert.match(dashboard, /!clipboard\?\.writeText/);
     assert.match(dashboard, /Ready to finalize/);
     assert.match(dashboard, /renderSegmentSelector/);
+  });
+});
+
+test("config persists operator settings and extends iteration limits", async () => {
+  await withTempDir("operator-config", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "operator config", "--metric-name", "seconds"]);
+    await runCli(["log", "--cwd", dir, "--metric", "5", "--status", "keep", "--description", "Baseline"]);
+
+    const result = await runCli([
+      "config",
+      "--cwd", dir,
+      "--autonomy-mode", "owner-autonomous",
+      "--checks-policy", "on-improvement",
+      "--keep-policy", "primary-or-risk-reduction",
+      "--dashboard-refresh-seconds", "2",
+      "--extend", "4",
+      "--commit-paths", "src,tests",
+    ]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.config.autonomyMode, "owner-autonomous");
+    assert.equal(payload.config.checksPolicy, "on-improvement");
+    assert.equal(payload.config.keepPolicy, "primary-or-risk-reduction");
+    assert.equal(payload.config.dashboardRefreshSeconds, 2);
+    assert.equal(payload.config.maxIterations, 5);
+    assert.deepEqual(payload.config.commitPaths, ["src", "tests"]);
+
+    const state = await runCli(["state", "--cwd", dir]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    assert.equal(statePayload.settings.autonomyMode, "owner-autonomous");
+    assert.equal(statePayload.limit.remainingIterations, 4);
+    assert.match(statePayload.commands[0].command, /autoresearch\.mjs/);
+    assert.match(statePayload.commands[0].command, /--cwd/);
+  });
+});
+
+test("next writes a reusable last-run packet and log can consume it", async () => {
+  await withTempDir("last-run", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "last run", "--metric-name", "seconds"]);
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3'); console.log('METRIC cache_hits=8')"`;
+
+    const next = await runCli(["next", "--cwd", dir, "--command", command, "--checks-policy", "manual"]);
+    assert.equal(next.code, 0, next.stderr);
+    const packet = JSON.parse(next.stdout);
+    assert.equal(packet.decision.metric, 3);
+    assert.equal(packet.decision.metrics.cache_hits, 8);
+
+    const lastRun = JSON.parse(await readFile(packet.lastRunPath, "utf8"));
+    assert.equal(lastRun.decision.metric, 3);
+
+    const log = await runCli([
+      "log",
+      "--cwd", dir,
+      "--from-last",
+      "--status", "discard",
+      "--description", "Discard cached packet",
+    ]);
+    assert.equal(log.code, 0, log.stderr);
+    const payload = JSON.parse(log.stdout);
+    assert.equal(payload.experiment.metric, 3);
+    assert.equal(payload.experiment.metrics.cache_hits, 8);
+  });
+});
+
+test("last-run packet does not dirty git worktrees before discard logging", async () => {
+  await withTempDir("git-last-run", async (dir) => {
+    await git(dir, ["init"]);
+    await git(dir, ["config", "user.email", "codex@example.test"]);
+    await git(dir, ["config", "user.name", "Codex Test"]);
+    await writeFile(path.join(dir, "tracked.txt"), "base\n", "utf8");
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-m", "initial"]);
+
+    await runCli(["init", "--cwd", dir, "--name", "git last run", "--metric-name", "seconds"]);
+    await git(dir, ["add", "autoresearch.jsonl"]);
+    await git(dir, ["commit", "-m", "session"]);
+
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3')"`;
+    const next = await runCli(["next", "--cwd", dir, "--command", command, "--checks-policy", "manual"]);
+    assert.equal(next.code, 0, next.stderr);
+    const packet = JSON.parse(next.stdout);
+    assert.doesNotMatch(packet.lastRunPath, /autoresearch\.last-run\.json$/);
+
+    const statusBeforeLog = await git(dir, ["status", "--short"]);
+    assert.equal(statusBeforeLog, "");
+
+    const log = await runCli([
+      "log",
+      "--cwd", dir,
+      "--from-last",
+      "--status", "discard",
+      "--description", "Discard clean packet",
+    ]);
+    assert.equal(log.code, 0, log.stderr);
+    const payload = JSON.parse(log.stdout);
+    assert.equal(payload.experiment.metric, 3);
+  });
+});
+
+test("config extend is based on the active segment run count", async () => {
+  await withTempDir("segment-extend", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "first segment", "--metric-name", "seconds"]);
+    await runCli(["log", "--cwd", dir, "--metric", "5", "--status", "keep", "--description", "Baseline"]);
+    await runCli(["init", "--cwd", dir, "--name", "second segment", "--metric-name", "seconds"]);
+
+    const result = await runCli(["config", "--cwd", dir, "--extend", "4"]);
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.config.maxIterations, 4);
+
+    const state = await runCli(["state", "--cwd", dir]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    assert.equal(statePayload.limit.maxIterations, 4);
+    assert.equal(statePayload.limit.remainingIterations, 4);
   });
 });
 

--- a/plugins/codex-autoresearch/tests/finalize-report.test.mjs
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.mjs
@@ -128,6 +128,44 @@ test("finalizer plan writes draft groups from autoresearch history", async () =>
   assert.ok(plan.groups[0].last_commit);
 });
 
+test("finalizer plan can create nested output paths and collapse overlapping groups", async () => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "autoresearch-plan-collapse-"));
+  const repo = path.join(root, "repo");
+  await fsp.mkdir(repo, { recursive: true });
+
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "codex@example.invalid"], repo);
+  await git(["config", "user.name", "Codex Test"], repo);
+
+  await writeFile(path.join(repo, "src", "value.txt"), "base\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "base"], repo);
+
+  await git(["switch", "-c", "codex/autoresearch-overlap"], repo);
+  await writeFile(path.join(repo, "src", "value.txt"), "first\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "first value change"], repo);
+
+  await writeFile(path.join(repo, "src", "value.txt"), "second\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "second value change"], repo);
+
+  const output = path.join(root, "plans", "nested", "groups.json");
+  const result = await run(process.execPath, [
+    finalizer,
+    "plan",
+    "--output", output,
+    "--goal", "overlap-loop",
+    "--collapse-overlap",
+  ], repo);
+  assert.match(result.stdout, /Groups: 1/);
+
+  const plan = JSON.parse(await fsp.readFile(output, "utf8"));
+  assert.equal(plan.groups.length, 1);
+  assert.match(plan.groups[0].title, /Consolidated overlap-loop changes/);
+  assert.match(plan.groups[0].body, /src\/value\.txt/);
+});
+
 test("finalizer removes empty skipped branches and sanitizes branch names", async () => {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), "autoresearch-empty-"));
   const repo = path.join(root, "repo");

--- a/plugins/codex-autoresearch/tests/finalize-report.test.mjs
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.mjs
@@ -19,7 +19,8 @@ async function run(command, args, cwd, allowFailure = false) {
     child.on("close", (code) => resolve({ code, stdout, stderr }));
   });
   if (!allowFailure && result.code !== 0) {
-    throw new Error(`${command} ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
+    const commandLine = command + " " + args.join(" ");
+    throw new Error(commandLine + " failed:\n" + result.stdout + result.stderr);
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- Add runtime configuration for autonomy mode, checks policy, keep policy, dashboard refresh, scoped paths, and iteration extension
- Persist reusable last-run packets outside Git worktree status where possible, then support `log --from-last`
- Make the dashboard more dynamic with live refresh controls and copyable operator commands
- Improve finalizer planning with nested output creation and optional overlap collapse
- Refresh README, command docs, skill guidance, MCP metadata, and regression coverage

## Root Cause / Why
- Follow-up autoresearch usage showed the plugin needed fewer manual metric-copying and regrouping steps, clearer owner-autonomous behavior, and a dashboard that can act as an operator cockpit during live runs.

## Validation
- `node --test tests/autoresearch-cli.test.mjs`
- `npm run check` (`quality_gap=0`, 33 tests passed)
- `quick_validate.py` for `autoresearch-create`, `autoresearch-dashboard`, and `autoresearch-finalize`
- `git diff --check`