### PR TITLE
[codex] autoresearch 0.2.0 dashboard guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ finalize Split the kept fixture change into a review branch when the noisy loop 
 | MCP tools | `setup_plan`, `list_recipes`, `setup_session`, `setup_research_session`, `configure_session`, `init_experiment`, `run_experiment`, `next_experiment`, `log_experiment`, `read_state`, `measure_quality_gap`, `gap_candidates`, `finalize_preview`, `integrations`, `doctor_session`, `export_dashboard`, `clear_session` |
 | Skills | Create/resume loops, turn deep research into quality gaps, export dashboards, finalize noisy branches |
 | Commands | `/autoresearch` and `/autoresearch-finalize` workflow docs |
-| Dashboard | HTML operator cockpit generated from `autoresearch.jsonl`, with embedded snapshot data, live refresh, copyable commands, setup/readiness/gap/finalization panels, and safe live actions when served locally |
+| Dashboard | HTML operator cockpit generated from `autoresearch.jsonl`, with embedded snapshot data, a next-best-action rail, experiment-family and lane-portfolio panels, live refresh, copyable commands, setup/readiness/gap/finalization panels, and safe live actions when served locally |
 | Templates | Starter `autoresearch.md`, shell/PowerShell benchmark scripts, and checks scripts |
 | Recipes and integrations | Built-in benchmark recipes, local/remote recipe catalogs, model-command gap candidates, and live dashboard action providers |
 
@@ -200,7 +200,7 @@ Then it creates:
 | `autoresearch.checks.sh` or `autoresearch.checks.ps1` | Optional correctness checks after a passing benchmark |
 | `autoresearch.jsonl` | Append-only run log |
 | `autoresearch-dashboard.html` | Exported operator dashboard that Codex links directly when the workflow starts or resumes |
-| last-run packet | Latest `next` packet for quick keep/discard logging with `--from-last`; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json` |
+| last-run packet | Latest `next` packet for quick keep/discard logging with `--from-last`; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json`, then cleared after a successful `log --from-last` |
 | `autoresearch.ideas.md` | Optional backlog for promising ideas |
 
 The deterministic setup path is available as MCP `setup_session` and CLI `setup`. It is the fastest way to create a fresh, resumable Codex session without hand-copying templates.
@@ -228,6 +228,8 @@ After `next`, the helper persists a last-run packet. Use `log --from-last` to re
 ```bash
 node plugins/codex-autoresearch/scripts/autoresearch.mjs log --cwd /path/to/project --from-last --status keep --description "Use worker pool"
 ```
+
+Successful packets still require an explicit `--status keep` or `--status discard`; failed benchmark/check packets can suggest the forced status. A consumed packet is cleared after logging, and stale packets are rejected if another run was logged after the packet was produced.
 
 Minimum useful ASI is one compact JSON object:
 
@@ -299,6 +301,8 @@ The dashboard shows:
 - baseline vs. best
 - improvement percentage
 - kept run count
+- the next best action, including evidence, command text, and any safe live action
+- experiment families, plateau risk, novelty signal, and lane-portfolio guidance
 - live refresh status plus `Refresh` and `Live on` controls that try to read the adjacent `autoresearch.jsonl`
 - copyable operator commands for doctor, next, keep/discard last packet, export, and extend
 - operator readout with best kept change, recent failures, next action, and confidence explanation

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "description": "Autonomous experiment loops for Codex: set up a benchmark, run iterations, log results, export dashboards, and finalize kept changes.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/README.md
+++ b/plugins/codex-autoresearch/README.md
@@ -121,7 +121,7 @@ finalize Split the kept fixture change into a review branch when the noisy loop 
 | MCP tools | `setup_plan`, `list_recipes`, `setup_session`, `setup_research_session`, `configure_session`, `init_experiment`, `run_experiment`, `next_experiment`, `log_experiment`, `read_state`, `measure_quality_gap`, `gap_candidates`, `finalize_preview`, `integrations`, `doctor_session`, `export_dashboard`, `clear_session` |
 | Skills | Create/resume loops, turn deep research into quality gaps, export dashboards, finalize noisy branches |
 | Commands | `/autoresearch` and `/autoresearch-finalize` workflow docs |
-| Dashboard | HTML operator cockpit generated from `autoresearch.jsonl`, with embedded snapshot data, live refresh, copyable commands, setup/readiness/gap/finalization panels, and safe live actions when served locally |
+| Dashboard | HTML operator cockpit generated from `autoresearch.jsonl`, with embedded snapshot data, a next-best-action rail, experiment-family and lane-portfolio panels, live refresh, copyable commands, setup/readiness/gap/finalization panels, and safe live actions when served locally |
 | Templates | Starter `autoresearch.md`, shell/PowerShell benchmark scripts, and checks scripts |
 | Recipes and integrations | Built-in benchmark recipes, local/remote recipe catalogs, model-command gap candidates, and live dashboard action providers |
 
@@ -200,7 +200,7 @@ Then it creates:
 | `autoresearch.checks.sh` or `autoresearch.checks.ps1` | Optional correctness checks after a passing benchmark |
 | `autoresearch.jsonl` | Append-only run log |
 | `autoresearch-dashboard.html` | Exported operator dashboard that Codex links directly when the workflow starts or resumes |
-| last-run packet | Latest `next` packet for quick keep/discard logging with `--from-last`; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json` |
+| last-run packet | Latest `next` packet for quick keep/discard logging with `--from-last`; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json`, then cleared after a successful `log --from-last` |
 | `autoresearch.ideas.md` | Optional backlog for promising ideas |
 
 The deterministic setup path is available as MCP `setup_session` and CLI `setup`. It is the fastest way to create a fresh, resumable Codex session without hand-copying templates.
@@ -228,6 +228,8 @@ After `next`, the helper persists a last-run packet. Use `log --from-last` to re
 ```bash
 node scripts/autoresearch.mjs log --cwd /path/to/project --from-last --status keep --description "Use worker pool"
 ```
+
+Successful packets still require an explicit `--status keep` or `--status discard`; failed benchmark/check packets can suggest the forced status. A consumed packet is cleared after logging, and stale packets are rejected if another run was logged after the packet was produced.
 
 Minimum useful ASI is one compact JSON object:
 
@@ -299,6 +301,8 @@ The dashboard shows:
 - baseline vs. best
 - improvement percentage
 - kept run count
+- the next best action, including evidence, command text, and any safe live action
+- experiment families, plateau risk, novelty signal, and lane-portfolio guidance
 - live refresh status plus `Refresh` and `Live on` controls that try to read the adjacent `autoresearch.jsonl`
 - copyable operator commands for doctor, next, keep/discard last packet, export, and extend
 - operator readout with best kept change, recent failures, next action, and confidence explanation

--- a/plugins/codex-autoresearch/assets/template.html
+++ b/plugins/codex-autoresearch/assets/template.html
@@ -126,6 +126,67 @@ h1 {
   color: var(--ink);
   font-size: 14px;
 }
