### PR TITLE
[codex] Improve autoresearch operator flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
 .learnings/
+
+# Codex Autoresearch session artifacts
+/autoresearch.md
+/autoresearch.jsonl
+/autoresearch.ideas.md
+/autoresearch.research/
+/autoresearch.config.json
+/autoresearch.last-run.json
+/autoresearch.sh
+/autoresearch.ps1
+/autoresearch.checks.sh
+/autoresearch.checks.ps1
+/autoresearch-dashboard.html

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Autonomous experiment loops for Codex: set up a benchmark, run iterations, log results, export dashboards, and finalize kept changes.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/assets/template.html
+++ b/plugins/codex-autoresearch/assets/template.html
@@ -1008,10 +1008,13 @@ function renderLiveActions() {
       const action = button.dataset.action;
       button.textContent = "Running";
       try {
+        const body = action === "gap-candidates"
+          ? { researchSlug: activeResearchSlug() }
+          : {};
         const response = await fetch("actions/" + action, {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({}),
+          body: JSON.stringify(body),
         });
         const payload = await response.json();
         button.textContent = payload.ok ? "Done" : "Failed";
@@ -1025,6 +1028,10 @@ function renderLiveActions() {
       }
     };
   }
+}
+
+function activeResearchSlug() {
+  return viewModel?.qualityGap?.slug || meta?.viewModel?.qualityGap?.slug || "research";
 }
 
 function actionLabel(action) {

--- a/plugins/codex-autoresearch/lib/cli-handlers.mjs
+++ b/plugins/codex-autoresearch/lib/cli-handlers.mjs
@@ -95,6 +95,7 @@ export function createCliCommandHandlers(deps) {
         researchSlug: args.researchSlug,
         slug: args.slug,
       });
