### PR TITLE
[codex] Bootstrap missing plugin runtime from release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version from plugins/codex-autoresearch/package.json, for example 1.1.12'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -56,6 +59,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Refuse non-main release
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "::error::Run the release workflow from main, not $GITHUB_REF_NAME."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -65,6 +76,41 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${INPUT_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release version must look like 1.2.3, got $INPUT_VERSION."
+            exit 1
+          fi
+          package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+          manifest_version="$(node -p "JSON.parse(require('fs').readFileSync('.codex-plugin/plugin.json', 'utf8')).version")"
+          if [ "$version" != "$package_version" ] || [ "$version" != "$manifest_version" ]; then
+            echo "::error::Input version $version does not match package.json $package_version and plugin.json $manifest_version."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse existing tag or release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists. Do not push release tags manually."
+            exit 1
+          fi
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::Release $TAG already exists."
+            exit 1
+          fi
 
       - name: Build node
         run: npm run build:node
@@ -78,13 +124,23 @@ jobs:
       - name: Smoke release package
         run: |
           set -euo pipefail
-          tarball="$(ls codex-autoresearch-*.tgz | head -n 1)"
+          tarball="codex-autoresearch-${{ steps.version.outputs.version }}.tgz"
+          test -f "$tarball"
           mkdir -p "$RUNNER_TEMP/codex-autoresearch-release"
           tar -xzf "$tarball" -C "$RUNNER_TEMP/codex-autoresearch-release"
           node "$RUNNER_TEMP/codex-autoresearch-release/package/scripts/autoresearch.mjs" mcp-smoke
 
-      - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
-        with:
-          files: plugins/codex-autoresearch/*.tgz
-          generate_release_notes: true
+      - name: Create GitHub release with tarball
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          tarball="codex-autoresearch-${VERSION}.tgz"
+          gh release create "$TAG" "$tarball#$tarball" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --generate-notes \
+            --fail-on-no-commits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses a root-only changelog because the root README is the public do
 
 ## Unreleased
 
+## 1.1.13
+
+### Fixed
+
+- Added launcher bootstrapping for Git marketplace installs: if `dist/` is missing from a source-shaped plugin cache, `scripts/*.mjs` downloads and extracts the matching GitHub release tarball before importing the compiled runtime.
+
+Bumped public package, plugin manifest, CLI server, and MCP server version surfaces to `1.1.13`.
+
 ## 1.1.12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses a root-only changelog because the root README is the public do
 
 - Moved the compiled `dist/` runtime out of the Git tree and into the release tarball contract: local checks now pack, extract, and smoke-test the generated package so source/runtime split regressions fail before release.
 - Tightened package artifact verification so published `scripts/*.mjs` launcher files must remain small wrappers into `dist/scripts/` and the compiled MCP support modules under `dist/lib/` must be present, preventing source/runtime split regressions from passing local checks while failing after Codex installs the plugin.
+- Changed release publishing so CI builds and smoke-tests the tarball before creating the GitHub release/tag, avoiding a tag-visible window where update clients could resolve a source archive without `dist/`.
 - Fixed the CLI-reported plugin version surface so internal session and dashboard metadata now reports `1.1.12` instead of the stale `1.1.10` value.
 
 ### Changed

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "One Codex skill for measured autoresearch loops: set up or resume, run packets, log decisions, use the live dashboard, and finalize kept changes.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -76,6 +76,8 @@ node scripts/autoresearch.mjs export --cwd examples/demo-session --output autore
 
 Before publishing, inspect the package artifact itself. The shipped `scripts/*.mjs` shims depend on `dist/`, but `dist/` is generated and ignored in the Git tree. A publishable release tarball must include the built runtime, exclude authored source and tests, and pass `node <extracted-package>/scripts/autoresearch.mjs mcp-smoke`.
 
+Do not push release tags by hand. After the version bump lands on `main`, run the `Release` GitHub Actions workflow manually with the package version. The workflow runs the checks, builds and smoke-tests the tarball, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. This keeps update clients on the previous release until the new install artifact exists.
+
 ## Version Surfaces
 
 For a version bump, update all version surfaces together:

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -74,7 +74,7 @@ When refreshing the checked-in demo, use the public showcase export so workstati
 node scripts/autoresearch.mjs export --cwd examples/demo-session --output autoresearch-dashboard.html --showcase
 ```
 
-Before publishing, inspect the package artifact itself. The shipped `scripts/*.mjs` shims depend on `dist/`, but `dist/` is generated and ignored in the Git tree. A publishable release tarball must include the built runtime, exclude authored source and tests, and pass `node <extracted-package>/scripts/autoresearch.mjs mcp-smoke`.
+Before publishing, inspect the package artifact itself. The shipped `scripts/*.mjs` shims depend on `dist/`, but `dist/` is generated and ignored in the Git tree. If a Git marketplace source checkout is missing `dist/`, the launcher bootstrap downloads and extracts the matching GitHub release tarball into the plugin cache before importing the runtime. A publishable release tarball must include the built runtime, exclude authored source and tests, and pass `node <extracted-package>/scripts/autoresearch.mjs mcp-smoke`.
 
 Do not push release tags by hand. After the version bump lands on `main`, run the `Release` GitHub Actions workflow manually with the package version. The workflow runs the checks, builds and smoke-tests the tarball, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. This keeps update clients on the previous release until the new install artifact exists.
 

--- a/plugins/codex-autoresearch/package-lock.json
+++ b/plugins/codex-autoresearch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-autoresearch",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^1.8.0",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "description": "Codex plugin for autonomous benchmark and optimization loops.",
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",

--- a/plugins/codex-autoresearch/scripts/autoresearch-mcp.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch-mcp.mjs
@@ -1,2 +1,4 @@
 #!/usr/bin/env node
-await import(new URL("../dist/scripts/autoresearch-mcp.mjs", import.meta.url));
+import { ensureRuntime } from "./bootstrap-runtime.mjs";
+
+await import(await ensureRuntime("autoresearch-mcp.mjs", import.meta.url));

--- a/plugins/codex-autoresearch/scripts/autoresearch-mcp.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch-mcp.ts
@@ -11,7 +11,7 @@ import { resolvePackageRoot } from "../lib/runtime-paths.js";
 const MAX_MCP_FRAME_BYTES = 1024 * 1024;
 const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
 const CLI_SCRIPT = path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs");
-const VERSION = "1.1.12";
+const VERSION = "1.1.13";
 const callCliTool = createCliToolCaller({ cliScript: CLI_SCRIPT, pluginRoot: PLUGIN_ROOT });
 
 let buffer = Buffer.alloc(0);

--- a/plugins/codex-autoresearch/scripts/autoresearch.mjs
+++ b/plugins/codex-autoresearch/scripts/autoresearch.mjs
@@ -1,2 +1,4 @@
 #!/usr/bin/env node
-await import(new URL("../dist/scripts/autoresearch.mjs", import.meta.url));
+import { ensureRuntime } from "./bootstrap-runtime.mjs";
+
+await import(await ensureRuntime("autoresearch.mjs", import.meta.url));

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -89,7 +89,7 @@ const MAX_MCP_FRAME_BYTES = 1024 * 1024;
 const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
 const REPO_ROOT = resolveRepoRoot(import.meta.url);
 const MCP_SCRIPT_PATH = path.join(PLUGIN_ROOT, "scripts", "autoresearch-mcp.mjs");
-const PLUGIN_VERSION = "1.1.12";
+const PLUGIN_VERSION = "1.1.13";
 const DASHBOARD_TEMPLATE_PATH = path.join(PLUGIN_ROOT, "assets", "template.html");
 const DASHBOARD_BUILD_DIR = path.join(PLUGIN_ROOT, "assets", "dashboard-build");
 const DASHBOARD_DATA_PLACEHOLDER = "__AUTORESEARCH_DATA_PAYLOAD__";
@@ -4237,7 +4237,7 @@ async function handleMcpMessage(message) {
       result: {
         protocolVersion: "2024-11-05",
         capabilities: { tools: {} },
-        serverInfo: { name: "codex-autoresearch", version: "1.1.12" },
+        serverInfo: { name: "codex-autoresearch", version: "1.1.13" },
       },
     });
     return;

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -1,0 +1,134 @@
+import { createWriteStream } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawn } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+const LOCK_TIMEOUT_MS = 120_000;
+const LOCK_RETRY_MS = 250;
+
+export async function ensureRuntime(entrypoint, importerUrl) {
+  const scriptDir = path.dirname(fileURLToPath(importerUrl));
+  const pluginRoot = path.resolve(scriptDir, "..");
+  const target = path.join(pluginRoot, "dist", "scripts", entrypoint);
+
+  if (await fileExists(target)) return pathToFileURL(target).href;
+
+  await withRuntimeInstallLock(pluginRoot, async () => {
+    if (await fileExists(target)) return;
+    await installRuntimeFromRelease(pluginRoot);
+    if (!(await fileExists(target))) {
+      throw new Error(`Release runtime did not provide ${path.relative(pluginRoot, target)}.`);
+    }
+  });
+
+  return pathToFileURL(target).href;
+}
+
+async function installRuntimeFromRelease(pluginRoot) {
+  const pkg = JSON.parse(await fs.readFile(path.join(pluginRoot, "package.json"), "utf8"));
+  const version = String(pkg.version || "").trim();
+  if (!version) throw new Error("package.json does not declare a version.");
+
+  const tag = version.startsWith("v") ? version : `v${version}`;
+  const tarballName = `codex-autoresearch-${version.replace(/^v/, "")}.tgz`;
+  const url = `https://github.com/TheGreenCedar/codex-autoresearch/releases/download/${tag}/${tarballName}`;
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-autoresearch-runtime-"));
+  const tarballPath = path.join(tmpDir, tarballName);
+  const extractDir = path.join(tmpDir, "extract");
+
+  try {
+    await downloadFile(url, tarballPath);
+    await fs.mkdir(extractDir, { recursive: true });
+    await run("tar", ["-xzf", tarballPath, "-C", extractDir]);
+
+    const extractedDist = path.join(extractDir, "package", "dist");
+    if (!(await fileExists(extractedDist))) {
+      throw new Error(`Release tarball ${tarballName} does not contain dist/.`);
+    }
+
+    await fs.rm(path.join(pluginRoot, "dist"), { recursive: true, force: true });
+    await fs.cp(extractedDist, path.join(pluginRoot, "dist"), { recursive: true });
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function withRuntimeInstallLock(pluginRoot, fn) {
+  const lockPath = path.join(pluginRoot, ".codex-autoresearch-runtime.lock");
+  const started = Date.now();
+  let handle;
+
+  while (!handle) {
+    try {
+      handle = await fs.open(lockPath, "wx");
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (Date.now() - started > LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for runtime install lock at ${lockPath}.`);
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+
+  try {
+    await fn();
+  } finally {
+    await handle.close().catch(() => {});
+    await fs.rm(lockPath, { force: true }).catch(() => {});
+  }
+}
+
+async function downloadFile(url, destination) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: { "user-agent": "codex-autoresearch-runtime-bootstrap" },
+      signal: controller.signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+    }
+    await pipeline(response.body, createWriteStream(destination));
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      windowsHide: true,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} failed with code ${code}: ${stderr.trim()}`));
+    });
+  });
+}
+
+async function fileExists(file) {
+  try {
+    await fs.access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/plugins/codex-autoresearch/scripts/check.ts
+++ b/plugins/codex-autoresearch/scripts/check.ts
@@ -62,6 +62,7 @@ const dashboardAssets = [
 ];
 
 const sourceCheckoutLauncherPaths = [
+  "plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs",
   "plugins/codex-autoresearch/scripts/autoresearch.mjs",
   "plugins/codex-autoresearch/scripts/autoresearch-mcp.mjs",
 ];
@@ -209,6 +210,7 @@ async function runPackageArtifactCheck() {
       "dist/lib/runtime-paths.mjs",
       "dist/scripts/autoresearch.mjs",
       "dist/scripts/autoresearch-mcp.mjs",
+      "scripts/bootstrap-runtime.mjs",
       "scripts/autoresearch.mjs",
       "scripts/autoresearch-mcp.mjs",
       "skills/codex-autoresearch/SKILL.md",
@@ -253,8 +255,8 @@ async function runPackageArtifactCheck() {
 
 async function packageWrapperProblems(packedEntries: Map<string, PackageEntry>) {
   const wrappers = [
-    ["scripts/autoresearch.mjs", "../dist/scripts/autoresearch.mjs"],
-    ["scripts/autoresearch-mcp.mjs", "../dist/scripts/autoresearch-mcp.mjs"],
+    ["scripts/autoresearch.mjs", 'ensureRuntime("autoresearch.mjs"'],
+    ["scripts/autoresearch-mcp.mjs", 'ensureRuntime("autoresearch-mcp.mjs"'],
   ];
   const problems: string[] = [];
 
@@ -269,14 +271,36 @@ async function packageWrapperProblems(packedEntries: Map<string, PackageEntry>) 
 
     const byteLength = Buffer.byteLength(content, "utf8");
     const packedSize = packedEntries.get(file)?.size;
-    if (!content.includes(target)) {
-      problems.push(`${file} should import ${target}`);
+    if (!content.includes("./bootstrap-runtime.mjs") || !content.includes(target)) {
+      problems.push(`${file} should call ${target} through bootstrap-runtime.mjs`);
     }
     if (byteLength > 512) {
       problems.push(`${file} should stay a tiny launcher, but is ${byteLength} bytes`);
     }
     if (typeof packedSize === "number" && packedSize !== byteLength) {
       problems.push(`${file} packs at ${packedSize} bytes, expected ${byteLength}`);
+    }
+  }
+
+  let bootstrap = "";
+  try {
+    bootstrap = await fsp.readFile(path.join(ROOT, "scripts", "bootstrap-runtime.mjs"), "utf8");
+  } catch (error) {
+    problems.push(`scripts/bootstrap-runtime.mjs could not be read: ${String(error)}`);
+    return problems;
+  }
+
+  if (!packedEntries.has("scripts/bootstrap-runtime.mjs")) {
+    problems.push("scripts/bootstrap-runtime.mjs is missing from the package");
+  }
+  for (const expected of [
+    "github.com/TheGreenCedar/codex-autoresearch/releases/download",
+    'codex-autoresearch-${version.replace(/^v/, "")}.tgz',
+    "tar",
+    "dist",
+  ]) {
+    if (!bootstrap.includes(expected)) {
+      problems.push(`scripts/bootstrap-runtime.mjs should contain ${expected}`);
     }
   }
 

--- a/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
+++ b/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
@@ -453,7 +453,9 @@ const checks = [
       const autoresearchLauncher = await readText("scripts/autoresearch.mjs");
       const mcpLauncher = await readText("scripts/autoresearch-mcp.mjs");
       const release = await readRootText(".github/workflows/release.yml");
+      const tagPushTrigger = /push:\s*\n\s*tags:/m.test(release);
       return ignoresDist &&
+        !tagPushTrigger &&
         includesAll(packageFiles, [
           "dist/lib/",
           "dist/scripts/",
@@ -463,10 +465,17 @@ const checks = [
         ]) &&
         autoresearchLauncher.includes("../dist/scripts/autoresearch.mjs") &&
         mcpLauncher.includes("../dist/scripts/autoresearch-mcp.mjs") &&
-        includesAll(release, ["npm pack", "mcp-smoke", "codex-autoresearch-*.tgz"])
+        includesAll(release, [
+          "workflow_dispatch:",
+          "gh release create",
+          '--target "$GITHUB_SHA"',
+          "npm pack",
+          "mcp-smoke",
+          "codex-autoresearch-${VERSION}.tgz",
+        ])
         ? pass()
         : fail(
-            "Release tarball runtime contract is incomplete: dist should be ignored in Git, package files should include built dist, launchers should point at dist, and release CI should smoke the tarball.",
+            "Release tarball runtime contract is incomplete: dist should be ignored in Git, package files should include built dist, launchers should point at dist, and release CI should smoke the tarball before creating the release tag.",
           );
     },
   },

--- a/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
+++ b/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
@@ -452,6 +452,7 @@ const checks = [
       const packageFiles = (pkg.files || []).join("\n");
       const autoresearchLauncher = await readText("scripts/autoresearch.mjs");
       const mcpLauncher = await readText("scripts/autoresearch-mcp.mjs");
+      const bootstrap = await readText("scripts/bootstrap-runtime.mjs");
       const release = await readRootText(".github/workflows/release.yml");
       const tagPushTrigger = /push:\s*\n\s*tags:/m.test(release);
       return ignoresDist &&
@@ -463,8 +464,17 @@ const checks = [
           ".codex-plugin/",
           ".mcp.json",
         ]) &&
-        autoresearchLauncher.includes("../dist/scripts/autoresearch.mjs") &&
-        mcpLauncher.includes("../dist/scripts/autoresearch-mcp.mjs") &&
+        autoresearchLauncher.includes("./bootstrap-runtime.mjs") &&
+        autoresearchLauncher.includes('ensureRuntime("autoresearch.mjs"') &&
+        mcpLauncher.includes("./bootstrap-runtime.mjs") &&
+        mcpLauncher.includes('ensureRuntime("autoresearch-mcp.mjs"') &&
+        includesAll(bootstrap, [
+          "github.com/TheGreenCedar/codex-autoresearch/releases/download",
+          'codex-autoresearch-${version.replace(/^v/, "")}.tgz',
+          "package.json",
+          "tar",
+          "dist",
+        ]) &&
         includesAll(release, [
           "workflow_dispatch:",
           "gh release create",
@@ -475,7 +485,7 @@ const checks = [
         ])
         ? pass()
         : fail(
-            "Release tarball runtime contract is incomplete: dist should be ignored in Git, package files should include built dist, launchers should point at dist, and release CI should smoke the tarball before creating the release tag.",
+            "Release tarball runtime contract is incomplete: dist should be ignored in Git, package files should include built dist, launchers should bootstrap missing dist from the matching GitHub release tarball, and release CI should smoke the tarball before creating the release tag.",
           );
     },
   },

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -3297,10 +3297,16 @@ test("drift report warns when installed Codex MCP runtime lags source", async ()
 });
 
 test("runShell configures a POSIX process group for timeout cleanup", async () => {
-  const [shim, runner] = await Promise.all([
+  const [shim, bootstrap, runner] = await Promise.all([
     readFile(cli, "utf8"),
+    readFile(path.join(pluginRoot, "scripts", "bootstrap-runtime.mjs"), "utf8"),
     readFile(path.join(pluginRoot, "lib", "runner.ts"), "utf8"),
   ]);
-  assert.match(shim, /await import\(new URL\("\.\.\/dist\/scripts\/autoresearch\.mjs"/);
+  assert.match(shim, /import \{ ensureRuntime \} from "\.\/bootstrap-runtime\.mjs"/);
+  assert.match(
+    shim,
+    /await import\(await ensureRuntime\("autoresearch\.mjs", import\.meta\.url\)\)/,
+  );
+  assert.match(bootstrap, /path\.join\(pluginRoot, "dist", "scripts", entrypoint\)/);
   assert.match(runner, /detached:\s*process\.platform !== "win32"/);
 });

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -3290,7 +3290,7 @@ test("drift report warns when installed Codex MCP runtime lags source", async ()
   });
 
   assert.equal(report.ok, false);
-  assert.equal(report.local.version, "1.1.12");
+  assert.equal(report.local.version, "1.1.13");
   assert.equal(report.installed.version, "0.5.1");
   assert.match(report.warnings.join("\n"), /Installed Codex MCP runtime is 0\.5\.1/);
   assert.match(report.warnings.join("\n"), /restart Codex/);

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -1132,7 +1132,7 @@ test("dashboard view model feeds dirty, corrupt, and stale state into trust and 
     },
     drift: {
       ok: false,
-      local: { version: "1.1.12" },
+      local: { version: "1.1.13" },
       installed: {
         available: true,
         version: "0.5.1",
@@ -1150,7 +1150,7 @@ test("dashboard view model feeds dirty, corrupt, and stale state into trust and 
   assert.match(viewModel.trustState.reasons.join("\n"), /dirty/);
   assert.match(viewModel.trustState.reasons.join("\n"), /Corrupt/);
   assert.match(viewModel.trustState.reasons.join("\n"), /stale/);
-  assert.equal(viewModel.trustState.runtimeDrift.sourceVersion, "1.1.12");
+  assert.equal(viewModel.trustState.runtimeDrift.sourceVersion, "1.1.13");
   assert.equal(viewModel.trustState.runtimeDrift.installedVersion, "0.5.1");
   assert.equal(viewModel.nextBestAction.kind, "stale-packet");
   assert.match(viewModel.nextBestAction.detail, /stale/);
@@ -1200,7 +1200,7 @@ test("dashboard trust builder separates read-only mode from decision blockers", 
         metricName: "seconds",
         metricUnit: "s",
         bestDirection: "lower",
-        pluginVersion: "1.1.12",
+        pluginVersion: "1.1.13",
       },
       current: [{ run: 1, metric: 5, status: "keep", description: "Baseline" }],
       baseline: 5,
@@ -1209,7 +1209,7 @@ test("dashboard trust builder separates read-only mode from decision blockers", 
     settings: {
       deliveryMode: "static-export",
       generatedAt: "2026-04-24T00:00:00.000Z",
-      pluginVersion: "1.1.12",
+      pluginVersion: "1.1.13",
       sourceCwd: "C:/repo",
     },
   });
@@ -1230,7 +1230,7 @@ test("dashboard trust builder separates read-only mode from decision blockers", 
       baseline: 5,
       best: 5,
     },
-    settings: { deliveryMode: "live-server", pluginVersion: "1.1.12" },
+    settings: { deliveryMode: "live-server", pluginVersion: "1.1.13" },
     warnings: ["Git worktree is dirty; review unrelated changes before logging a keep result."],
   });
 

--- a/plugins/codex-autoresearch/tests/full-product.test.ts
+++ b/plugins/codex-autoresearch/tests/full-product.test.ts
@@ -267,7 +267,7 @@ test("setup-plan, recipes, and recipe-backed setup are wired through the CLI", a
     assert.equal(doctor.code, 0, doctor.stderr);
     const doctorPayload = JSON.parse(doctor.stdout);
     assert.equal(doctorPayload.ok, true);
-    assert.equal(doctorPayload.drift.local.surfaces.packageJson, "1.1.12");
+    assert.equal(doctorPayload.drift.local.surfaces.packageJson, "1.1.13");
     assert.equal(doctorPayload.drift.ok, true);
   });
 });


### PR DESCRIPTION
## Summary
- add launcher bootstrap that downloads and extracts the matching GitHub release tarball when `dist/` is missing from a source-shaped plugin cache
- bump release surfaces to `1.1.13` so users get a fresh plugin cache after the poisoned `1.1.12` source install
- keep release creation manual and tarball-smoked before the tag/release exists

## Root Cause
Codex marketplace installs can materialize the Git source checkout rather than the release tarball. After `dist/` was intentionally removed from Git, that source-shaped cache kept the tiny `scripts/*.mjs` shims but not the built runtime they imported.

## Verification
- `npm run check`
- temporary source-shaped plugin copy with no `dist/` and package version set to `1.1.12`: `node scripts/autoresearch.mjs mcp-smoke` downloaded the release tarball, created `dist/`, and returned 27 MCP tools with empty stderr
- `git diff --check`

Fixes #6