+.next-rail {
+  margin: 18px 0;
+}
+.next-action-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, .7fr);
+  gap: 16px;
+  padding: 16px 18px 18px;
+  align-items: stretch;
+  min-height: 218px;
+}
+.priority-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  background: rgba(15, 159, 143, .12);
+  color: #0b6f65;
+  padding: 4px 9px;
+  font-size: 11px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+.next-action-copy h3 {
+  margin: 10px 0 0;
+  font-size: 22px;
+  line-height: 1.18;
+  overflow-wrap: anywhere;
+}
+.next-action-copy p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+.next-action-command {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  grid-template-rows: minmax(112px, auto) 38px 38px;
+}
+.inline-command {
+  border: 1px solid var(--soft-line);
+  border-radius: 8px;
+  background: #f9fafb;
+  padding: 10px;
+  min-width: 0;
+}
+.inline-command span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.inline-command code {
+  display: block;
+  margin-top: 6px;
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 12px;
+}
 .tool-button {
   border: 1px solid var(--line);
   border-radius: 8px;
@@ -328,6 +389,38 @@ th {
   color: var(--muted);
   text-align: center;
 }
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr);
+  gap: 16px;
+  padding: 16px 18px 18px;
+  align-items: start;
+}
+.family-list,
+.lane-list {
+  display: grid;
+  gap: 8px;
+}
+.family-row,
+.lane-row {
+  border-top: 1px solid var(--soft-line);
+  padding-top: 9px;
+  min-width: 0;
+  min-height: 68px;
+}
+.family-row strong,
+.lane-row strong {
+  display: block;
+  font-size: 14px;
+}
+.family-row span,
+.lane-row span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
 .command-grid {
   display: grid;
   gap: 8px;
@@ -362,6 +455,7 @@ th {
 @media (max-width: 940px) {
   .wrap { padding: 18px; }
   .masthead, .layout { grid-template-columns: 1fr; }
+  .next-action-body, .portfolio-grid { grid-template-columns: 1fr; }
   .readout-grid, .cockpit-grid, .action-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .control-strip { align-items: stretch; flex-direction: column; }
   .live-strip, .command-row { grid-template-columns: 1fr; }
@@ -410,6 +504,29 @@ th {
     </div>
     <button class="tool-button" id="refresh-now" type="button">Refresh</button>
     <button class="tool-button" id="live-toggle" type="button" aria-pressed="false">Live off</button>
+  </section>
+
+  <section class="panel next-rail" aria-label="Next best action">
+    <div class="panel-head">
+      <h2 class="panel-title">Next best action</h2>
+      <span class="panel-note" id="next-best-note">Evidence-backed recommendation</span>
+    </div>
+    <div class="next-action-body">
+      <div class="next-action-copy">
+        <span class="priority-badge" id="next-best-priority">Recommended</span>
+        <h3 id="next-best-title">Choose next hypothesis</h3>
+        <p id="next-best-detail">Run and log a baseline before optimizing.</p>
+        <p id="next-best-evidence">No run evidence yet.</p>
+      </div>
+      <div class="next-action-command">
+        <div class="inline-command">
+          <span id="next-best-command-label">Command</span>
+          <code id="next-best-command">-</code>
+        </div>
+        <button class="tool-button" id="copy-next-best" type="button">Copy command</button>
+        <button class="tool-button" id="run-next-best-action" type="button">Live action unavailable</button>
+      </div>
+    </div>
   </section>
 
   <section class="panel readout" aria-label="Operator cockpit">
@@ -498,6 +615,27 @@ th {
       </div>
       <div class="rail-list" id="decision-rail"></div>
     </aside>
+  </section>
+
+  <section class="panel" aria-label="Experiment portfolio">
+    <div class="panel-head">
+      <h2 class="panel-title">Experiment portfolio</h2>
+      <span class="panel-note" id="portfolio-note">Families, lanes, and plateau risk</span>
+    </div>
+    <div class="portfolio-grid">
+      <div>
+        <span class="readout-label">Plateau</span>
+        <div class="family-row">
+          <strong id="plateau-title">Signal forming</strong>
+          <span id="plateau-detail">Plateau detection needs more measured runs.</span>
+        </div>
+        <div class="family-list" id="family-list"></div>
+      </div>
+      <div>
+        <span class="readout-label">Lane portfolio</span>
+        <div class="lane-list" id="lane-list"></div>
+      </div>
+    </div>
   </section>
 
   <section class="panel" aria-label="Command shortcuts">
@@ -646,8 +784,10 @@ function render() {
   renderSegmentSelector();
   renderReadout();
   renderProductCockpit();
+  renderNextBestAction();
   renderChart();
   renderRail();
+  renderPortfolio();
   renderCommands();
   renderLiveActions();
   renderLedger();
@@ -744,6 +884,64 @@ function renderProductCockpit() {
   document.getElementById("finalize-preview-detail").textContent = finalizePreview.nextAction || "Run finalize-preview after keeping at least one committed experiment.";
   document.getElementById("blocker-title").textContent = blockers.length ? blockers.length + " blocker" + (blockers.length === 1 ? "" : "s") : "No blockers";
   document.getElementById("blocker-detail").textContent = blockers.slice(0, 2).join("; ") || "No setup, memory, version, or finalization blockers reported in the export.";
+}
+
+function renderNextBestAction() {
+  const action = viewModel.nextBestAction || (Array.isArray(viewModel.actionRail) ? viewModel.actionRail[0] : null) || {};
+  const command = action.primaryCommand?.command || action.command || "";
+  const safeAction = action.safeAction || "";
+  document.getElementById("next-best-note").textContent = action.source ? "Source: " + action.source : "Evidence-backed recommendation";
+  document.getElementById("next-best-priority").textContent = action.priority || "Recommended";
+  document.getElementById("next-best-title").textContent = action.title || "Choose next hypothesis";
+  document.getElementById("next-best-detail").textContent = action.detail || "Run and log a baseline before optimizing.";
+  document.getElementById("next-best-evidence").textContent = action.utilityCopy || action.reason || "No run evidence yet.";
+  document.getElementById("next-best-command-label").textContent = action.primaryCommand?.label || action.commandLabel || "Command";
+  document.getElementById("next-best-command").textContent = command || "No command embedded";
+  const copyButton = document.getElementById("copy-next-best");
+  if (copyButton) {
+    copyButton.onclick = () => copyText(command, copyButton, "Copy command");
+  }
+  const liveButton = document.getElementById("run-next-best-action");
+  if (liveButton) {
+    liveButton.textContent = safeAction ? actionLabel(safeAction) : "Live action unavailable";
+    liveButton.disabled = !safeAction;
+    liveButton.onclick = safeAction ? () => runLiveAction(safeAction, liveButton) : null;
+  }
+}
+
+function renderPortfolio() {
+  const portfolio = viewModel.portfolio || {};
+  const memory = viewModel.experimentMemory || {};
+  const plateau = portfolio.plateau || memory.plateau || {};
+  const families = Array.isArray(portfolio.families) ? portfolio.families : [];
+  const lanes = Array.isArray(portfolio.lanes) ? portfolio.lanes : [];
+  const noveltyScore = portfolio.summary?.noveltyScore;
+  document.getElementById("portfolio-note").textContent = noveltyScore == null
+    ? "Families, lanes, and plateau risk"
+    : "Novelty score " + noveltyScore;
+  document.getElementById("plateau-title").textContent = plateau.detected || plateau.state === "plateau"
+    ? "Plateau likely"
+    : (plateau.title || "Signal moving");
+  document.getElementById("plateau-detail").textContent = plateau.reason || plateau.detail || plateau.recommendation || "No plateau warning in the current segment.";
+  const familyList = document.getElementById("family-list");
+  familyList.innerHTML = families.length ? families.slice(0, 6).map((family) => {
+    const runCount = family.runs ?? family.total ?? family.runCount ?? 0;
+    const kept = family.kept ?? 0;
+    const rejected = family.rejected ?? 0;
+    const bestMetric = family.bestRun?.metric ?? family.bestMetric ?? null;
+    return '<div class="family-row">' +
+      '<strong>' + escapeHtml(family.label || family.name || family.title || "Experiment family") + '</strong>' +
+      '<span>' + escapeHtml(runCount + " run(s), " + kept + " kept, " + rejected + " rejected" + (bestMetric == null ? "" : ", best " + formatMetric(Number(bestMetric)))) + '</span>' +
+      '</div>';
+  }).join("") : '<div class="empty">No experiment families yet</div>';
+  const laneList = document.getElementById("lane-list");
+  laneList.innerHTML = lanes.length ? lanes.slice(0, 6).map((lane) => {
+    const priority = lane.priority ? " [" + lane.priority + "]" : "";
+    return '<div class="lane-row">' +
+      '<strong>' + escapeHtml(lane.label || lane.title || lane.id || "Lane") + escapeHtml(priority) + '</strong>' +
+      '<span>' + escapeHtml(lane.nextActionHint || lane.detail || lane.reason || "No lane detail yet.") + '</span>' +
+      '</div>';
+  }).join("") : '<div class="empty">No lane portfolio yet</div>';
 }
 
 function renderSegmentSelector() {
@@ -863,7 +1061,10 @@ function asiText(run, keys, fallback) {
 function renderReadout() {
   const keptBest = bestKeptRun();
   const recentFailure = failedRuns().at(-1);
-  const nextAction = viewModel.experimentMemory?.latestNextAction || [...session.runs].reverse().map((run) => asiText(run, ["next_action_hint", "nextAction", "next_action"], "")).find(Boolean);
+  const nextAction = viewModel.readout?.nextAction
+    || viewModel.nextBestAction?.detail
+    || viewModel.experimentMemory?.latestNextAction
+    || [...session.runs].reverse().map((run) => asiText(run, ["next_action_hint", "nextAction", "next_action"], "")).find(Boolean);
   const confidence = latestConfidence();
 
   document.getElementById("best-kept-title").textContent = keptBest ? "#" + keptBest.run + " " + formatMetric(keptBest.metric) : "No kept changes yet";
@@ -988,21 +1189,25 @@ function renderCommands() {
   for (const button of grid.querySelectorAll ? grid.querySelectorAll(".copy-command") : []) {
     button.onclick = async () => {
       const command = commands[Number(button.dataset.commandIndex)]?.command || "";
-      try {
-        const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : null;
-        if (!clipboard?.writeText) {
-          button.textContent = "Select";
-          return;
-        }
-        await clipboard.writeText(command);
-        button.textContent = "Copied";
-        if (typeof setTimeout === "function") {
-          setTimeout(() => { button.textContent = "Copy"; }, 1200);
-        }
-      } catch {
-        button.textContent = "Select";
-      }
+      await copyText(command, button, "Copy");
     };
+  }
+}
+
+async function copyText(value, button, resetText) {
+  try {
+    const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : null;
+    if (!value || !clipboard?.writeText) {
+      button.textContent = "Select";
+      return;
+    }
+    await clipboard.writeText(value);
+    button.textContent = "Copied";
+    if (typeof setTimeout === "function") {
+      setTimeout(() => { button.textContent = resetText; }, 1200);
+    }
+  } catch {
+    button.textContent = "Select";
   }
 }
 
@@ -1012,27 +1217,41 @@ function renderLiveActions() {
   for (const button of grid.querySelectorAll(".live-action")) {
     button.onclick = async () => {
       const action = button.dataset.action;
-      button.textContent = "Running";
-      try {
-        const body = action === "gap-candidates"
-          ? { researchSlug: activeResearchSlug() }
-          : {};
-        const response = await fetch("actions/" + action, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(body),
-        });
-        const payload = await response.json();
-        button.textContent = payload.ok ? "Done" : "Failed";
-        updateLiveStatus(action + " action", payload.ok ? "Completed" : (payload.stderr || payload.error || "Failed"));
-        if (typeof setTimeout === "function") {
-          setTimeout(() => { button.textContent = actionLabel(action); }, 1400);
-        }
-      } catch (error) {
-        button.textContent = "Unavailable";
-        updateLiveStatus("Live action unavailable", error.message || String(error));
-      }
+      runLiveAction(action, button);
     };
+  }
+}
+
+async function runLiveAction(action, button) {
+  button.textContent = "Running";
+  button.disabled = true;
+  button.setAttribute("aria-busy", "true");
+  try {
+    const body = action === "gap-candidates"
+      ? { researchSlug: activeResearchSlug() }
+      : {};
+    const response = await fetch("actions/" + action, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const payload = await response.json();
+    button.textContent = payload.ok ? "Done" : "Failed";
+    updateLiveStatus(action + " action", payload.ok ? "Completed" : (payload.stderr || payload.error || "Failed"));
+    await refreshViewModel();
+    if (typeof setTimeout === "function") {
+      setTimeout(() => {
+        button.textContent = actionLabel(action);
+        button.disabled = false;
+        button.setAttribute("aria-busy", "false");
+        render();
+      }, 1400);
+    }
+  } catch (error) {
+    button.textContent = "Unavailable";
+    button.disabled = false;
+    button.setAttribute("aria-busy", "false");
+    updateLiveStatus("Live action unavailable", error.message || String(error));
   }
 }
 

--- a/plugins/codex-autoresearch/commands/autoresearch.md
+++ b/plugins/codex-autoresearch/commands/autoresearch.md
@@ -50,7 +50,7 @@ Use the local routing above when this repository is the target.
 - `setup-plan`: run `node <plugin-root>/scripts/autoresearch.mjs setup-plan --cwd <current-project>` to get a read-only guided setup plan, missing fields, recipe recommendation, and exact next setup command. Add `--catalog <path-or-url>` when planning from a local or remote recipe catalog.
 - `recipes ...`: run `node <plugin-root>/scripts/autoresearch.mjs recipes list|show ...` to inspect built-in or local/remote catalog benchmark recipes. Catalog recipe IDs can be used by `setup --recipe <id> --catalog <path-or-url>`.
 - `doctor`: run `node <plugin-root>/scripts/autoresearch.mjs doctor --cwd <current-project> --check-benchmark` when a benchmark is configured, then report issues, warnings, and next action.
-- `next`: run `node <plugin-root>/scripts/autoresearch.mjs next --cwd <current-project>`, then report doctor status, metric, allowed log statuses, ASI template, and next action.
+- `next`: run `node <plugin-root>/scripts/autoresearch.mjs next --cwd <current-project>`, then report doctor status, metric, allowed log statuses, suggested status if present, ASI template, and next action.
 - `log`: run `node <plugin-root>/scripts/autoresearch.mjs log --cwd <current-project> --from-last --status <keep|discard|crash|checks_failed> --description <text>`, then follow `continuation`; do not ask the user to rerun `autoresearch-create` for the next packet.
 - `config ...`: run `node <plugin-root>/scripts/autoresearch.mjs config --cwd <current-project> ...` for runtime settings such as `--autonomy-mode`, `--checks-policy`, `--keep-policy`, `--extend`, and `--dashboard-refresh-seconds`.
 - `status`: run `node <plugin-root>/scripts/autoresearch.mjs state --cwd <current-project>` and summarize.
@@ -72,7 +72,7 @@ Before starting a new loop, check git status. If the worktree is dirty, ask whet
 
 Before logging a kept result in a dirty tree, prefer scoped commit paths from the session scope or ask the user to confirm broad staging.
 
-After `next`, prefer `log --from-last` so Codex does not retype parsed metrics from the previous packet. Still choose `keep` or `discard` deliberately based on the metric and ASI.
+After `next`, prefer `log --from-last` so Codex does not retype parsed metrics from the previous packet. Still choose `keep` or `discard` deliberately based on the metric and ASI. Successful packets require an explicit status; consumed packets are cleared, and stale packets must be replaced by running `next` again.
 
 Before logging a discard/crash/checks-failed result, use configured `commitPaths`/`revertPaths`. Do not pass `--allow-dirty-revert` unless the user explicitly accepts broad cleanup.
 
@@ -82,6 +82,6 @@ For qualitative research loops, use `autoresearch-deep-research`. Its benchmark 
 
 Model-assisted gap generation must stay provider-agnostic. Use `gap-candidates --model-command <cmd>` only when the command prints a JSON array of candidate objects; the helper validates and previews the output before `--apply`.
 
-Dashboard live actions are local-only and limited to safe commands: doctor, setup-plan, recipes, gap-candidates preview, finalize-preview, and export. Mutating review branch creation remains in `/autoresearch-finalize`.
+Dashboard live actions are local-only and limited to safe commands: doctor, setup-plan, recipes, gap-candidates preview, finalize-preview, and export. Mutating review branch creation and keep/discard logging remain outside the dashboard surface.
 
 When using this repo-local copy, `<plugin-root>` is `plugins/codex-autoresearch`.

--- a/plugins/codex-autoresearch/lib/dashboard-view-model.mjs
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.mjs
@@ -20,13 +20,31 @@ export function buildDashboardViewModel({
   const nextAction = [...current].reverse()
     .map((run) => run.asi?.next_action_hint || run.asi?.nextAction || run.asi?.next_action)
     .find(Boolean) || (current.length ? "Choose the next measured hypothesis." : "Run and log a baseline.");
+  const actionRail = buildActionRail({
+    current,
+    bestKept,
+    latestFailure,
+    nextAction,
+    setupPlan,
+    guidedSetup,
+    qualityGap,
+    finalizePreview,
+    experimentMemory,
+    drift,
+    commands,
+  });
+  const portfolio = buildPortfolio(experimentMemory, state.config.bestDirection);
   return {
     setup: setupPlan,
     guidedSetup,
+    lastRun: guidedSetup?.lastRun || null,
     qualityGap,
     finalizePreview,
     recipes,
     experimentMemory,
+    portfolio,
+    nextBestAction: actionRail[0],
+    actionRail,
     drift,
     summary: {
       name: state.config.name || "Autoresearch",
@@ -49,7 +67,7 @@ export function buildDashboardViewModel({
     readout: {
       bestKept: bestKept ? compactRun(bestKept) : null,
       latestFailure: latestFailure ? compactRun(latestFailure) : null,
-      nextAction,
+      nextAction: actionRail[0]?.detail || nextAction,
       confidenceText: state.confidence == null
         ? "Confidence needs at least three finite metric runs and enough signal over noise."
         : "Confidence compares best movement against median absolute deviation.",
@@ -59,6 +77,396 @@ export function buildDashboardViewModel({
     },
     commands,
   };
+}
+
+function buildActionRail({
+  current,
+  bestKept,
+  latestFailure,
+  nextAction,
+  setupPlan,
+  guidedSetup,
+  qualityGap,
+  finalizePreview,
+  experimentMemory,
+  drift,
+  commands,
+}) {
+  const commandMap = commandLookup(commands);
+  const warnings = [
+    ...(current.length ? [] : Array.isArray(setupPlan?.missing) ? setupPlan.missing : []),
+    ...(Array.isArray(setupPlan?.warnings) ? setupPlan.warnings : []),
+    ...(Array.isArray(drift?.warnings) ? drift.warnings : []),
+  ];
+  const lastMemoryAction = experimentMemory?.latestNextAction || "";
+  const qualityGapOpen = Number(qualityGap?.open);
+  const hasQualityGaps = Number.isFinite(qualityGapOpen) && qualityGapOpen > 0;
+  const canFinalize = Boolean(finalizePreview?.ready);
+
+  let primary;
+  if (guidedSetup?.stage === "needs-setup") {
+    primary = actionItem({
+      kind: "setup",
+      priority: "Critical",
+      title: "Complete setup",
+      detail: guidedSetup.nextAction || "Create or complete the session setup before running a baseline.",
+      utilityCopy: "Setup comes before trustworthy metrics.",
+      safeAction: "setup-plan",
+      command: guidedSetup.commands?.setup || commandMap.get("setup plan"),
+      commandLabel: "Setup",
+      tone: "warn",
+      source: "setup",
+    });
+  } else if (guidedSetup?.stage === "stale-last-run") {
+    const stalePacketCommand = guidedSetup.commands?.replaceLast
+      || (setupPlan?.defaultBenchmarkCommandReady ? commandMap.get("next run") : "");
+    primary = actionItem({
+      kind: "stale-packet",
+      priority: "Critical",
+      title: "Replace the stale packet",
+      detail: guidedSetup.lastRun?.freshness?.reason || guidedSetup.nextAction || "The saved last-run packet no longer matches the ledger.",
+      utilityCopy: "Run a fresh packet before logging so old metrics cannot be reused.",
+      safeAction: stalePacketCommand ? "" : "setup-plan",
+      command: stalePacketCommand || guidedSetup.commands?.setup || commandMap.get("setup plan"),
+      commandLabel: stalePacketCommand ? "Next" : "Setup",
+      tone: "warn",
+      source: "packet",
+    });
+  } else if (guidedSetup?.stage === "needs-log-decision") {
+    const suggested = guidedSetup.lastRun?.suggestedStatus || "keep or discard";
+    primary = actionItem({
+      kind: "log-decision",
+      priority: "Critical",
+      title: "Log the last packet",
+      detail: `Record the last packet as ${suggested}, then run a new packet.`,
+      utilityCopy: "Logging clears the packet so it cannot be reused by mistake.",
+      command: guidedSetup.commands?.logLast || commandMap.get("keep last") || commandMap.get("discard last"),
+      commandLabel: "Log",
+      tone: "warn",
+      source: "packet",
+    });
+  } else if (guidedSetup?.stage === "needs-benchmark-command") {
+    primary = actionItem({
+      kind: "benchmark-command",
+      priority: "Critical",
+      title: "Add a benchmark command",
+      detail: guidedSetup.nextAction || "This session has logged metrics, but next has no default benchmark script to run.",
+      utilityCopy: "Measured loops need a repeatable command before the dashboard can send you to next.",
+      safeAction: "setup-plan",
+      command: guidedSetup.commands?.setup || commandMap.get("setup plan"),
+      commandLabel: "Setup",
+      tone: "warn",
+      source: "setup",
+    });
+  } else if (warnings.length) {
+    primary = actionItem({
+      kind: "fix-blocker",
+      priority: "Critical",
+      title: "Clear setup drift",
+      detail: String(warnings[0]),
+      utilityCopy: "Trust the loop after doctor is clean.",
+      safeAction: "doctor",
+      command: commandMap.get("doctor"),
+      commandLabel: "Doctor",
+      tone: "warn",
+      source: "doctor",
+    });
+  } else if (!current.length) {
+    primary = actionItem({
+      kind: "baseline",
+      priority: "Start",
+      title: guidedSetup?.stage ? `Run ${guidedSetup.stage}` : "Capture the baseline",
+      detail: guidedSetup?.nextAction || setupPlan?.nextCommand || "Run the first measured packet so future changes have a floor.",
+      utilityCopy: "Establish the benchmark floor before tuning.",
+      command: guidedSetup?.commands?.baseline || commandMap.get("next run"),
+      commandLabel: "Next",
+      tone: "start",
+      source: "baseline",
+    });
+  } else if (experimentMemory?.plateau?.detected) {
+    const lane = experimentMemory.diversityGuidance || (Array.isArray(experimentMemory.lanePortfolio) ? experimentMemory.lanePortfolio[0] : null);
+    primary = actionItem({
+      kind: "plateau",
+      priority: "Critical",
+      title: "Break the plateau",
+      detail: lane?.nextActionHint || experimentMemory.plateau.recommendation,
+      utilityCopy: experimentMemory.plateau.reason || "Recent runs are clustering without a new best.",
+      command: commandMap.get("next run"),
+      commandLabel: "Next",
+      tone: "warn",
+      source: lane?.id || "plateau",
+    });
+  } else if (canFinalize) {
+    primary = actionItem({
+      kind: "finalize-preview",
+      priority: "Review",
+      title: "Preview finalization",
+      detail: finalizePreview.nextAction || "Inspect the branch packet before creating review branches.",
+      utilityCopy: "Turn kept evidence into a reviewable packet.",
+      safeAction: "finalize-preview",
+      command: commandMap.get("finalize preview"),
+      commandLabel: "Preview",
+      tone: "good",
+      source: "finalize",
+    });
+  } else if (hasQualityGaps) {
+    primary = actionItem({
+      kind: "continue",
+      priority: "Narrow",
+      title: "Pick a quality gap",
+      detail: `${qualityGap.open} open gap${qualityGap.open === 1 ? "" : "s"} remain in ${qualityGap.slug}.`,
+      utilityCopy: "Convert the next gap into one measurable hypothesis.",
+      safeAction: "gap-candidates",
+      command: commandMap.get("gap candidates"),
+      commandLabel: "Gaps",
+      tone: "focus",
+      source: "quality-gap",
+    });
+  } else if (lastMemoryAction || nextAction) {
+    primary = actionItem({
+      kind: "continue",
+      priority: "Next",
+      title: "Run the next measured hypothesis",
+      detail: lastMemoryAction || nextAction,
+      utilityCopy: latestFailure ? "Avoid repeating the rejected path." : "Use the latest ASI hint as the next loop input.",
+      command: commandMap.get("next run"),
+      commandLabel: "Next",
+      tone: "focus",
+      source: "asi-memory",
+    });
+  } else {
+    primary = actionItem({
+      kind: "continue",
+      priority: "Decide",
+      title: "Choose the next hypothesis",
+      detail: "No ASI next action was recorded on the latest runs.",
+      utilityCopy: "Add next_action_hint when logging the next result.",
+      command: commandMap.get("next run"),
+      commandLabel: "Next",
+      tone: "warn",
+      source: "memory",
+    });
+  }
+
+  const secondary = [
+    latestFailure && actionItem({
+      priority: "Avoid",
+      title: `Revisit run #${latestFailure.run}`,
+      detail: latestFailure.asi?.rollback_reason || latestFailure.asi?.failure || latestFailure.description || "Recent failure needs a rollback reason.",
+      utilityCopy: "Keep failed lanes visible before the next edit.",
+      command: commandMap.get("discard last"),
+      commandLabel: "Review",
+      tone: "warn",
+      source: "failure",
+    }),
+    bestKept && actionItem({
+      priority: "Anchor",
+      title: `Best kept #${bestKept.run}`,
+      detail: bestKept.description || bestKept.asi?.hypothesis || "Use the best kept run as the comparison anchor.",
+      utilityCopy: "Compare future work against the strongest kept result.",
+      command: commandMap.get("keep last"),
+      commandLabel: "Anchor",
+      tone: "good",
+      source: "kept",
+    }),
+    actionItem({
+      priority: "Safe",
+      title: "Refresh the runboard",
+      detail: "Export a fresh static dashboard after meaningful changes.",
+      utilityCopy: "Keep shared status pages current.",
+      safeAction: "export",
+      command: commandMap.get("export dashboard"),
+      commandLabel: "Export",
+      tone: "neutral",
+      source: "export",
+    }),
+  ].filter(Boolean);
+
+  return [primary, ...secondary].slice(0, 4);
+}
+
+function actionItem({ kind = "continue", priority, title, detail, utilityCopy, safeAction = "", command = "", commandLabel = "Copy", tone = "neutral", source = "" }) {
+  return {
+    kind,
+    priority,
+    title,
+    detail,
+    utilityCopy,
+    safeAction,
+    command,
+    primaryCommand: command ? { label: commandLabel, command } : null,
+    tone,
+    source,
+  };
+}
+
+function commandLookup(commands) {
+  const map = new Map();
+  for (const item of Array.isArray(commands) ? commands : []) {
+    const label = String(item?.label || "").toLowerCase();
+    if (label) map.set(label, item.command || "");
+  }
+  return map;
+}
+
+function buildPortfolio(memory, direction) {
+  if (Array.isArray(memory?.families) || Array.isArray(memory?.lanePortfolio)) {
+    return {
+      summary: {
+        families: memory?.families?.length || 0,
+        lanes: memory?.lanePortfolio?.length || 0,
+        experiments: (memory?.kept?.length || 0) + (memory?.rejected?.length || 0),
+        noveltyScore: memory?.novelty?.score ?? null,
+      },
+      families: Array.isArray(memory?.families) ? memory.families : [],
+      lanes: Array.isArray(memory?.lanePortfolio) ? memory.lanePortfolio : [],
+      plateau: memory?.plateau || { detected: false, recommendation: "" },
+    };
+  }
+  const experiments = memoryExperiments(memory);
+  const families = buildFamilies(experiments, direction);
+  const lanes = buildLanes(memory, experiments);
+  const plateau = buildPlateau(experiments, direction);
+  return {
+    summary: {
+      families: families.length,
+      lanes: lanes.length,
+      experiments: experiments.length,
+    },
+    families,
+    lanes,
+    plateau,
+  };
+}
+
+function memoryExperiments(memory) {
+  const kept = Array.isArray(memory?.kept) ? memory.kept : [];
+  const rejected = Array.isArray(memory?.rejected) ? memory.rejected : [];
+  return [
+    ...kept.map((item) => ({ ...item, lane: "promote" })),
+    ...rejected.map((item) => ({ ...item, lane: "avoid" })),
+  ].sort((a, b) => Number(a.run || 0) - Number(b.run || 0));
+}
+
+function buildFamilies(experiments, direction) {
+  const byKey = new Map();
+  for (const item of experiments) {
+    const source = item.hypothesis || item.description || `Run ${item.run}`;
+    const key = familyKey(source);
+    const existing = byKey.get(key) || {
+      key,
+      name: familyName(source),
+      total: 0,
+      kept: 0,
+      rejected: 0,
+      latestRun: null,
+      latestStatus: "",
+      bestMetric: null,
+      lane: "explore",
+    };
+    existing.total += 1;
+    if (item.status === "keep") existing.kept += 1;
+    else existing.rejected += 1;
+    existing.latestRun = item.run;
+    existing.latestStatus = item.status;
+    const metric = finiteMetric(item.metric);
+    if (metric != null && (existing.bestMetric == null || isBetter(metric, existing.bestMetric, direction))) {
+      existing.bestMetric = metric;
+    }
+    existing.lane = existing.kept && existing.rejected ? "mixed" : existing.kept ? "promote" : "avoid";
+    byKey.set(key, existing);
+  }
+  return [...byKey.values()]
+    .sort((a, b) => b.total - a.total || Number(b.latestRun || 0) - Number(a.latestRun || 0))
+    .slice(0, 6);
+}
+
+function buildLanes(memory, experiments) {
+  const kept = experiments.filter((item) => item.status === "keep");
+  const rejected = experiments.filter((item) => item.status !== "keep");
+  const nextActions = Array.isArray(memory?.nextActions) ? memory.nextActions : [];
+  return [
+    {
+      id: "promote",
+      title: "Promote",
+      count: kept.length,
+      detail: kept.at(-1)?.description || kept.at(-1)?.hypothesis || "No kept lane yet.",
+    },
+    {
+      id: "avoid",
+      title: "Avoid",
+      count: rejected.length,
+      detail: rejected.at(-1)?.rollbackReason || rejected.at(-1)?.description || "No rejected lane yet.",
+    },
+    {
+      id: "explore",
+      title: "Explore",
+      count: nextActions.length,
+      detail: nextActions.at(-1)?.nextActionHint || "No queued ASI hint yet.",
+    },
+  ];
+}
+
+function buildPlateau(experiments, direction) {
+  const finite = experiments
+    .map((item, index) => ({ ...item, metric: finiteMetric(item.metric), index }))
+    .filter((item) => item.metric != null);
+  if (finite.length < 3) {
+    return {
+      state: "forming",
+      title: "Signal forming",
+      detail: "Plateau detection needs at least three finite experiment-memory metrics.",
+      sinceBest: 0,
+    };
+  }
+  let bestIndex = 0;
+  for (let index = 1; index < finite.length; index += 1) {
+    if (isBetter(finite[index].metric, finite[bestIndex].metric, direction)) bestIndex = index;
+  }
+  const sinceBest = finite.length - bestIndex - 1;
+  const recent = finite.slice(-3);
+  const recentSpread = Math.max(...recent.map((item) => item.metric)) - Math.min(...recent.map((item) => item.metric));
+  const anchor = Math.max(1, Math.abs(finite[bestIndex].metric));
+  const flat = sinceBest >= 2 && recentSpread / anchor < 0.03;
+  if (flat) {
+    return {
+      state: "plateau",
+      title: "Plateau likely",
+      detail: `${sinceBest} finite run${sinceBest === 1 ? "" : "s"} since the best metric without a clear move.`,
+      sinceBest,
+    };
+  }
+  return {
+    state: sinceBest ? "moving" : "new-best",
+    title: sinceBest ? "Still moving" : "New best is latest",
+    detail: sinceBest
+      ? `${sinceBest} finite run${sinceBest === 1 ? "" : "s"} since the best metric; keep probing the active lane.`
+      : "The newest best metric is still fresh.",
+    sinceBest,
+  };
+}
+
+function familyKey(value) {
+  return tokens(value).slice(0, 3).join("-") || "experiment";
+}
+
+function familyName(value) {
+  const picked = tokens(value).slice(0, 3);
+  if (!picked.length) return "Experiment";
+  return picked.map((token) => token.slice(0, 1).toUpperCase() + token.slice(1)).join(" ");
+}
+
+function tokens(value) {
+  const stop = new Set(["the", "and", "for", "with", "from", "into", "all", "next", "run", "try", "use", "add"]);
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length > 2 && !stop.has(token));
+}
+
+function isBetter(next, current, direction) {
+  return direction === "higher" ? next > current : next < current;
 }
 
 function bestRun(runs, direction) {

--- a/plugins/codex-autoresearch/lib/experiment-memory.mjs
+++ b/plugins/codex-autoresearch/lib/experiment-memory.mjs
@@ -1,12 +1,14 @@
 const FAILURE_STATUSES = new Set(["discard", "crash", "checks_failed"]);
+const FAMILY_IGNORE_KEYS = new Set(["attempt", "attempts", "run", "trial", "trials", "seed", "repeat", "repeats", "r"]);
 
-export function buildExperimentMemory({ runs = [], direction = "lower" } = {}) {
+export function buildExperimentMemory({ runs = [], direction = "lower", settings = {} } = {}) {
   const kept = [];
   const rejected = [];
   const nextActions = [];
   const missingAsiRuns = [];
+  const enriched = runs.map((run) => ({ ...run, family: familyForRun(run) }));
 
-  for (const run of runs) {
+  for (const run of enriched) {
     const asi = run.asi || {};
     const compact = {
       run: run.run,
@@ -16,6 +18,7 @@ export function buildExperimentMemory({ runs = [], direction = "lower" } = {}) {
       hypothesis: asi.hypothesis || "",
       evidence: asi.evidence || "",
       commit: run.commit || "",
+      family: run.family.label,
     };
     const nextActionHint = asi.next_action_hint || asi.nextAction || asi.next_action || "";
     if (nextActionHint) {
@@ -34,10 +37,28 @@ export function buildExperimentMemory({ runs = [], direction = "lower" } = {}) {
     }
   }
 
+  const families = summarizeFamilies(enriched, direction);
+  const plateau = detectPlateau({ runs: enriched, families, direction });
+  const novelty = noveltySummary(enriched);
   const warnings = [];
   if (runs.length && missingAsiRuns.length) {
     warnings.push(`Runs missing ASI memory fields: ${missingAsiRuns.slice(-5).join(", ")}.`);
   }
+  if (plateau.detected) warnings.push(plateau.reason);
+  const latestNextAction = nextActions.at(-1)?.nextActionHint || "";
+  const lanePortfolio = buildLanePortfolio({
+    runs: enriched,
+    direction,
+    families,
+    plateau,
+    latestNextAction,
+    missingAsi: missingAsiRuns.length,
+    settings,
+  });
+  const diversityGuidance = lanePortfolio.find((lane) => lane.priority === "high" && lane.status !== "waiting")
+    || lanePortfolio.find((lane) => lane.status === "ready")
+    || lanePortfolio[0]
+    || null;
 
   return {
     direction,
@@ -45,11 +66,19 @@ export function buildExperimentMemory({ runs = [], direction = "lower" } = {}) {
     rejected,
     nextActions,
     warnings,
-    latestNextAction: nextActions.at(-1)?.nextActionHint || "",
+    latestNextAction,
+    families,
+    plateau,
+    novelty,
+    lanePortfolio,
+    diversityGuidance,
     summary: {
       kept: kept.length,
       rejected: rejected.length,
       missingAsi: missingAsiRuns.length,
+      families: families.length,
+      plateau: plateau.detected,
+      suggestedLane: diversityGuidance?.id || "",
     },
   };
 }
@@ -61,10 +90,17 @@ export function detectRepeatedHypothesis({ proposed = "", memory = {} } = {}) {
     ...(memory.rejected || []),
     ...(memory.kept || []),
   ];
+  const proposedFamily = canonicalFamilyKey(proposed);
   for (const item of candidates) {
     const previous = normalizeHypothesis(item.hypothesis || item.description);
+    const previousFamily = canonicalFamilyKey(item.family || item.hypothesis || item.description);
     if (!previous) continue;
-    if (previous === key || previous.includes(key) || key.includes(previous)) {
+    if (
+      previous === key
+      || previous.includes(key)
+      || key.includes(previous)
+      || (proposedFamily && previousFamily && (proposedFamily === previousFamily || proposedFamily.includes(previousFamily) || previousFamily.includes(proposedFamily)))
+    ) {
       return {
         matchedRun: item.run,
         status: item.status,
@@ -73,6 +109,285 @@ export function detectRepeatedHypothesis({ proposed = "", memory = {} } = {}) {
     }
   }
   return null;
+}
+
+function summarizeFamilies(runs, direction) {
+  const map = new Map();
+  for (const run of runs) {
+    const key = run.family.key;
+    if (!map.has(key)) {
+      map.set(key, {
+        key,
+        label: run.family.label,
+        runs: 0,
+        kept: 0,
+        rejected: 0,
+        latestRun: null,
+        bestRun: null,
+        bestKeptRun: null,
+        statuses: {},
+      });
+    }
+    const family = map.get(key);
+    family.runs += 1;
+    family.latestRun = compactFamilyRun(run);
+    family.statuses[run.status] = (family.statuses[run.status] || 0) + 1;
+    if (run.status === "keep") family.kept += 1;
+    if (FAILURE_STATUSES.has(run.status)) family.rejected += 1;
+    if (Number.isFinite(Number(run.metric)) && (!family.bestRun || isBetter(Number(run.metric), Number(family.bestRun.metric), direction))) {
+      family.bestRun = compactFamilyRun(run);
+    }
+    if (run.status === "keep" && Number.isFinite(Number(run.metric)) && (!family.bestKeptRun || isBetter(Number(run.metric), Number(family.bestKeptRun.metric), direction))) {
+      family.bestKeptRun = compactFamilyRun(run);
+    }
+  }
+  const summarized = [...map.values()]
+    .map((family) => ({
+      ...family,
+      exhausted: family.runs >= 3 && family.rejected >= Math.max(2, family.kept + 1),
+    }));
+  const sorted = summarized
+    .sort((a, b) => b.runs - a.runs || (b.latestRun?.run || 0) - (a.latestRun?.run || 0));
+  const limited = sorted.slice(0, 8);
+  const incumbent = bestIncumbentFamily(summarized, direction);
+  if (incumbent && !limited.some((family) => family.key === incumbent.key)) {
+    return [...limited.slice(0, 7), incumbent];
+  }
+  return limited;
+}
+
+function detectPlateau({ runs, families, direction }) {
+  const finiteRuns = runs.filter((run) => Number.isFinite(Number(run.metric)));
+  const keptFinite = finiteRuns.filter((run) => run.status === "keep");
+  const best = bestRun(keptFinite, direction);
+  const bestIndex = best ? runs.findIndex((run) => run.run === best.run) : -1;
+  const runsSinceBest = bestIndex >= 0 ? runs.length - bestIndex - 1 : runs.length;
+  const recent = runs.slice(-Math.min(6, runs.length));
+  const recentFailures = recent.filter((run) => FAILURE_STATUSES.has(run.status)).length;
+  const familyCounts = new Map();
+  for (const run of recent) {
+    familyCounts.set(run.family.key, (familyCounts.get(run.family.key) || 0) + 1);
+  }
+  const repeatedFamilyRuns = Math.max(0, ...familyCounts.values());
+  const repeatedFamilyKey = [...familyCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || "";
+  const repeatedFamily = families.find((family) => family.key === repeatedFamilyKey) || null;
+  const detected = Boolean(
+    best
+    && runs.length >= 5
+    && runsSinceBest >= 4
+    && (repeatedFamilyRuns >= 3 || recentFailures >= 3)
+  );
+  return {
+    detected,
+    state: detected ? "plateau" : runs.length < 5 ? "forming" : "moving",
+    runsSinceBest,
+    recentWindow: recent.length,
+    recentFailures,
+    repeatedFamilyRuns,
+    repeatedFamily: repeatedFamily ? repeatedFamily.label : "",
+    reason: detected
+      ? `Plateau risk: ${runsSinceBest} runs since the best keep, with ${repeatedFamilyRuns} recent run(s) in ${repeatedFamily?.label || "one family"}.`
+      : "",
+    recommendation: detected
+      ? "Force a distant scout or constraint-removal lane before another near-neighbor tweak."
+      : "Continue balancing incumbent confirmation with fresh scouts.",
+  };
+}
+
+function noveltySummary(runs) {
+  const recent = runs.slice(-Math.min(6, runs.length));
+  const unique = new Set(recent.map((run) => run.family.key));
+  const topCount = Math.max(0, ...[...unique].map((key) => recent.filter((run) => run.family.key === key).length));
+  return {
+    recentWindow: recent.length,
+    uniqueFamilies: unique.size,
+    repeatedFamilyRuns: topCount,
+    score: recent.length ? Number((unique.size / recent.length).toFixed(3)) : null,
+  };
+}
+
+function buildLanePortfolio({ runs, direction, families, plateau, latestNextAction, missingAsi, settings = {} }) {
+  const recentFailures = runs.slice(-5).filter((run) => FAILURE_STATUSES.has(run.status)).length;
+  const kept = runs.filter((run) => run.status === "keep");
+  const rejected = runs.filter((run) => FAILURE_STATUSES.has(run.status));
+  const topFamily = bestIncumbentFamily(families, direction);
+  const exhaustedFamily = families.find((family) => family.exhausted);
+  const checksPolicy = settings.checksPolicy || "always";
+  const keepPolicy = settings.keepPolicy || "primary-only";
+  const aggregateLanes = [
+    {
+      id: "promote",
+      label: "Promote",
+      title: "Promote",
+      count: kept.length,
+      priority: kept.length ? "medium" : "low",
+      status: kept.length ? "ready" : "watch",
+      reason: kept.at(-1)?.description || kept.at(-1)?.asi?.hypothesis || "No kept lane yet.",
+      nextActionHint: kept.at(-1)?.asi?.next_action_hint || kept.at(-1)?.description || "Keep measured wins visible for finalization.",
+    },
+    {
+      id: "avoid",
+      label: "Avoid",
+      title: "Avoid",
+      count: rejected.length,
+      priority: rejected.length ? "high" : "low",
+      status: rejected.length ? "ready" : "watch",
+      reason: rejected.at(-1)?.asi?.rollback_reason || rejected.at(-1)?.description || "No rejected lane yet.",
+      nextActionHint: rejected.at(-1)?.asi?.next_action_hint || rejected.at(-1)?.asi?.rollback_reason || rejected.at(-1)?.description || "Keep rejected paths visible before the next edit.",
+    },
+    {
+      id: "explore",
+      label: "Explore",
+      title: "Explore",
+      count: latestNextAction ? 1 : 0,
+      priority: latestNextAction ? "medium" : "low",
+      status: "ready",
+      reason: latestNextAction || "No queued ASI hint yet.",
+      nextActionHint: latestNextAction || "Add ASI next_action_hint when logging the next result.",
+    },
+  ];
+  return [
+    {
+      id: "distant-scout",
+      label: "Distant scout",
+      priority: plateau.detected ? "high" : "medium",
+      status: "ready",
+      reason: plateau.detected ? plateau.recommendation : "Reserve one lane for a materially different family each batch.",
+      nextActionHint: "Try a different algorithm, model family, data slice, or architecture knob before another small parameter tweak.",
+    },
+    {
+      id: "incumbent-confirmation",
+      label: "Incumbent confirmation",
+      priority: topFamily && !plateau.detected ? "high" : "medium",
+      status: topFamily ? "ready" : "waiting",
+      reason: topFamily ? `Best-known local family: ${topFamily.label}.` : "No kept incumbent yet.",
+      nextActionHint: topFamily
+        ? (topFamily.bestKeptRun?.nextActionHint || topFamily.latestRun?.nextActionHint || latestNextAction || "Repeat or stress the best kept idea only after a fresh scout lane exists.")
+        : "Keep a baseline before confirmation lanes.",
+    },
+    {
+      id: "near-neighbor",
+      label: "Near-neighbor tweak",
+      priority: plateau.detected ? "low" : "medium",
+      status: plateau.detected ? "cooldown" : "ready",
+      reason: exhaustedFamily ? `${exhaustedFamily.label} looks exhausted.` : "Small tweaks are useful after the portfolio has enough novelty.",
+      nextActionHint: "Limit near-neighbor tweaks to one lane when recent runs cluster together.",
+    },
+    {
+      id: "constraint-removal",
+      label: "Constraint removal",
+      priority: recentFailures >= 2 ? "high" : "medium",
+      status: recentFailures ? "ready" : "watch",
+      reason: recentFailures ? `${recentFailures} recent failed or discarded run(s) need a different blocker hypothesis.` : "Use this lane when failures share a cause.",
+      nextActionHint: "Change the constraint, benchmark slice, or validation guard before retesting the same idea.",
+    },
+    {
+      id: "measurement-quality",
+      label: "Measurement quality",
+      priority: missingAsi || checksPolicy === "manual" ? "high" : "low",
+      status: missingAsi || checksPolicy === "manual" ? "ready" : "watch",
+      reason: missingAsi
+        ? `${missingAsi} run(s) are missing ASI memory.`
+        : checksPolicy === "manual"
+          ? "Checks are manual, so keep decisions need extra review evidence."
+          : "Keep benchmark noise and ASI quality from hiding real wins.",
+      nextActionHint: "Add clearer ASI or tighten the benchmark before spending more iterations.",
+    },
+    {
+      id: "promotion-policy",
+      label: "Promotion policy",
+      priority: keepPolicy === "primary-or-risk-reduction" ? "medium" : "low",
+      status: "watch",
+      reason: `Keep policy is ${keepPolicy}; use this lane when a run reduces risk without moving the primary metric.`,
+      nextActionHint: "Only promote non-primary wins when ASI evidence names the reduced risk.",
+    },
+    ...aggregateLanes,
+    {
+      id: "wild-card",
+      label: "Wild-card eureka",
+      priority: plateau.detected || runs.length >= 8 ? "high" : "medium",
+      status: "ready",
+      reason: "Always reserve one slot for a non-local solution that could change the search space.",
+      nextActionHint: "Try the idea that would make the current lane obsolete if it worked.",
+    },
+  ];
+}
+
+function bestIncumbentFamily(families, direction) {
+  let best = null;
+  for (const family of families) {
+    if (!family.kept || !family.bestKeptRun) continue;
+    const metric = Number(family.bestKeptRun.metric);
+    const bestMetric = Number(best?.bestKeptRun?.metric);
+    if (!best || (Number.isFinite(metric) && (!Number.isFinite(bestMetric) || isBetter(metric, bestMetric, direction)))) {
+      best = family;
+    }
+  }
+  return best;
+}
+
+function familyForRun(run) {
+  const asi = run.asi || {};
+  const explicit = asi.family || asi.family_key || asi.strategy || asi.lane;
+  const settings = asi.settings || asi.params || asi.parameters || asi.config;
+  const settingsKey = settingsSignature(settings);
+  const source = explicit || settingsKey || asi.hypothesis || run.description || `run ${run.run}`;
+  return {
+    key: canonicalFamilyKey(source),
+    label: familyLabel(explicit || asi.hypothesis || run.description || settingsKey || `Run ${run.run}`),
+  };
+}
+
+function settingsSignature(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "";
+  const entries = Object.entries(value)
+    .filter(([key]) => !FAMILY_IGNORE_KEYS.has(String(key).toLowerCase()))
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (!entries.length) return "";
+  return entries.map(([key, item]) => `${key}:${typeof item === "object" ? JSON.stringify(item) : String(item)}`).join("|");
+}
+
+function familyLabel(value) {
+  const text = String(value || "Unlabeled family")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > 44 ? `${text.slice(0, 41)}...` : text;
+}
+
+function canonicalFamilyKey(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/\b(repeat|attempt|trial|seed|run)\s*[:=-]?\s*\d+\b/g, "$1 *")
+    .replace(/\br\s*\d+\b/g, "r *")
+    .replace(/\b\d+(?:\.\d+)?(?:k|m|b|ms|s|mb|gb|dim|d)?\b/g, "#")
+    .replace(/\b(keep|discard|baseline|regression|quality|new|leader|full|query|try|use|test)\b/g, " ")
+    .replace(/[^a-z0-9#*]+/g, " ")
+    .trim()
+    .slice(0, 96) || "unlabeled";
+}
+
+function compactFamilyRun(run) {
+  return {
+    run: run.run,
+    metric: run.metric,
+    status: run.status,
+    description: run.description || "",
+    nextActionHint: run.asi?.next_action_hint || run.asi?.nextAction || run.asi?.next_action || "",
+  };
+}
+
+function bestRun(runs, direction) {
+  let best = null;
+  for (const run of runs) {
+    const metric = Number(run.metric);
+    if (!Number.isFinite(metric)) continue;
+    if (!best || isBetter(metric, Number(best.metric), direction)) best = run;
+  }
+  return best;
+}
+
+function isBetter(value, current, direction) {
+  return direction === "higher" ? value > current : value < current;
 }
 
 function normalizeHypothesis(value) {

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "type": "module",
   "private": true,
   "description": "Codex plugin for autonomous benchmark and optimization loops.",
@@ -17,6 +17,6 @@
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",
   "scripts": {
     "test": "node --test tests/*.test.mjs",
-    "check": "node --check scripts/autoresearch.mjs && node --check scripts/autoresearch-mcp.mjs && node --check scripts/finalize-autoresearch.mjs && node --check scripts/perfection-benchmark.mjs && node scripts/perfection-benchmark.mjs --fail-on-gap && node scripts/autoresearch.mjs --help && node scripts/finalize-autoresearch.mjs --help && npm test"
+    "check": "node scripts/check.mjs"
   }
 }

--- a/plugins/codex-autoresearch/scripts/autoresearch-mcp.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch-mcp.mjs
@@ -9,7 +9,7 @@ const TOOL_TIMEOUT_SECONDS = 15 * 60;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = path.resolve(SCRIPT_DIR, "..");
 const CLI_SCRIPT = path.join(SCRIPT_DIR, "autoresearch.mjs");
-const VERSION = "0.1.13";
+const VERSION = "0.2.0";
 
 let buffer = Buffer.alloc(0);
 

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -273,10 +273,12 @@ async function setupPlan(args) {
     recommended = await recommendRecipe(workDir);
   }
   const state = currentState(workDir);
+  const hasDefaultBenchmarkCommand = await defaultBenchmarkCommandExists(workDir);
+  const hasBenchmarkInput = Boolean(args.benchmark_command || args.benchmarkCommand);
   const missing = [];
   if (!args.name && !state.config.name && !recommended) missing.push("name");
   if (!args.metric_name && !args.metricName && !state.config.metricName && !recommended) missing.push("metric_name");
-  if (!args.benchmark_command && !args.benchmarkCommand && !(await pathExists(path.join(workDir, "autoresearch.ps1"))) && !(await pathExists(path.join(workDir, "autoresearch.sh")))) {
+  if (state.current.length === 0 && !hasBenchmarkInput && !hasDefaultBenchmarkCommand) {
     missing.push("benchmark_command");
   }
   const planArgs = await withRecipeDefaults({
@@ -314,6 +316,7 @@ async function setupPlan(args) {
     currentMetric: state.config.metricName,
     recommendedRecipe: recommended,
     missing,
+    defaultBenchmarkCommandReady: hasDefaultBenchmarkCommand,
     nextCommand: command,
     guideCommand,
     baselineCommand,
@@ -336,16 +339,26 @@ async function guidedSetup(args) {
   const state = publicState({ cwd: workDir });
   const doctor = await doctorSession({ cwd: workDir, checkBenchmark: false });
   const lastRun = await readLastRunPacket(workDir).catch(() => null);
+  const lastRunFreshness = lastRun ? lastRunPacketFreshness(workDir, lastRun) : null;
+  const lastRunLogStatus = lastRun
+    ? (lastRun.decision?.safeSuggestedStatus
+        || lastRun.decision?.suggestedStatus
+        || (lastRun.decision?.allowedStatuses?.length === 1 ? lastRun.decision.allowedStatuses[0] : "discard"))
+    : "";
+  const replaceLastRunCommand = lastRun ? replacementNextCommandFromLastRun(workDir, lastRun, setup.defaultBenchmarkCommandReady) : "";
   const dashboardCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} export --cwd ${shellQuote(workDir)}`;
   const baselineCommand = setup.baselineCommand;
   const logCommand = lastRun
-    ? `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} log --cwd ${shellQuote(workDir)} --from-last --status ${shellQuote(lastRun.decision?.suggestedStatus || "keep")} --description ${shellQuote("Describe the last packet")}`
+    ? `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} log --cwd ${shellQuote(workDir)} --from-last --status ${shellQuote(lastRunLogStatus)} --description ${shellQuote("Describe the last packet")}`
     : setup.guidedFlow.find((step) => step.step === "log")?.command;
   let stage = "ready";
   let nextAction = "Run the next measured packet.";
-  if (setup.missing.length) {
+  if (setup.missing.length && state.runs === 0) {
     stage = "needs-setup";
     nextAction = "Create or complete the session setup before running a baseline.";
+  } else if (lastRun && lastRunFreshness?.fresh === false) {
+    stage = "stale-last-run";
+    nextAction = lastRunFreshness.reason;
   } else if (lastRun) {
     stage = "needs-log-decision";
     nextAction = "Log the last packet with an allowed status before starting another run.";
@@ -355,6 +368,9 @@ async function guidedSetup(args) {
   } else if (state.limit.limitReached) {
     stage = "limit-reached";
     nextAction = "Export the dashboard or extend the iteration limit.";
+  } else if (!setup.defaultBenchmarkCommandReady) {
+    stage = "needs-benchmark-command";
+    nextAction = "Add autoresearch.ps1 or autoresearch.sh, or run setup with a benchmark command before using next.";
   }
   return {
     ok: doctor.issues.length === 0,
@@ -372,19 +388,53 @@ async function guidedSetup(args) {
       ok: lastRun.ok,
       allowedStatuses: lastRun.decision?.allowedStatuses || [],
       suggestedStatus: lastRun.decision?.suggestedStatus || "",
+      rawSuggestedStatus: lastRun.decision?.rawSuggestedStatus || "",
+      safeSuggestedStatus: lastRun.decision?.safeSuggestedStatus || lastRunLogStatus,
+      statusGuidance: lastRun.decision?.statusGuidance || "",
+      diversityGuidance: lastRun.decision?.diversityGuidance || state.memory?.diversityGuidance || null,
+      lanePortfolio: lastRun.decision?.lanePortfolio || state.memory?.lanePortfolio || [],
       metric: lastRun.decision?.metric ?? null,
       path: lastRun.lastRunPath || "",
+      freshness: lastRunFreshness,
     } : null,
     commands: {
       setup: setup.nextCommand,
       doctor: setup.guidedFlow.find((step) => step.step === "doctor")?.command,
       baseline: baselineCommand,
       logLast: logCommand,
+      replaceLast: replaceLastRunCommand,
       dashboard: dashboardCommand,
     },
     settings: dashboardSettings(config),
+    diversityGuidance: state.memory?.diversityGuidance || null,
+    lanePortfolio: state.memory?.lanePortfolio || [],
     nextAction,
   };
+}
+
+function replacementNextCommandFromLastRun(workDir, packet, defaultBenchmarkCommandReady) {
+  const parts = [
+    "node",
+    shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs")),
+    "next",
+    "--cwd",
+    shellQuote(workDir),
+  ];
+  const command = packet?.run?.command;
+  if (command) {
+    parts.push("--command", shellQuote(command));
+  } else if (!defaultBenchmarkCommandReady) {
+    return "";
+  }
+  const checksPolicy = packet?.run?.checksPolicy;
+  if (CHECKS_POLICIES.has(checksPolicy)) {
+    parts.push("--checks-policy", shellQuote(checksPolicy));
+  }
+  const checksCommand = packet?.run?.checks?.command;
+  if (checksCommand) {
+    parts.push("--checks-command", shellQuote(checksCommand));
+  }
+  return parts.join(" ");
 }
 
 async function recipeCommand(subcommand, args) {
@@ -900,6 +950,10 @@ async function defaultBenchmarkCommand(workDir) {
   throw new Error("No command provided; expected autoresearch.ps1 or autoresearch.sh in the work directory.");
 }
 
+async function defaultBenchmarkCommandExists(workDir) {
+  return (await pathExists(path.join(workDir, "autoresearch.ps1"))) || (await pathExists(path.join(workDir, "autoresearch.sh")));
+}
+
 async function defaultChecksCommand(workDir) {
   if (await pathExists(path.join(workDir, "autoresearch.checks.ps1"))) {
     return "powershell -NoProfile -ExecutionPolicy Bypass -File ./autoresearch.checks.ps1";
@@ -1365,7 +1419,11 @@ async function dashboardViewModel(workDir, config) {
       nextAction: "Fix finalization preview errors before relying on review readiness.",
     })),
     recipes: listBuiltInRecipes().map((recipe) => ({ id: recipe.id, title: recipe.title, tags: recipe.tags || [] })),
-    experimentMemory: buildExperimentMemory({ runs: state.current, direction: state.config.bestDirection }),
+    experimentMemory: buildExperimentMemory({
+      runs: state.current,
+      direction: state.config.bestDirection,
+      settings: dashboardSettings(config),
+    }),
     drift: await buildDriftReport({ pluginRoot: PLUGIN_ROOT }).catch((error) => ({ ok: false, warnings: [error.message] })),
   });
 }
@@ -1431,6 +1489,7 @@ async function runExperiment(args) {
   const primaryPresent = finiteMetric(primary) != null;
   const primaryMetric = finiteMetric(primary);
   const improvesPrimary = primaryMetric != null && (state.best == null || isBetter(primaryMetric, state.best, state.config.bestDirection));
+  const isBaseline = state.current.filter((run) => finiteMetric(run.metric) != null).length === 0;
   let checks = null;
   const checksCommand = args.checks_command || args.checksCommand || await defaultChecksCommand(workDir);
   const checksPolicy = checksPolicyFromArgs(args, config);
@@ -1446,6 +1505,18 @@ async function runExperiment(args) {
   const passed = benchmarkPassed && primaryPresent && checksPassedOrSkipped;
   const failedStatus = benchmarkPassed && primaryPresent ? "checks_failed" : "crash";
   const allowedStatuses = passed ? ["keep", "discard"] : [failedStatus];
+  const suggestedStatus = passed
+    ? (isBaseline || improvesPrimary ? "keep" : "discard")
+    : failedStatus;
+  const checksWereVerified = checksPassed === true;
+  const safeSuggestedStatus = passed
+    ? (suggestedStatus === "keep" && !isBaseline && !checksWereVerified ? "discard" : suggestedStatus)
+    : failedStatus;
+  const statusGuidance = passed
+    ? (safeSuggestedStatus === "keep"
+        ? "Safe to consider keep because this is a baseline or a checked improvement; still review ASI before logging."
+        : "Default to discard unless the operator can justify keep with ASI and verification evidence.")
+    : `Only ${failedStatus} is allowed because the benchmark or checks failed.`;
   return {
     ok: passed,
     workDir,
@@ -1474,6 +1545,9 @@ async function runExperiment(args) {
       metric: primary,
       metrics: Object.fromEntries(Object.entries(parsedMetrics).filter(([key]) => key !== state.config.metricName)),
       status: passed ? null : failedStatus,
+      suggestedStatus,
+      safeSuggestedStatus,
+      statusGuidance,
       needsDecision: passed,
       allowedStatuses,
     },
@@ -1484,9 +1558,12 @@ async function runExperiment(args) {
 async function logExperiment(args) {
   const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
   const lastPacket = boolOption(args.from_last ?? args.fromLast, false) ? await readLastRunPacket(workDir) : null;
+  if (lastPacket) assertFreshLastRunPacket(workDir, lastPacket);
   const metric = numberOption(args.metric ?? lastPacket?.decision?.metric, null);
   if (metric == null) throw new Error("metric is required");
-  const status = args.status || lastPacket?.decision?.suggestedStatus;
+  const packetAllowed = Array.isArray(lastPacket?.decision?.allowedStatuses) ? lastPacket.decision.allowedStatuses : [];
+  const status = args.status || (packetAllowed.length === 1 ? lastPacket?.decision?.suggestedStatus : null);
+  if (!status) throw new Error("status is required; choose keep or discard explicitly for successful packets.");
   if (!STATUS_VALUES.has(status)) throw new Error(`status must be one of ${[...STATUS_VALUES].join(", ")}`);
   if (lastPacket?.decision && Array.isArray(lastPacket.decision.allowedStatuses) && !lastPacket.decision.allowedStatuses.includes(status)) {
     throw new Error(`Cannot log status '${status}' for the last run. Allowed statuses: ${lastPacket.decision.allowedStatuses.join(", ")}.`);
@@ -1557,6 +1634,7 @@ async function logExperiment(args) {
   if (asi && Object.keys(asi).length > 0) experiment.asi = asi;
   experiment.confidence = computeConfidence([...currentRuns, experiment], stateBefore.config.bestDirection);
   appendJsonl(workDir, experiment);
+  if (lastPacket) await deleteLastRunPacket(workDir);
 
   const stateAfter = currentState(workDir);
   const limit = iterationLimitInfo(stateAfter, config);
@@ -1571,6 +1649,7 @@ async function logExperiment(args) {
     limit,
     git: gitMessage,
     revert: revertMessage,
+    lastRunCleared: Boolean(lastPacket),
     continuation: loopContinuation(workDir, stateAfter, config, "logged"),
   };
 }
@@ -1660,10 +1739,87 @@ async function readLastRunPacket(workDir) {
   return JSON.parse(fs.readFileSync(readablePath, "utf8"));
 }
 
+function assertFreshLastRunPacket(workDir, packet) {
+  const freshness = lastRunPacketFreshness(workDir, packet);
+  if (!freshness.fresh) throw new Error(freshness.reason);
+}
+
+function lastRunPacketFreshness(workDir, packet) {
+  const expectedNextRun = Number(packet.history?.nextRun);
+  const expectedSegment = Number(packet.history?.segment);
+  if (!Number.isFinite(expectedNextRun)) {
+    return {
+      fresh: false,
+      reason: "Last-run packet is missing history metadata. Run next again before logging.",
+    };
+  }
+  const state = currentState(workDir);
+  const actualNextRun = state.results.length + 1;
+  if (Number.isFinite(expectedSegment) && state.segment !== expectedSegment) {
+    return {
+      fresh: false,
+      expectedSegment,
+      actualSegment: state.segment,
+      reason: `Last-run packet is stale: expected segment #${expectedSegment}, but current segment is #${state.segment}. Run next again before logging.`,
+    };
+  }
+  const expectedConfig = packet.history?.config;
+  if (!expectedConfig || typeof expectedConfig !== "object") {
+    return {
+      fresh: false,
+      reason: "Last-run packet is missing config metadata. Run next again before logging.",
+    };
+  }
+  const actualConfig = lastRunConfigSnapshot(state.config);
+  if (JSON.stringify(expectedConfig) !== JSON.stringify(actualConfig)) {
+    return {
+      fresh: false,
+      expectedConfig,
+      actualConfig,
+      reason: "Last-run packet is stale: session config changed since the packet was created. Run next again before logging.",
+    };
+  }
+  if (actualNextRun !== expectedNextRun) {
+    return {
+      fresh: false,
+      expectedNextRun,
+      actualNextRun,
+      reason: `Last-run packet is stale: expected next log run #${expectedNextRun}, but current history would log #${actualNextRun}. Run next again before logging.`,
+    };
+  }
+  return {
+    fresh: true,
+    expectedNextRun,
+    actualNextRun,
+    reason: "Last-run packet matches the current ledger.",
+  };
+}
+
+function lastRunConfigSnapshot(config = {}) {
+  return {
+    name: config.name || null,
+    metricName: config.metricName || "metric",
+    metricUnit: config.metricUnit ?? "",
+    bestDirection: config.bestDirection === "higher" ? "higher" : "lower",
+  };
+}
+
+async function deleteLastRunPacket(workDir) {
+  const filePath = await resolveLastRunPath(workDir);
+  const legacyPath = path.join(workDir, "autoresearch.last-run.json");
+  for (const target of new Set([filePath, legacyPath])) {
+    await fsp.rm(target, { force: true }).catch(() => {});
+  }
+}
+
 function publicState(args) {
   const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
   const state = currentState(workDir);
-  const memory = buildExperimentMemory({ runs: state.current, direction: state.config.bestDirection });
+  const memory = buildExperimentMemory({
+    runs: state.current,
+    direction: state.config.bestDirection,
+    settings: dashboardSettings(config),
+  });
   const statusCounts = Object.fromEntries([...STATUS_VALUES].map((status) => [
     status,
     state.current.filter((run) => run.status === status).length,
@@ -1717,6 +1873,12 @@ function loopContinuation(workDir, state, config = {}, stage = "state", options 
   const mode = config.autonomyMode || "guarded";
   const limit = iterationLimitInfo(state, config);
   const commands = continuationCommands(workDir);
+  const memory = buildExperimentMemory({
+    runs: state.current,
+    direction: state.config.bestDirection,
+    settings: dashboardSettings(config),
+  });
+  const topLane = memory.diversityGuidance || memory.lanePortfolio?.[0];
   const stopConditions = [
     "user interrupts or turns the loop off",
     "iteration limit is reached",
@@ -1778,11 +1940,15 @@ function loopContinuation(workDir, state, config = {}, stage = "state", options 
   return {
     mode,
     stage,
+    plateau: memory.plateau,
+    lanePortfolio: memory.lanePortfolio,
     shouldContinue: true,
     shouldAskUser: false,
     forbidFinalAnswer: ownerAutonomous,
     nextAction: ownerAutonomous
-      ? "Keep the floor: choose the next hypothesis from ASI/autoresearch.ideas.md, edit the scoped files, run next_experiment, and log the result without asking the user to restart the create skill."
+      ? (memory.plateau?.detected
+          ? `Keep the floor: run the ${topLane?.label || "distant scout"} lane next because the current search is plateauing.`
+          : "Keep the floor: choose the next hypothesis from ASI/autoresearch.ideas.md, edit the scoped files, run next_experiment, and log the result without asking the user to restart the create skill.")
       : "Continue the active loop when the current user request asks for iteration; otherwise report the state and next command.",
     commands,
     stopConditions,
@@ -1915,21 +2081,38 @@ async function nextExperiment(args) {
     };
   }
   const run = await runExperiment(args);
+  const stateBeforeLog = currentState(run.workDir);
+  const memory = buildExperimentMemory({
+    runs: stateBeforeLog.current,
+    direction: stateBeforeLog.config.bestDirection,
+    settings: dashboardSettings(config),
+  });
   const decision = {
     metric: run.parsedPrimary,
     metrics: run.logHint.metrics,
     allowedStatuses: run.logHint.allowedStatuses,
-    suggestedStatus: run.logHint.status,
+    suggestedStatus: run.logHint.safeSuggestedStatus ?? run.logHint.suggestedStatus ?? run.logHint.status,
+    rawSuggestedStatus: run.logHint.suggestedStatus ?? run.logHint.status,
+    safeSuggestedStatus: run.logHint.safeSuggestedStatus ?? run.logHint.suggestedStatus ?? run.logHint.status,
+    statusGuidance: run.logHint.statusGuidance || "",
+    diversityGuidance: memory.diversityGuidance,
+    lanePortfolio: memory.lanePortfolio,
+    plateau: memory.plateau,
+    novelty: memory.novelty,
     needsDecision: run.logHint.needsDecision,
     asiTemplate: run.ok
       ? {
           hypothesis: "",
           evidence: `${run.metricName}=${run.parsedPrimary}${run.metricUnit || ""}`,
+          lane: memory.diversityGuidance?.id || "",
+          family: "",
           next_action_hint: "",
         }
       : {
           evidence: run.metricError || `Benchmark exit ${run.exitCode ?? "none"}`,
           rollback_reason: "",
+          lane: memory.diversityGuidance?.id || "",
+          family: "",
           next_action_hint: "",
         },
   };
@@ -1938,11 +2121,18 @@ async function nextExperiment(args) {
     ok: doctor.ok && run.ok,
     workDir: run.workDir,
     lastRunPath: lastRunFile,
+    history: {
+      segment: stateBeforeLog.segment,
+      config: lastRunConfigSnapshot(stateBeforeLog.config),
+      currentRuns: stateBeforeLog.current.length,
+      totalRuns: stateBeforeLog.results.length,
+      nextRun: stateBeforeLog.results.length + 1,
+    },
     doctor,
     run,
     decision,
     nextAction: run.ok
-      ? "Log this run with status keep or discard, include ASI, then continue with the next hypothesis."
+      ? `Log this run as ${decision.safeSuggestedStatus || "keep/discard"} unless review evidence says otherwise, include ASI, then continue with the next ${memory.diversityGuidance?.label || "diversity"} lane.`
       : `Log this run as ${run.logHint.status} with rollback ASI before trying another change.`,
     continuation: loopContinuation(workDir, currentState(workDir), config, "needs-log-decision", {
       requiredStatus: run.logHint.status,
@@ -2028,7 +2218,7 @@ async function handleMcpMessage(message) {
       result: {
         protocolVersion: "2024-11-05",
         capabilities: { tools: {} },
-        serverInfo: { name: "codex-autoresearch", version: "0.1.13" },
+        serverInfo: { name: "codex-autoresearch", version: "0.2.0" },
       },
     });
     return;

--- a/plugins/codex-autoresearch/scripts/check.mjs
+++ b/plugins/codex-autoresearch/scripts/check.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const node = process.execPath;
+
+const syntaxChecks = [
+  ["syntax:autoresearch", node, ["--check", "scripts/autoresearch.mjs"]],
+  ["syntax:mcp", node, ["--check", "scripts/autoresearch-mcp.mjs"]],
+  ["syntax:finalize", node, ["--check", "scripts/finalize-autoresearch.mjs"]],
+  ["syntax:benchmark", node, ["--check", "scripts/perfection-benchmark.mjs"]],
+  ["syntax:check", node, ["--check", "scripts/check.mjs"]],
+];
+
+const productChecks = [
+  ["quality-gap", node, ["scripts/perfection-benchmark.mjs", "--fail-on-gap"]],
+  ["help:autoresearch", node, ["scripts/autoresearch.mjs", "--help"]],
+  ["help:finalize", node, ["scripts/finalize-autoresearch.mjs", "--help"]],
+  ["tests", node, ["--test", "tests/*.test.mjs"]],
+];
+
+const ok = await runPhase("syntax", syntaxChecks)
+  && await runPhase("product", productChecks);
+
+process.exit(ok ? 0 : 1);
+
+async function runPhase(name, commands) {
+  console.log(`\n== ${name} ==`);
+  const results = await Promise.all(commands.map(runCommand));
+  for (const result of results) {
+    const marker = result.code === 0 ? "ok" : "fail";
+    console.log(`${marker} ${result.label}`);
+    if (result.code !== 0 || process.env.CODEX_AUTORESEARCH_CHECK_VERBOSE === "1") {
+      const output = `${result.stdout}${result.stderr}`.trim();
+      if (output) console.log(indent(output));
+    }
+  }
+  return results.every((result) => result.code === 0);
+}
+
+function runCommand([label, command, args]) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: ROOT,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (error) => {
+      resolve({ label, code: -1, stdout, stderr: `${stderr}${error.message}\n` });
+    });
+    child.on("close", (code) => {
+      resolve({ label, code, stdout, stderr });
+    });
+  });
+}
+
+function indent(text) {
+  return text.split(/\r?\n/).map((line) => `  ${line}`).join("\n");
+}

--- a/plugins/codex-autoresearch/scripts/perfection-benchmark.mjs
+++ b/plugins/codex-autoresearch/scripts/perfection-benchmark.mjs
@@ -315,13 +315,16 @@ const checks = [
   },
   {
     id: "quality-gate-in-checks",
-    file: "package.json",
+    file: "package.json, scripts/check.mjs",
     description: "npm run check fails when the plugin's own quality_gap benchmark regresses.",
     run: async () => {
       const pkg = await readJson("package.json");
-      return String(pkg.scripts?.check || "").includes("perfection-benchmark.mjs --fail-on-gap")
+      const checkScript = await readText("scripts/check.mjs");
+      return String(pkg.scripts?.check || "").includes("scripts/check.mjs")
+        && checkScript.includes("perfection-benchmark.mjs")
+        && checkScript.includes("--fail-on-gap")
         ? pass()
-        : fail("package check does not run perfection-benchmark with --fail-on-gap.");
+        : fail("package check does not run scripts/check.mjs with perfection-benchmark --fail-on-gap.");
     },
   },
   {
@@ -367,6 +370,41 @@ const checks = [
       return template.includes('<link rel="icon" href="data:image/svg+xml,')
         ? pass()
         : fail("Missing embedded data-URL favicon.");
+    },
+  },
+  {
+    id: "dashboard-next-action-and-portfolio",
+    file: "assets/template.html, lib/dashboard-view-model.mjs",
+    description: "The dashboard exposes a next-best-action rail and experiment portfolio guidance.",
+    run: async () => {
+      const template = await readText("assets/template.html");
+      const viewModel = await readText("lib/dashboard-view-model.mjs");
+      return includesAll(`${template}\n${viewModel}`, [
+        "Next best action",
+        "nextBestAction",
+        "Experiment portfolio",
+        "lanePortfolio",
+        "plateau",
+      ])
+        ? pass()
+        : fail("Dashboard is missing next-best-action or portfolio/plateau surfaces.");
+    },
+  },
+  {
+    id: "last-run-packet-safety",
+    file: "scripts/autoresearch.mjs, tests/autoresearch-cli.test.mjs",
+    description: "Last-run packets are cleared after logging and stale packets are rejected.",
+    run: async () => {
+      const cli = await readText("scripts/autoresearch.mjs");
+      const tests = await readText("tests/autoresearch-cli.test.mjs");
+      return includesAll(`${cli}\n${tests}`, [
+        "deleteLastRunPacket",
+        "assertFreshLastRunPacket",
+        "status is required; choose keep or discard explicitly",
+        "stale last-run packets are rejected",
+      ])
+        ? pass()
+        : fail("Last-run packet safety behavior is not implemented and tested.");
     },
   },
   {

--- a/plugins/codex-autoresearch/skills/autoresearch-create/SKILL.md
+++ b/plugins/codex-autoresearch/skills/autoresearch-create/SKILL.md
@@ -20,7 +20,7 @@ Use this skill to run a measured optimization loop:
 - `autoresearch.checks.sh` or `autoresearch.checks.ps1`: optional correctness checks.
 - `autoresearch.jsonl`: append-only run log.
 - `autoresearch-dashboard.html`: exported operator dashboard; refresh it when the workflow starts, resumes, and after meaningful logged runs.
-- last-run packet: latest `next` packet for fast keep/discard logging; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json`.
+- last-run packet: latest `next` packet for fast keep/discard logging; stored in Git metadata when possible and otherwise as `autoresearch.last-run.json`, then cleared after a successful `log --from-last`.
 - `autoresearch.ideas.md`: optional backlog for promising ideas not tried yet.
 
 Starter templates live in the plugin `assets/` directory:
@@ -103,7 +103,7 @@ Then log the result every time with MCP `log_experiment` or:
 node scripts/autoresearch.mjs log --cwd /absolute/project/path --metric 12.3 --status keep --description "Short description" --metrics "{}" --asi "{\"hypothesis\":\"what changed\"}"
 ```
 
-After `next`, prefer `--from-last` so the metric, secondary metrics, and ASI template are reused from the last-run packet:
+After `next`, prefer `--from-last` so the metric, secondary metrics, and ASI template are reused from the last-run packet. Successful packets still require an explicit `--status keep` or `--status discard`; consumed packets are cleared, and stale packets are rejected after history advances:
 
 ```bash
 node scripts/autoresearch.mjs log --cwd /absolute/project/path --from-last --status keep --description "Short description"

--- a/plugins/codex-autoresearch/skills/autoresearch-dashboard/SKILL.md
+++ b/plugins/codex-autoresearch/skills/autoresearch-dashboard/SKILL.md
@@ -5,7 +5,7 @@ description: Export and inspect a Codex autoresearch dashboard from autoresearch
 
 # Autoresearch Dashboard
 
-Use this skill to turn `autoresearch.jsonl` into an HTML dashboard with embedded snapshot data, optional live refresh from disk, copyable operator commands, setup/readiness/gap/finalization panels, and safe local actions when served through live mode.
+Use this skill to turn `autoresearch.jsonl` into an HTML dashboard with embedded snapshot data, a next-best-action rail, experiment-family and lane-portfolio panels, optional live refresh from disk, copyable operator commands, setup/readiness/gap/finalization panels, and safe local actions when served through live mode.
 
 ## Workflow
 
@@ -33,6 +33,7 @@ Use this review readout pattern when summarizing:
 - Recent regressions, crashes, or checks failures.
 - Confidence caveat: explain whether the signal is strong or still noisy.
 - Top ASI next action, especially `next_action_hint`.
+- Plateau and lane-portfolio guidance when recent runs cluster around similar hypotheses.
 - Whether the iteration limit is reached and whether finalization looks timely.
 - Which segment is active when multiple segments exist.
 - Whether the dashboard says the branch is ready to finalize.
@@ -41,12 +42,12 @@ Use this review readout pattern when summarizing:
 
 The dashboard can be opened directly from disk and does not require a dev server. It embeds the current JSONL snapshot, then the `Refresh` and `Live on` controls try to refetch `autoresearch.jsonl` next to the HTML file. If the browser blocks local `fetch` for `file://`, the embedded snapshot remains usable and the status strip reports that live refresh is unavailable.
 
-The command panel includes copyable commands for setup-plan, doctor, next run, keep/discard last packet, gap candidates, finalization preview, dashboard export, and iteration-limit extension. Use those commands as operator shortcuts, not as a substitute for reading the current run output before keeping a change.
+The next-best-action rail should be read first. The command panel includes copyable commands for setup-plan, doctor, next run, keep/discard last packet, gap candidates, finalization preview, dashboard export, and iteration-limit extension. Use those commands as operator shortcuts, not as a substitute for reading the current run output before keeping a change.
 
-The live action panel calls local `serve` endpoints only. Safe actions include doctor, setup-plan, recipe listing, gap-candidates preview, finalize-preview, and export; branch creation stays behind `/autoresearch-finalize`.
+The live action panel calls local `serve` endpoints only. Safe actions include doctor, setup-plan, recipe listing, gap-candidates preview, finalize-preview, and export; keep/discard logging and branch creation stay outside the dashboard.
 
 ## Notes
 
-The operator readout, setup/gap/finalization cockpit, segment selector, command panel, live status strip, and ready-to-finalize card are designed to make exported dashboards useful in PRs and status updates, not just local charts.
+The next-best-action rail, operator readout, setup/gap/finalization cockpit, experiment portfolio, segment selector, command panel, live status strip, and ready-to-finalize card are designed to make exported dashboards useful in PRs and status updates, not just local charts.
 
 If no `autoresearch.jsonl` exists, say that there is no session to export yet and point the user to `autoresearch-create`.

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.mjs
@@ -315,9 +315,15 @@ test("next writes a reusable last-run packet and log can consume it", async () =
     const packet = JSON.parse(next.stdout);
     assert.equal(packet.decision.metric, 3);
     assert.equal(packet.decision.metrics.cache_hits, 8);
+    assert.equal(packet.decision.safeSuggestedStatus, "keep");
+    assert.match(packet.decision.statusGuidance, /Safe to consider keep/);
+    assert.ok(packet.decision.diversityGuidance);
+    assert.equal(packet.decision.asiTemplate.lane, packet.decision.diversityGuidance.id);
 
     const lastRun = JSON.parse(await readFile(packet.lastRunPath, "utf8"));
     assert.equal(lastRun.decision.metric, 3);
+    assert.equal(lastRun.history.nextRun, 1);
+    assert.equal(lastRun.history.config.metricName, "seconds");
 
     const log = await runCli([
       "log",
@@ -330,6 +336,90 @@ test("next writes a reusable last-run packet and log can consume it", async () =
     const payload = JSON.parse(log.stdout);
     assert.equal(payload.experiment.metric, 3);
     assert.equal(payload.experiment.metrics.cache_hits, 8);
+    assert.equal(payload.lastRunCleared, true);
+    await assert.rejects(access(packet.lastRunPath));
+
+    const duplicate = await runCli([
+      "log",
+      "--cwd", dir,
+      "--from-last",
+      "--status", "discard",
+      "--description", "Duplicate cached packet",
+    ]);
+    assert.notEqual(duplicate.code, 0);
+    assert.match(duplicate.stderr, /No last-run packet/);
+  });
+});
+
+test("successful last-run packets require explicit status and suggest discard for regressions", async () => {
+  await withTempDir("last-run-suggest-discard", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "suggest discard", "--metric-name", "seconds", "--direction", "lower"]);
+    await runCli(["log", "--cwd", dir, "--metric", "3", "--status", "keep", "--description", "Baseline"]);
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=4')"`;
+
+    const next = await runCli(["next", "--cwd", dir, "--command", command, "--checks-policy", "manual"]);
+    assert.equal(next.code, 0, next.stderr);
+    const packet = JSON.parse(next.stdout);
+    assert.equal(packet.decision.suggestedStatus, "discard");
+    assert.deepEqual(packet.decision.allowedStatuses, ["keep", "discard"]);
+
+    const missingStatus = await runCli(["log", "--cwd", dir, "--from-last", "--description", "No status"]);
+    assert.notEqual(missingStatus.code, 0);
+    assert.match(missingStatus.stderr, /status is required/);
+
+    const discard = await runCli([
+      "log",
+      "--cwd", dir,
+      "--from-last",
+      "--status", "discard",
+      "--description", "Discard slower run",
+    ]);
+    assert.equal(discard.code, 0, discard.stderr);
+    assert.equal(JSON.parse(discard.stdout).experiment.status, "discard");
+  });
+});
+
+test("stale last-run packets are rejected when history advances", async () => {
+  await withTempDir("stale-last-run", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "stale packet", "--metric-name", "seconds"]);
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3')"`;
+    const next = await runCli(["next", "--cwd", dir, "--command", command, "--checks-policy", "manual"]);
+    assert.equal(next.code, 0, next.stderr);
+
+    const directLog = await runCli(["log", "--cwd", dir, "--metric", "2", "--status", "keep", "--description", "Manual run"]);
+    assert.equal(directLog.code, 0, directLog.stderr);
+
+    const stale = await runCli([
+      "log",
+      "--cwd", dir,
+      "--from-last",
+      "--status", "keep",
+      "--description", "Old packet",
+    ]);
+    assert.notEqual(stale.code, 0);
+    assert.match(stale.stderr, /Last-run packet is stale/);
+  });
+});
+
+test("last-run packets are rejected when config changes before logging", async () => {
+  await withTempDir("config-stale-last-run", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "first config", "--metric-name", "seconds"]);
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3')"`;
+    const next = await runCli(["next", "--cwd", dir, "--command", command, "--checks-policy", "manual"]);
+    assert.equal(next.code, 0, next.stderr);
+
+    const secondConfig = await runCli(["init", "--cwd", dir, "--name", "second config", "--metric-name", "points", "--direction", "higher"]);
+    assert.equal(secondConfig.code, 0, secondConfig.stderr);
+
+    const stale = await runCli([
+      "log",
+      "--cwd", dir,
+      "--from-last",
+      "--status", "keep",
+      "--description", "Old metric packet",
+    ]);
+    assert.notEqual(stale.code, 0);
+    assert.match(stale.stderr, /session config changed/);
   });
 });
 
@@ -879,6 +969,11 @@ test("next command runs preflight and benchmark as one decision packet", async (
     assert.equal(payload.doctor.ok, true);
     assert.equal(payload.run.parsedPrimary, 2);
     assert.deepEqual(payload.decision.allowedStatuses, ["keep", "discard"]);
+    assert.equal(payload.decision.suggestedStatus, "keep");
+    assert.equal(payload.decision.safeSuggestedStatus, "keep");
+    assert.match(payload.decision.statusGuidance, /Safe to consider keep/);
+    assert.ok(Array.isArray(payload.decision.lanePortfolio));
+    assert.ok(payload.decision.diversityGuidance);
     assert.match(payload.nextAction, /Log this run/);
   });
 });
@@ -892,7 +987,7 @@ test("dashboard renders an operator readout from ASI and failures", async () => 
       "--metric", "10",
       "--status", "keep",
       "--description", "Baseline",
-      "--asi", JSON.stringify({ hypothesis: "baseline", next_action_hint: "try caching" }),
+      "--asi", JSON.stringify({ hypothesis: "baseline", family: "baseline", lane: "incumbent-confirmation", next_action_hint: "try caching" }),
     ]);
     await runCli([
       "log",
@@ -902,6 +997,8 @@ test("dashboard renders an operator readout from ASI and failures", async () => 
       "--description", "Cache package metadata",
       "--asi", JSON.stringify({
         hypothesis: "metadata cache removes repeated filesystem scans",
+        family: "metadata cache",
+        lane: "near-neighbor",
         evidence: "seconds improved from 10 to 7",
         next_action_hint: "measure memory impact next",
       }),
@@ -913,20 +1010,83 @@ test("dashboard renders an operator readout from ASI and failures", async () => 
       "--status", "discard",
       "--description", "Inline all parsing",
       "--asi", JSON.stringify({
+        family: "parser inlining",
+        lane: "near-neighbor",
         rollback_reason: "slower and harder to read",
         next_action_hint: "avoid parser inlining",
       }),
     ]);
 
+    const state = await runCli(["state", "--cwd", dir]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    assert.ok(statePayload.memory.families.length >= 2);
+    assert.equal(typeof statePayload.memory.plateau.detected, "boolean");
+    assert.equal(typeof statePayload.memory.novelty.score, "number");
+    assert.ok(statePayload.memory.lanePortfolio.some((lane) => lane.id === "measurement-quality"));
+    assert.ok(statePayload.memory.diversityGuidance);
+
     const exportResult = await runCli(["export", "--cwd", dir]);
     assert.equal(exportResult.code, 0, exportResult.stderr);
+    const payload = JSON.parse(exportResult.stdout);
     const dashboard = await readFile(path.join(dir, "autoresearch-dashboard.html"), "utf8");
 
     assert.match(dashboard, /Operator readout/);
     assert.match(dashboard, /Best kept change/);
     assert.match(dashboard, /Recent failures/);
     assert.match(dashboard, /Next action/);
+    assert.match(dashboard, /Next best action/);
+    assert.match(dashboard, /Experiment portfolio/);
     assert.match(dashboard, /lower is better/);
+    assert.ok(payload.viewModel.nextBestAction.detail);
+    assert.ok(payload.viewModel.nextBestAction.command || payload.viewModel.nextBestAction.safeAction);
+    assert.equal(payload.viewModel.experimentMemory.latestNextAction, "avoid parser inlining");
+    assert.equal(payload.viewModel.portfolio.families.length > 0, true);
+    assert.equal(payload.viewModel.portfolio.lanes.some((lane) => lane.id === "measurement-quality"), true);
+    assert.equal(typeof payload.viewModel.portfolio.plateau.detected, "boolean");
+  });
+});
+
+test("dashboard does not recommend next when manual metrics have no benchmark command", async () => {
+  await withTempDir("dashboard-manual-no-command", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "manual metrics", "--metric-name", "seconds"]);
+    const log = await runCli(["log", "--cwd", dir, "--metric", "5", "--status", "keep", "--description", "Manual baseline"]);
+    assert.equal(log.code, 0, log.stderr);
+
+    const exportResult = await runCli(["export", "--cwd", dir]);
+    assert.equal(exportResult.code, 0, exportResult.stderr);
+    const payload = JSON.parse(exportResult.stdout);
+
+    assert.equal(payload.viewModel.guidedSetup.stage, "needs-benchmark-command");
+    assert.equal(payload.viewModel.setup.defaultBenchmarkCommandReady, false);
+    assert.equal(payload.viewModel.nextBestAction.kind, "benchmark-command");
+    assert.match(payload.viewModel.nextBestAction.title, /benchmark command/i);
+    assert.doesNotMatch(payload.viewModel.nextBestAction.title, /next measured/i);
+  });
+});
+
+test("dashboard surfaces stale last-run packets before normal next guidance", async () => {
+  await withTempDir("dashboard-stale-last-run", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "stale dashboard", "--metric-name", "seconds"]);
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3')"`;
+    const next = await runCli(["next", "--cwd", dir, "--command", command, "--checks-policy", "manual"]);
+    assert.equal(next.code, 0, next.stderr);
+    const directLog = await runCli(["log", "--cwd", dir, "--metric", "2", "--status", "keep", "--description", "Manual run"]);
+    assert.equal(directLog.code, 0, directLog.stderr);
+
+    const exportResult = await runCli(["export", "--cwd", dir]);
+    assert.equal(exportResult.code, 0, exportResult.stderr);
+    const payload = JSON.parse(exportResult.stdout);
+
+    assert.equal(payload.viewModel.guidedSetup.stage, "stale-last-run");
+    assert.equal(payload.viewModel.lastRun.freshness.fresh, false);
+    assert.equal(payload.viewModel.nextBestAction.kind, "stale-packet");
+    assert.match(payload.viewModel.guidedSetup.commands.replaceLast, /--command/);
+    assert.match(payload.viewModel.guidedSetup.commands.replaceLast, /METRIC seconds=3/);
+    assert.match(payload.viewModel.guidedSetup.commands.replaceLast, /--checks-policy "manual"/);
+    assert.equal(payload.viewModel.nextBestAction.command, payload.viewModel.guidedSetup.commands.replaceLast);
+    assert.match(payload.viewModel.nextBestAction.detail, /Last-run packet is stale/);
+    assert.match(payload.viewModel.readout.nextAction, /Last-run packet is stale/);
   });
 });
 

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.mjs
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.resolve(__dirname, "..");
+const dashboardTemplatePath = path.join(pluginRoot, "assets", "template.html");
+
+const createDashboardElement = (id) => {
+  return {
+    id,
+    textContent: "",
+    innerHTML: "",
+    className: "",
+    onclick: null,
+    onchange: null,
+    dataset: {},
+    value: "",
+    setAttribute(name, value) {
+      this[name] = String(value);
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+};
+
+const getDashboardElement = (elements, id) => {
+  if (!elements.has(id)) {
+    elements.set(id, createDashboardElement(id));
+  }
+  return elements.get(id);
+};
+
+const createDashboardDocument = (elements) => ({
+  getElementById: (id) => getDashboardElement(elements, id),
+});
+
+const extractDashboardScript = (template) => {
+  const match = template.match(/<script>([\s\S]*?)<\/script>/);
+  assert.ok(match?.[1], "Dashboard script block not found");
+  return match[1];
+};
+
+const runDashboard = async (entries, meta = {}) => {
+  const template = await readFile(dashboardTemplatePath, "utf8");
+  const script = extractDashboardScript(template);
+  const elements = new Map();
+  const context = {
+    console,
+    document: createDashboardDocument(elements),
+    __AUTORESEARCH_DATA__: entries,
+    __AUTORESEARCH_META__: meta,
+  };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  const getById = (id) => getDashboardElement(elements, id);
+  return { elements, getById };
+};
+
+test("dashboard DOM renders non-blank next action in operator rail", async () => {
+  const entries = [
+    { type: "config", name: "zero path", metricName: "seconds", bestDirection: "lower", metricUnit: "s" },
+    {
+      type: "run",
+      run: 1,
+      metric: 5.4,
+      status: "keep",
+      description: "Baseline baseline",
+      asi: { next_action_hint: "Try reducing startup overhead." },
+      confidence: 1,
+    },
+    {
+      type: "run",
+      run: 2,
+      metric: 4.9,
+      status: "discard",
+      description: "Noisy baseline",
+      confidence: 1,
+    },
+    {
+      type: "run",
+      run: 3,
+      metric: 4.8,
+      status: "keep",
+      description: "Cache manifest",
+      confidence: 1,
+    },
+  ];
+
+  const { getById } = await runDashboard(entries, { commands: [] });
+  const rail = getById("decision-rail").innerHTML;
+  const nextActionDetail = getById("next-action-detail").textContent.trim();
+  const nextActionTitle = getById("next-action-title").textContent.trim();
+
+  assert.match(rail, /#1/);
+  assert.match(rail, /Keep|Discard|crash|checks_failed/i);
+  assert.notEqual(rail.includes("No decisions yet"), true);
+  assert.match(nextActionTitle, /Next action/i);
+  assert.equal(nextActionDetail, "Try reducing startup overhead.");
+});
+
+test("dashboard family/plateau display marks best row and zero-delta plateau clearly", async () => {
+  const entries = [
+    { type: "config", name: "plateau path", metricName: "seconds", bestDirection: "lower", metricUnit: "s" },
+    {
+      type: "run",
+      run: 1,
+      metric: 10,
+      status: "keep",
+      description: "Warm cache enabled",
+      confidence: 1,
+      asi: { hypothesis: "Baseline plateau." },
+    },
+    { type: "run", run: 2, metric: 12, status: "discard", description: "Increased batch size", confidence: 1 },
+    { type: "run", run: 3, metric: 10, status: "keep", description: "Alternate cache key", confidence: 1 },
+  ];
+
+  const { getById } = await runDashboard(entries, { commands: [] });
+  const ledgerHtml = getById("ledger-body").innerHTML;
+  const readout = getById("best-kept-detail").textContent;
+
+  assert.match(ledgerHtml, /best-row/);
+  assert.match(ledgerHtml, /0%/);
+  assert.match(ledgerHtml, /#3/);
+  assert.match(readout, /Warm cache enabled/);
+});
+
+test("dashboard handles zero and negative metrics without unsafe percent or sign artifacts", async () => {
+  const entries = [
+    { type: "config", name: "negative path", metricName: "delta", bestDirection: "lower", metricUnit: "" },
+    {
+      type: "run",
+      run: 1,
+      metric: 0,
+      status: "keep",
+      description: "Zero baseline",
+      confidence: 1,
+    },
+    {
+      type: "run",
+      run: 2,
+      metric: -2,
+      status: "keep",
+      description: "Crosses below zero",
+      confidence: 1,
+      asi: { next_action_hint: "Track stability after crossing baseline." },
+    },
+    {
+      type: "run",
+      run: 3,
+      metric: -2,
+      status: "discard",
+      description: "Plateau below zero",
+      confidence: 1,
+    },
+  ];
+
+  const { getById } = await runDashboard(entries, { commands: [] });
+  const chart = getById("trend-chart").innerHTML;
+  const improvement = getById("improvement-value").textContent;
+  const baseline = getById("baseline-value").textContent;
+  const best = getById("best-value").textContent;
+  const delta = getById("ledger-body").innerHTML;
+
+  assert.equal(improvement, "-");
+  assert.equal(baseline, "0");
+  assert.equal(best, "-2");
+  assert.match(chart, /-2/);
+  assert.doesNotMatch(chart, /Infinity|NaN/);
+  assert.match(delta, /0%/);
+  assert.match(getById("next-action-detail").textContent, /Track stability/);
+});
+
+test("stale last-run handling remains visible in dashboard guidance", async () => {
+  const staleReason = "Last-run packet is stale: expected next log run #2, but current history would log #3.";
+  const viewModel = {
+    experimentMemory: { latestNextAction: "Measure from live backend." },
+    guidedSetup: { stage: "stale-last-run" },
+    lastRun: {
+      generatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      freshness: {
+        fresh: false,
+        reason: staleReason,
+      },
+    },
+    nextBestAction: {
+      kind: "stale-packet",
+      title: "Replace the stale packet",
+      detail: staleReason,
+      utilityCopy: "Run a fresh packet before logging so old metrics cannot be reused.",
+      command: "node scripts/autoresearch.mjs next --cwd .",
+      source: "packet",
+    },
+    actionRail: [],
+    readout: { nextAction: staleReason },
+  };
+
+  const entries = [
+    { type: "config", name: "stale path", metricName: "seconds", bestDirection: "lower", metricUnit: "" },
+    {
+      type: "run",
+      run: 1,
+      metric: 10,
+      status: "keep",
+      description: "stable baseline",
+      confidence: 1,
+      asi: { next_action_hint: "Follow the stale metadata check." },
+    },
+  ];
+
+  const { getById } = await runDashboard(entries, { viewModel, commands: [] });
+  const staleTimestamp = Date.parse(viewModel.lastRun.generatedAt);
+  assert.equal(Number.isFinite(staleTimestamp), true);
+  assert.equal(staleTimestamp <= Date.now(), true);
+  assert.equal(viewModel.guidedSetup.stage, "stale-last-run");
+  assert.equal(viewModel.lastRun.freshness.fresh, false);
+  assert.match(getById("next-best-title").textContent, /Replace the stale packet/);
+  assert.match(getById("next-action-detail").textContent, /Last-run packet is stale/);
+  assert.equal(getById("decision-rail").innerHTML.includes("No decisions yet"), false);
+});

--- a/plugins/codex-autoresearch/tests/experiment-memory.test.mjs
+++ b/plugins/codex-autoresearch/tests/experiment-memory.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildExperimentMemory, detectRepeatedHypothesis } from "../lib/experiment-memory.mjs";
+
+test("experiment memory groups repeated setting families and detects plateau risk", () => {
+  const runs = [
+    kept(1, 100, "Baseline BGE b512 r1", { hypothesis: "BGE base b512 repeat 1" }),
+    rejected(2, 99, "Q8 b512 r1 regression", { hypothesis: "Q8 b512 r1" }),
+    rejected(3, 99.2, "Q8 b512 r2 regression", { hypothesis: "Q8 b512 r2" }),
+    rejected(4, 99.1, "Q8 b512 r3 regression", { hypothesis: "Q8 b512 r3" }),
+    rejected(5, 99.3, "Q8 b512 r4 regression", { hypothesis: "Q8 b512 r4" }),
+  ];
+
+  const memory = buildExperimentMemory({ runs, direction: "higher" });
+  const q8Family = memory.families.find((family) => /q8 b512 r/.test(family.key));
+
+  assert.ok(q8Family, JSON.stringify(memory.families, null, 2));
+  assert.equal(q8Family.runs, 4);
+  assert.equal(q8Family.exhausted, true);
+  assert.equal(memory.plateau.detected, true);
+  assert.match(memory.plateau.recommendation, /distant scout/i);
+  assert.equal(memory.lanePortfolio[0].id, "distant-scout");
+  assert.equal(memory.novelty.uniqueFamilies < memory.novelty.recentWindow, true);
+});
+
+test("experiment memory uses structured settings while ignoring repeat-only fields", () => {
+  const runs = [
+    kept(1, 10, "settings baseline", {
+      settings: { model: "nomic", dim: 512, repeat: 1 },
+      hypothesis: "Nomic 512 repeat 1",
+    }),
+    rejected(2, 12, "settings repeat", {
+      settings: { model: "nomic", dim: 512, repeat: 2 },
+      hypothesis: "Nomic 512 repeat 2",
+    }),
+  ];
+
+  const memory = buildExperimentMemory({ runs, direction: "lower" });
+  assert.equal(memory.families.length, 1);
+  assert.equal(memory.families[0].runs, 2);
+});
+
+test("repeated hypothesis detection catches near-family repeats", () => {
+  const memory = buildExperimentMemory({
+    direction: "higher",
+    runs: [
+      rejected(1, 90, "Q8 b512 r3 regression", { hypothesis: "Q8 b512 r3" }),
+    ],
+  });
+
+  const repeat = detectRepeatedHypothesis({ proposed: "Try Q8 b512 r5", memory });
+  assert.equal(repeat.matchedRun, 1);
+  assert.match(repeat.reason, /already logged/);
+});
+
+test("incumbent guidance prefers kept families over latest rejected families", () => {
+  const memory = buildExperimentMemory({
+    direction: "lower",
+    runs: [
+      kept(1, 10, "Good family wins", {
+        family: "good",
+        next_action_hint: "stress the good path",
+      }),
+      rejected(2, 12, "Bad family regresses", {
+        family: "bad",
+        rollback_reason: "regressed",
+        next_action_hint: "avoid bad path",
+      }),
+    ],
+  });
+
+  assert.equal(memory.diversityGuidance.id, "incumbent-confirmation");
+  assert.match(memory.diversityGuidance.reason, /good/);
+  assert.equal(memory.diversityGuidance.nextActionHint, "stress the good path");
+});
+
+test("incumbent guidance waits when there are no kept families", () => {
+  const memory = buildExperimentMemory({
+    direction: "lower",
+    runs: [
+      rejected(1, 12, "Bad family regresses", {
+        family: "bad",
+        rollback_reason: "regressed",
+        next_action_hint: "avoid bad path",
+      }),
+    ],
+  });
+  const incumbent = memory.lanePortfolio.find((lane) => lane.id === "incumbent-confirmation");
+
+  assert.equal(incumbent.status, "waiting");
+  assert.equal(memory.diversityGuidance.id, "avoid");
+  assert.match(memory.diversityGuidance.reason, /regressed/);
+});
+
+test("best kept incumbent is preserved when active families are trimmed", () => {
+  const runs = [
+    kept(1, 1, "Best early family", {
+      family: "best",
+      next_action_hint: "stress the best path",
+    }),
+  ];
+  for (let run = 2; run <= 10; run += 1) {
+    const suffix = String.fromCharCode(96 + run);
+    runs.push(kept(run, 10 + run, `Later worse family ${suffix}`, {
+      family: `worse-${suffix}`,
+      next_action_hint: `worse path ${suffix}`,
+    }));
+  }
+
+  const memory = buildExperimentMemory({ runs, direction: "lower" });
+
+  assert.ok(memory.families.some((family) => family.label === "best"));
+  assert.equal(memory.diversityGuidance.id, "incumbent-confirmation");
+  assert.match(memory.diversityGuidance.reason, /best/);
+  assert.equal(memory.diversityGuidance.nextActionHint, "stress the best path");
+});
+
+function kept(run, metric, description, asi = {}) {
+  return { run, metric, description, status: "keep", asi };
+}
+
+function rejected(run, metric, description, asi = {}) {
+  return { run, metric, description, status: "discard", asi };
+}

--- a/plugins/codex-autoresearch/tests/full-product.test.mjs
+++ b/plugins/codex-autoresearch/tests/full-product.test.mjs
@@ -220,7 +220,7 @@ test("setup-plan, recipes, and recipe-backed setup are wired through the CLI", a
     assert.equal(doctor.code, 0, doctor.stderr);
     const doctorPayload = JSON.parse(doctor.stdout);
     assert.equal(doctorPayload.ok, true);
-    assert.equal(doctorPayload.drift.local.surfaces.packageJson, "0.1.13");
+    assert.equal(doctorPayload.drift.local.surfaces.packageJson, "0.2.0");
     assert.equal(doctorPayload.drift.ok, true);
   });
 });


### PR DESCRIPTION
## What changed

- Bumped the codex-autoresearch plugin version surfaces to `0.2.0` across package metadata, plugin metadata, and MCP server info.
- Added a dashboard next-best-action rail plus experiment family, plateau, novelty, and lane-portfolio guidance.
- Hardened last-run packet handling so consumed packets are cleared, stale packets are rejected, and stale dashboard recovery can replay the original one-off benchmark command.
- Replaced the long package `check` script with `scripts/check.mjs` and added focused dashboard and experiment-memory regression coverage.

## Why

The dashboard was growing into the operator surface for active autoresearch loops, but it still left too much state interpretation to raw JSON and terminal history. The stale-packet path also needed a runnable recovery command when the original packet came from `next --command` instead of a default benchmark script.

## Impact

Operators get clearer next-step guidance, safer packet reuse behavior, and a versioned `0.2.0` plugin package. Reviewers also get a smaller `npm run check` entrypoint that still runs syntax checks, product checks, help checks, and the test suite.

## Validation

- `npm test -- --test-name-pattern "stale last-run|manual metrics"`
- `npm run check`
- `git diff --check`