+      if (args.list) return { result };
       return { text: result.metricOutput };
     },
     "gap-candidates": async (args) => ({

--- a/plugins/codex-autoresearch/lib/live-server.mjs
+++ b/plugins/codex-autoresearch/lib/live-server.mjs
@@ -37,7 +37,7 @@ export async function serveAutoresearch(args) {
           return;
         }
         const body = await readJsonBody(req);
-        const cliArgs = actionArgs(action, workDir, body);
+        const cliArgs = await actionArgs(action, workDir, body);
         const result = await runNode(scriptPath, cliArgs, workDir);
         sendJson(res, { ok: result.code === 0, action, stdout: result.stdout, stderr: result.stderr, code: result.code });
         return;
@@ -58,14 +58,33 @@ export async function serveAutoresearch(args) {
   };
 }
 
-function actionArgs(action, workDir, body) {
+async function actionArgs(action, workDir, body) {
   if (action === "doctor") return ["doctor", "--cwd", workDir, "--check-benchmark"];
   if (action === "setup-plan") return ["setup-plan", "--cwd", workDir];
   if (action === "recipes") return ["recipes", "list"];
-  if (action === "gap-candidates") return ["gap-candidates", "--cwd", workDir, "--research-slug", body.researchSlug || body.slug || "research"];
+  if (action === "gap-candidates") return ["gap-candidates", "--cwd", workDir, "--research-slug", body.researchSlug || body.slug || await firstResearchSlug(workDir) || "research"];
   if (action === "finalize-preview") return ["finalize-preview", "--cwd", workDir];
   if (action === "export") return ["export", "--cwd", workDir];
   return [];
+}
+
+async function firstResearchSlug(workDir) {
+  const researchRoot = path.join(workDir, "autoresearch.research");
+  try {
+    const entries = await fsp.readdir(researchRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      try {
+        await fsp.access(path.join(researchRoot, entry.name, "quality-gaps.md"));
+        return entry.name;
+      } catch {
+        // Keep looking.
+      }
+    }
+  } catch {
+    return "";
+  }
+  return "";
 }
 
 async function readJsonBody(req) {

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "private": true,
   "description": "Codex plugin for autonomous benchmark and optimization loops.",

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -59,7 +59,7 @@ Usage:
   node scripts/autoresearch.mjs next --cwd <project> [--command <cmd>] [--timeout-seconds <n>]
   node scripts/autoresearch.mjs config --cwd <project> [--autonomy-mode guarded|owner-autonomous|manual] [--checks-policy always|on-improvement|manual] [--extend <n>]
   node scripts/autoresearch.mjs research-setup --cwd <project> --slug <slug> --goal <goal> [--checks-command <cmd>] [--max-iterations <n>]
-  node scripts/autoresearch.mjs quality-gap --cwd <project> --research-slug <slug>
+  node scripts/autoresearch.mjs quality-gap --cwd <project> --research-slug <slug> [--list]
   node scripts/autoresearch.mjs gap-candidates --cwd <project> --research-slug <slug> [--apply] [--model-command <cmd>]
   node scripts/autoresearch.mjs finalize-preview --cwd <project> [--trunk main]
   node scripts/autoresearch.mjs serve --cwd <project> [--port <n>]
@@ -290,6 +290,9 @@ async function setupPlan(args) {
     recommended ? `--recipe ${shellQuote(recommended.id)}` : "",
     args.catalog ? `--catalog ${shellQuote(args.catalog)}` : "",
   ].filter(Boolean).join(" ");
+  const doctorCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} doctor --cwd ${shellQuote(workDir)} --check-benchmark`;
+  const baselineCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} next --cwd ${shellQuote(workDir)}`;
+  const logCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} log --cwd ${shellQuote(workDir)} --from-last --status keep --description ${shellQuote("Describe the kept change")}`;
   return {
     ok: true,
     workDir,
@@ -299,7 +302,13 @@ async function setupPlan(args) {
     recommendedRecipe: recommended,
     missing,
     nextCommand: command,
-    baselineCommand: `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} next --cwd ${shellQuote(workDir)}`,
+    baselineCommand,
+    guidedFlow: [
+      { step: "setup", command, purpose: "Create the session files and metric config." },
+      { step: "doctor", command: doctorCommand, purpose: "Verify the benchmark emits the configured metric." },
+      { step: "baseline", command: baselineCommand, purpose: "Run the first measured packet." },
+      { step: "log", command: logCommand, purpose: "Record the last packet with a deliberate keep/discard decision." },
+    ],
     notes: [
       "setup-plan is read-only.",
       "Generated recipe scripts remain inspectable and should be checked with doctor before logging a keep.",
@@ -560,15 +569,21 @@ function renderResearchFile(fileName, args, slug) {
 }
 
 function parseQualityGaps(text) {
-  let open = 0;
-  let closed = 0;
+  const items = parseQualityGapItems(text);
+  return { open: items.open.length, closed: items.closed.length, total: items.open.length + items.closed.length };
+}
+
+function parseQualityGapItems(text) {
+  const open = [];
+  const closed = [];
   for (const line of text.split(/\r?\n/)) {
-    const match = line.match(/^\s*-\s*\[([ xX])\]\s+\S/);
+    const match = line.match(/^\s*-\s*\[([ xX])\]\s+(.+?)\s*$/);
     if (!match) continue;
-    if (match[1].toLowerCase() === "x") closed += 1;
-    else open += 1;
+    const item = match[2].trim();
+    if (match[1].toLowerCase() === "x") closed.push(item);
+    else open.push(item);
   }
-  return { open, closed, total: open + closed };
+  return { open, closed };
 }
 
 async function writeSessionFile(filePath, content, options = {}) {
@@ -1192,6 +1207,7 @@ async function measureQualityGap(args) {
   }
   const text = await fsp.readFile(gapsPath, "utf8");
   const counts = parseQualityGaps(text);
+  const items = parseQualityGapItems(text);
   const metricOutput = [
     `METRIC quality_gap=${counts.open}`,
     `METRIC quality_total=${counts.total}`,
@@ -1206,6 +1222,8 @@ async function measureQualityGap(args) {
     open: counts.open,
     closed: counts.closed,
     total: counts.total,
+    openItems: items.open,
+    closedItems: items.closed,
     metricOutput,
   };
 }
@@ -1221,7 +1239,8 @@ async function currentQualityGapSummary(workDir) {
     if (!(await pathExists(gapsPath))) continue;
     const text = await fsp.readFile(gapsPath, "utf8");
     const counts = parseQualityGaps(text);
-    return { slug, path: gapsPath, ...counts };
+    const items = parseQualityGapItems(text);
+    return { slug, path: gapsPath, ...counts, openItems: items.open, closedItems: items.closed };
   }
   return null;
 }
@@ -1236,12 +1255,13 @@ function dashboardSettings(config) {
 }
 
 async function dashboardViewModel(workDir, config) {
+  const qualityGap = await currentQualityGapSummary(workDir);
   return buildDashboardViewModel({
     state: currentState(workDir),
     settings: dashboardSettings(config),
-    commands: dashboardCommands(workDir),
+    commands: dashboardCommands(workDir, qualityGap),
     setupPlan: await setupPlan({ cwd: workDir }).catch((error) => ({ ok: false, warnings: [error.message] })),
-    qualityGap: await currentQualityGapSummary(workDir),
+    qualityGap,
     finalizePreview: await buildFinalizePreview({ cwd: workDir }).catch((error) => ({
       ok: false,
       ready: false,
@@ -1574,20 +1594,34 @@ function publicState(args) {
   };
 }
 
-function dashboardCommands(workDir) {
+function dashboardCommands(workDir, qualityGap = null) {
   const cwd = shellQuote(workDir);
   const script = shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"));
+  const researchSlug = qualityGap?.slug || currentQualityGapSlug(workDir) || "research";
   return [
     { label: "Setup plan", command: `node ${script} setup-plan --cwd ${cwd}` },
     { label: "Doctor", command: `node ${script} doctor --cwd ${cwd} --check-benchmark` },
     { label: "Next run", command: `node ${script} next --cwd ${cwd}` },
     { label: "Keep last", command: `node ${script} log --cwd ${cwd} --from-last --status keep --description "Describe the kept change"` },
     { label: "Discard last", command: `node ${script} log --cwd ${cwd} --from-last --status discard --description "Describe the discarded change"` },
-    { label: "Gap candidates", command: `node ${script} gap-candidates --cwd ${cwd} --research-slug research` },
+    { label: "Gap candidates", command: `node ${script} gap-candidates --cwd ${cwd} --research-slug ${shellQuote(researchSlug)}` },
     { label: "Finalize preview", command: `node ${script} finalize-preview --cwd ${cwd}` },
     { label: "Export dashboard", command: `node ${script} export --cwd ${cwd}` },
     { label: "Extend limit", command: `node ${script} config --cwd ${cwd} --extend 10` },
   ];
+}
+
+function currentQualityGapSlug(workDir) {
+  const researchRoot = path.join(workDir, RESEARCH_DIR);
+  try {
+    for (const entry of fs.readdirSync(researchRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (fs.existsSync(path.join(researchRoot, entry.name, "quality-gaps.md"))) return entry.name;
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 async function doctorSession(args) {
@@ -1787,7 +1821,7 @@ async function handleMcpMessage(message) {
       result: {
         protocolVersion: "2024-11-05",
         capabilities: { tools: {} },
-        serverInfo: { name: "codex-autoresearch", version: "0.1.8" },
+        serverInfo: { name: "codex-autoresearch", version: "0.1.9" },
       },
     });
     return;

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
@@ -130,6 +130,12 @@ test("research-setup creates a quality_gap scratchpad and benchmark", async () =
     const state = await runCli(["state", "--cwd", dir]);
     assert.equal(state.code, 0, state.stderr);
     assert.equal(JSON.parse(state.stdout).config.metricName, "quality_gap");
+
+    const exportResult = await runCli(["export", "--cwd", dir]);
+    assert.equal(exportResult.code, 0, exportResult.stderr);
+    const dashboard = await readFile(path.join(dir, "autoresearch-dashboard.html"), "utf8");
+    assert.match(dashboard, /--research-slug \\"project-study\\"/);
+    assert.match(dashboard, /activeResearchSlug/);
   });
 });
 
@@ -152,6 +158,12 @@ test("quality-gap counts checked and unchecked research gaps", async () => {
     assert.match(result.stdout, /METRIC quality_gap=2/);
     assert.match(result.stdout, /METRIC quality_total=4/);
     assert.match(result.stdout, /METRIC quality_closed=2/);
+
+    const listed = await runCli(["quality-gap", "--cwd", dir, "--research-slug", "study", "--list"]);
+    assert.equal(listed.code, 0, listed.stderr);
+    const listedPayload = JSON.parse(listed.stdout);
+    assert.deepEqual(listedPayload.openItems, ["Open gap", "Another open gap"]);
+    assert.deepEqual(listedPayload.closedItems, ["Closed gap", "Rejected with evidence"]);
   });
 });
 

--- a/plugins/codex-autoresearch/tests/full-product.test.mjs
+++ b/plugins/codex-autoresearch/tests/full-product.test.mjs
@@ -178,6 +178,7 @@ test("setup-plan, recipes, and recipe-backed setup are wired through the CLI", a
     const planPayload = JSON.parse(plan.stdout);
     assert.equal(planPayload.recommendedRecipe.id, "node-test-runtime");
     assert.match(planPayload.nextCommand, /setup/);
+    assert.deepEqual(planPayload.guidedFlow.map((step) => step.step), ["setup", "doctor", "baseline", "log"]);
 
     const recipes = await runCli(["recipes", "list"]);
     assert.equal(recipes.code, 0, recipes.stderr);
@@ -433,6 +434,34 @@ test("live server exposes health and view-model endpoints", async () => {
       assert.equal(health.ok, true);
       const viewModel = await fetch(`${payload.url}view-model.json`).then((res) => res.json());
       assert.equal(viewModel.summary.runs, 1);
+    } finally {
+      child.kill();
+    }
+  });
+});
+
+test("live server gap-candidates action uses the active research slug", async () => {
+  await withTempDir("live-gap-action", async (dir) => {
+    await runCli(["research-setup", "--cwd", dir, "--slug", "Custom Study", "--goal", "Study live gaps"]);
+
+    const child = spawn(process.execPath, [cli, "serve", "--cwd", dir, "--port", "0"], {
+      cwd: pluginRoot,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    try {
+      const payload = await waitForServerPayload(() => stdout, () => stderr);
+      const action = await fetch(`${payload.url}actions/gap-candidates`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }).then((res) => res.json());
+      assert.equal(action.ok, true, action.stderr || action.error);
+      assert.match(action.stdout, /"slug": "custom-study"/);
     } finally {
       child.kill();
     }


### PR DESCRIPTION
## What changed
- Added root ignores for Codex Autoresearch session artifacts.
- Added `quality-gap --list` so operators can inspect open and closed gap items directly.
- Made dashboard command generation and live gap-candidate actions use the active research slug instead of silently falling back to `research`.
- Added a guided setup flow to `setup-plan`, regression coverage for the new operator paths, and bumped Codex Autoresearch from `0.1.8` to `0.1.9` across package, manifest, and MCP metadata.

## Why
This removes friction found while dogfooding deep research sessions and keeps gap workflows pointed at the research session the operator is actually using.

## Impact
Operators get clearer first-run guidance, listable quality-gap details, safer dashboard/live action behavior, and a synced plugin version for the next release.

## Root cause
Root self-dogfooding previously lacked artifact ignores, and the dashboard/live gap-candidate paths had hardcoded assumptions around the `research` slug. The version bump also exposed that public version surfaces need to be kept in sync.

## Validation
- `node --test tests/autoresearch-cli.test.mjs tests/full-product.test.mjs`
- `npm run check`
- `git diff --check`
