### PR TITLE
[codex] Add MCP resources and guided dashboard setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses a root-only changelog because the root README is the public do
 
 ## Unreleased
 
+### Added
+
+- Added MCP resource templates and prompts for read-only session truth: state, last-run, quality-gap, dashboard-summary, continue-loop, review-last-packet, and first-valid-loop.
+- Added explicit `guided_setup` dashboard startup support over MCP with `start_dashboard`, returning a verified live dashboard URL when requested.
+
+### Changed
+
+- Clarified that `guided_setup` is read-only by default but becomes a local process-starting operation when `start_dashboard=true`.
+
 ## 1.1.14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses a root-only changelog because the root README is the public do
 
 ## Unreleased
 
+## 1.1.15
+
 ### Added
 
 - Added MCP resource templates and prompts for read-only session truth: state, last-run, quality-gap, dashboard-summary, continue-loop, review-last-packet, and first-valid-loop.
@@ -14,6 +16,8 @@ This project uses a root-only changelog because the root README is the public do
 ### Changed
 
 - Clarified that `guided_setup` is read-only by default but becomes a local process-starting operation when `start_dashboard=true`.
+
+Bumped public package, plugin manifest, CLI server, and MCP server version surfaces to `1.1.15`.
 
 ## 1.1.14
 

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "One Codex skill for measured autoresearch loops: set up or resume, run packets, log decisions, use the live dashboard, and finalize kept changes.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/docs/mcp-tools.md
+++ b/plugins/codex-autoresearch/docs/mcp-tools.md
@@ -7,7 +7,7 @@ The `codex-autoresearch` skill is the user-facing entrypoint. MCP tools are the 
 | Tool | Use |
 | --- | --- |
 | `setup_plan` | Return a read-only setup readiness plan with missing fields, recipe suggestion, and next commands. |
-| `guided_setup` | Return a guided first-run or resume packet with setup, doctor, baseline, log, and dashboard readout guidance. |
+| `guided_setup` | Return a guided first-run or resume packet with setup, doctor, baseline, log, and dashboard readout guidance; pass `start_dashboard: true` to also start and verify the live local dashboard. |
 | `prompt_plan` | Convert a natural-language request into inferred metric defaults, experiment lanes, missing essentials, and setup commands. |
 | `onboarding_packet` | Return a compact human-and-agent onboarding packet with state, hazards, templates, and commands. |
 | `recommend_next` | Return the single safest next action with evidence and commands. |
@@ -78,6 +78,25 @@ The public `tools/list` response includes `name`, `description`, `inputSchema`, 
 
 Tool calls return structured content for programmatic clients and the same payload as text JSON for older clients. Keep those two surfaces aligned when adding a tool.
 
+## MCP Resources And Prompts
+
+The server also exposes read-only MCP resource templates so clients can inspect session truth without turning state reads into tool calls. Discover them through `resources/templates/list`, then read the resolved URI:
+
+| Resource Template | Use |
+| --- | --- |
+| `autoresearch://state{?working_dir}` | Compact session state, run counts, best metric, warnings, memory, and continuation context. |
+| `autoresearch://last-run{?working_dir}` | Last-run decision packet summary, allowed statuses, freshness, and ASI template. |
+| `autoresearch://quality-gaps{?working_dir,research_slug}` | Active or requested quality-gap checklist counts. Add `research_slug=<slug>` when needed. |
+| `autoresearch://dashboard-summary{?working_dir}` | Dashboard-style stage, next action, dashboard command, warnings, and memory summary without exporting HTML or starting a server. |
+
+Prompt templates point agents at the right resources and tools without embedding stale state:
+
+| Prompt | Use |
+| --- | --- |
+| `continue-loop` | Resume a loop from durable state and last-run evidence. |
+| `review-last-packet` | Review the latest packet before choosing keep, discard, crash, or checks_failed. |
+| `first-valid-loop` | Drive the first valid loop path through `guided_setup` with `start_dashboard=true`, setup/checks/doctor, baseline, log, and continuation. |
+
 Operational metadata such as CLI command name, mutation status, and command-bearing argument fields lives in the shared tool registry. When adding a tool, update the schema, contract, registry, dispatch handler, CLI fallback, docs, and parity tests together.
 
 Command-bearing fields require `allow_unsafe_command: true` over MCP:
@@ -89,6 +108,8 @@ Command-bearing fields require `allow_unsafe_command: true` over MCP:
 - setup guidance that materializes commands from an external recipe catalog
 
 Prefer project-local benchmark scripts over inline shell commands. If a custom command is necessary, keep it narrow and explain why the gate is being opened.
+
+`guided_setup` is read-only unless `start_dashboard: true` is passed. With that flag it starts a local process bound to `127.0.0.1` and returns `dashboard.requested`, `dashboard.started`, `dashboard.url`, `dashboard.healthUrl`, `dashboard.verified`, and `dashboard.modeGuidance`.
 
 ## CLI Fallbacks
 

--- a/plugins/codex-autoresearch/lib/mcp-cli-adapter.ts
+++ b/plugins/codex-autoresearch/lib/mcp-cli-adapter.ts
@@ -97,6 +97,48 @@ export function createCliToolCaller({
 
   return async function callCliTool(name, args) {
     if (name === "serve_dashboard") return await startLiveDashboard(args);
+    if (name === "guided_setup" && boolOption(args.start_dashboard ?? args.startDashboard, false)) {
+      const guideArgs = { ...args, start_dashboard: false, startDashboard: false };
+      const guideInvocation = buildCliInvocationForTool(name, guideArgs, {
+        cliScript,
+        cwd: pluginRoot,
+        timeoutSeconds: toolTimeoutSeconds,
+      });
+      const guideResult = await runCliInvocation(guideInvocation);
+      if (guideResult.code !== 0) {
+        throw new Error(
+          `autoresearch CLI failed (${guideResult.code})\n${guideResult.stderr || guideResult.stdout}`,
+        );
+      }
+      const guide = JSON.parse(guideResult.stdout);
+      try {
+        const served = await startLiveDashboard(args);
+        return {
+          ...guide,
+          dashboard: {
+            requested: true,
+            started: served.ok !== false,
+            url: served.url || "",
+            healthUrl: served.healthUrl || "",
+            verified: Boolean(served.verified),
+            modeGuidance: served.modeGuidance || null,
+          },
+        };
+      } catch (error) {
+        return {
+          ...guide,
+          dashboard: {
+            requested: true,
+            started: false,
+            url: "",
+            healthUrl: "",
+            verified: false,
+            modeGuidance: null,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+    }
     const invocation = buildCliInvocationForTool(name, args, {
       cliScript,
       cwd: pluginRoot,

--- a/plugins/codex-autoresearch/lib/mcp-interface.ts
+++ b/plugins/codex-autoresearch/lib/mcp-interface.ts
@@ -4,6 +4,13 @@ import {
   requireUnsafeCommandGate,
   validateToolArguments,
 } from "./mcp-tool-schemas.js";
+import {
+  getMcpPrompt,
+  listMcpPrompts,
+  listMcpResourceTemplates,
+  listMcpResources,
+  readMcpResource,
+} from "./mcp-protocol.js";
 import { toolNames } from "./tool-registry.js";
 
 export {
@@ -29,6 +36,11 @@ export function createMcpInterface(deps) {
 
   return {
     callTool,
+    getPrompt: (name, args) => getMcpPrompt(name, args),
+    listPrompts: listMcpPrompts,
+    listResourceTemplates: listMcpResourceTemplates,
+    listResources: listMcpResources,
+    readResource: (uri) => readMcpResource(uri, callTool),
     toolSchemas: mcpToolSchemas,
     validateToolArguments,
   };
@@ -37,7 +49,15 @@ export function createMcpInterface(deps) {
 function createToolHandlers(deps) {
   return ensureToolHandlerCoverage({
     setup_plan: (args) => deps.setupPlan(args),
-    guided_setup: (args) => deps.guidedSetup(args),
+    guided_setup: async (args) => {
+      const startDashboard = deps.boolOption(args.startDashboard ?? args.start_dashboard, false);
+      const guide = await deps.guidedSetup({
+        ...args,
+        startDashboard: false,
+        start_dashboard: false,
+      });
+      return await attachGuidedDashboard(guide, args, deps, startDashboard);
+    },
     prompt_plan: (args) => deps.promptPlan(args),
     onboarding_packet: (args) => deps.onboardingPacket(args),
     recommend_next: (args) => deps.recommendNext(args),
@@ -69,6 +89,53 @@ function createToolHandlers(deps) {
     doctor_session: (args) => (args.hooks ? deps.doctorHooks(args) : deps.doctorSession(args)),
     clear_session: (args) => deps.clearSession(args),
   });
+}
+
+async function attachGuidedDashboard(guide, args, deps, startDashboard) {
+  if (!startDashboard) {
+    return {
+      ...guide,
+      dashboard: guide.dashboard || {
+        requested: false,
+        started: false,
+        url: "",
+        healthUrl: "",
+        verified: false,
+        modeGuidance: null,
+      },
+    };
+  }
+  try {
+    const served = await deps.serveDashboard({
+      cwd: guide.workDir || args.cwd || args.working_dir,
+      port: args.port,
+      dashboardRefreshSeconds: args.dashboardRefreshSeconds,
+    });
+    return {
+      ...guide,
+      dashboard: {
+        requested: true,
+        started: served.ok !== false,
+        url: served.url || "",
+        healthUrl: served.healthUrl || "",
+        verified: Boolean(served.verified),
+        modeGuidance: served.modeGuidance || null,
+      },
+    };
+  } catch (error) {
+    return {
+      ...guide,
+      dashboard: {
+        requested: true,
+        started: false,
+        url: "",
+        healthUrl: "",
+        verified: false,
+        modeGuidance: null,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
 }
 
 function ensureToolHandlerCoverage(handlers) {

--- a/plugins/codex-autoresearch/lib/mcp-protocol.ts
+++ b/plugins/codex-autoresearch/lib/mcp-protocol.ts
@@ -1,0 +1,250 @@
+type LooseObject = Record<string, any>;
+
+export const MCP_PROTOCOL_METHODS = [
+  "resources/list",
+  "resources/templates/list",
+  "resources/read",
+  "prompts/list",
+  "prompts/get",
+];
+
+const RESOURCE_DEFINITIONS = [
+  {
+    uri: "autoresearch://state",
+    name: "Autoresearch state",
+    description: "Read-only compact session state for a target working directory.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "autoresearch://last-run",
+    name: "Autoresearch last run",
+    description: "Read-only last-run decision packet summary from guided setup state.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "autoresearch://quality-gaps",
+    name: "Autoresearch quality gaps",
+    description:
+      "Read-only quality-gap checklist summary for the active or requested research slug.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "autoresearch://dashboard-summary",
+    name: "Autoresearch dashboard summary",
+    description:
+      "Read-only dashboard-style operator summary without exporting or starting a server.",
+    mimeType: "application/json",
+  },
+];
+
+const RESOURCE_TEMPLATES = [
+  {
+    uriTemplate: "autoresearch://state{?working_dir}",
+    name: "Autoresearch state",
+    description: "Read-only compact session state for a target working directory.",
+    mimeType: "application/json",
+  },
+  {
+    uriTemplate: "autoresearch://last-run{?working_dir}",
+    name: "Autoresearch last run",
+    description: "Read-only last-run decision packet summary from guided setup state.",
+    mimeType: "application/json",
+  },
+  {
+    uriTemplate: "autoresearch://quality-gaps{?working_dir,research_slug}",
+    name: "Autoresearch quality gaps",
+    description:
+      "Read-only quality-gap checklist summary for the active or requested research slug.",
+    mimeType: "application/json",
+  },
+  {
+    uriTemplate: "autoresearch://dashboard-summary{?working_dir}",
+    name: "Autoresearch dashboard summary",
+    description:
+      "Read-only dashboard-style operator summary without exporting or starting a server.",
+    mimeType: "application/json",
+  },
+];
+
+const PROMPT_DEFINITIONS = [
+  {
+    name: "continue-loop",
+    description: "Continue an existing Autoresearch loop from current state and last-run evidence.",
+    arguments: [{ name: "working_dir", description: "Target project directory.", required: true }],
+  },
+  {
+    name: "review-last-packet",
+    description: "Review the last packet before logging keep, discard, crash, or checks_failed.",
+    arguments: [{ name: "working_dir", description: "Target project directory.", required: true }],
+  },
+  {
+    name: "first-valid-loop",
+    description: "Run the first valid loop path with guided setup and an explicit live dashboard.",
+    arguments: [{ name: "working_dir", description: "Target project directory.", required: true }],
+  },
+];
+
+export function listMcpResources() {
+  return { resources: [] };
+}
+
+export function listMcpResourceTemplates() {
+  return { resourceTemplates: RESOURCE_TEMPLATES.map((resource) => ({ ...resource })) };
+}
+
+export function listMcpPrompts() {
+  return { prompts: PROMPT_DEFINITIONS.map((prompt) => ({ ...prompt })) };
+}
+
+export async function readMcpResource(
+  uri: string,
+  callTool: (name: string, args: LooseObject) => Promise<LooseObject>,
+) {
+  const request = parseAutoresearchResourceUri(uri);
+  const baseArgs = {
+    working_dir: request.workingDir,
+    ...(request.researchSlug ? { research_slug: request.researchSlug } : {}),
+  };
+  const stateArgs = { working_dir: request.workingDir, compact: true };
+
+  if (request.kind === "state") {
+    return resourceResponse(uri, await callTool("read_state", stateArgs));
+  }
+
+  if (request.kind === "last-run") {
+    const guide = await callTool("guided_setup", { working_dir: request.workingDir });
+    return resourceResponse(uri, {
+      ok: guide.ok !== false,
+      workDir: guide.workDir,
+      stage: guide.stage,
+      nextAction: guide.nextAction,
+      lastRun: guide.lastRun ?? null,
+    });
+  }
+
+  if (request.kind === "quality-gaps") {
+    return resourceResponse(uri, await callTool("measure_quality_gap", baseArgs));
+  }
+
+  if (request.kind === "dashboard-summary") {
+    const [state, guide] = await Promise.all([
+      callTool("read_state", stateArgs),
+      callTool("guided_setup", { working_dir: request.workingDir }),
+    ]);
+    return resourceResponse(uri, {
+      ok: state.ok !== false && guide.ok !== false,
+      workDir: request.workingDir,
+      stage: guide.stage,
+      nextAction: guide.nextAction,
+      dashboardCommand: guide.commands?.dashboard || "",
+      runs: state.runs,
+      best: state.best,
+      warnings: [...(state.warnings || []), ...(guide.doctor?.warnings || [])],
+      memory: state.memory || null,
+    });
+  }
+
+  throw new Error(`Unknown autoresearch resource: ${request.kind}`);
+}
+
+export function getMcpPrompt(name: string, args: LooseObject = {}) {
+  const definition = PROMPT_DEFINITIONS.find((prompt) => prompt.name === name);
+  if (!definition) throw new Error(`Unknown prompt: ${name}`);
+  const workingDir = stringArg(args.working_dir ?? args.workingDir ?? args.cwd);
+  if (!workingDir) throw new Error(`${name} requires working_dir.`);
+  const stateUri = resourceUri("state", workingDir);
+  const lastRunUri = resourceUri("last-run", workingDir);
+  const dashboardUri = resourceUri("dashboard-summary", workingDir);
+  const qualityGapsUri = resourceUri("quality-gaps", workingDir);
+  const text = promptText(name, { workingDir, stateUri, lastRunUri, dashboardUri, qualityGapsUri });
+  return {
+    description: definition.description,
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text,
+        },
+      },
+    ],
+  };
+}
+
+function promptText(name: string, context: LooseObject) {
+  if (name === "continue-loop") {
+    return [
+      "Continue the Codex Autoresearch loop without relying on stale chat memory.",
+      `Target: ${context.workingDir}`,
+      `Read current state from ${context.stateUri}.`,
+      `Read last-run evidence from ${context.lastRunUri}.`,
+      "Then use recommend_next, guided_setup, next_experiment, and log_experiment as appropriate.",
+      "Do not run another packet until any fresh last-run packet is logged or intentionally replaced.",
+    ].join("\n");
+  }
+  if (name === "review-last-packet") {
+    return [
+      "Review the latest Autoresearch packet before making a log decision.",
+      `Target: ${context.workingDir}`,
+      `Read ${context.lastRunUri} and ${context.dashboardUri}.`,
+      "Decide only among keep, discard, crash, or checks_failed, and preserve ASI evidence.",
+      "If the packet is stale, replace it with guided_setup guidance instead of logging it.",
+    ].join("\n");
+  }
+  return [
+    "Run the first valid Codex Autoresearch loop path.",
+    `Target: ${context.workingDir}`,
+    `Read ${context.stateUri}, ${context.dashboardUri}, and ${context.qualityGapsUri} when relevant.`,
+    "Call guided_setup with start_dashboard=true so the operator receives a verified live dashboard URL.",
+    "Then complete setup/checks/doctor, run the baseline packet, log the result, and continue or finalize.",
+  ].join("\n");
+}
+
+function parseAutoresearchResourceUri(uri: string) {
+  if (!uri) throw new Error("resources/read requires uri.");
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`Invalid resource URI: ${uri}`);
+  }
+  if (parsed.protocol !== "autoresearch:") {
+    throw new Error(`Unsupported resource URI scheme: ${parsed.protocol}`);
+  }
+  const kind = parsed.hostname || parsed.pathname.replace(/^\/+/, "");
+  const known = RESOURCE_DEFINITIONS.some((resource) => resource.uri === `autoresearch://${kind}`);
+  if (!known) throw new Error(`Unknown autoresearch resource: ${kind}`);
+  const workingDir = stringArg(
+    parsed.searchParams.get("working_dir") ||
+      parsed.searchParams.get("workingDir") ||
+      parsed.searchParams.get("cwd"),
+  );
+  if (!workingDir) throw new Error(`${uri} requires working_dir query parameter.`);
+  return {
+    kind,
+    workingDir,
+    researchSlug: stringArg(
+      parsed.searchParams.get("research_slug") || parsed.searchParams.get("researchSlug"),
+    ),
+  };
+}
+
+function resourceResponse(uri: string, body: LooseObject) {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify(body, null, 2),
+      },
+    ],
+  };
+}
+
+function resourceUri(kind: string, workingDir: string) {
+  return `autoresearch://${kind}?working_dir=${encodeURIComponent(workingDir)}`;
+}
+
+function stringArg(value: unknown) {
+  return value == null ? "" : String(value).trim();
+}

--- a/plugins/codex-autoresearch/lib/mcp-tool-schemas.ts
+++ b/plugins/codex-autoresearch/lib/mcp-tool-schemas.ts
@@ -75,6 +75,9 @@ export const toolSchemas = applyToolContracts([
         secondary_metrics: { type: "array", items: { type: "string" } },
         commit_paths: { type: "array", items: { type: "string" } },
         max_iterations: { type: "integer" },
+        start_dashboard: { type: "boolean" },
+        port: { type: "number" },
+        dashboard_refresh_seconds: { type: "number" },
         allow_unsafe_command: { type: "boolean" },
       },
       required: ["working_dir"],
@@ -586,6 +589,7 @@ const RUNTIME_ARG_ALIASES: Record<string, string> = {
   revert_paths: "revertPaths",
   secondary_metrics: "secondaryMetrics",
   skip_init: "skipInit",
+  start_dashboard: "startDashboard",
   timeout_seconds: "timeoutSeconds",
   working_dir: "cwd",
 };

--- a/plugins/codex-autoresearch/lib/tool-contracts.ts
+++ b/plugins/codex-autoresearch/lib/tool-contracts.ts
@@ -29,8 +29,15 @@ const CONTRACTS = {
     purpose: "Return a complete first-run or resume action packet.",
     whenToUse: "Use when an operator asks what to do next from an existing or new session.",
     contrast: "Use setup_plan for read-only setup fields without resume state.",
-    safety: "Read-only.",
-    outputSchema: basicOutputSchema(["ok", "workDir", "stage", "commands", "nextAction"]),
+    safety: "Read-only by default; starts a local dashboard only when start_dashboard=true.",
+    outputSchema: basicOutputSchema([
+      "ok",
+      "workDir",
+      "stage",
+      "commands",
+      "nextAction",
+      "dashboard",
+    ]),
   },
   prompt_plan: {
     purpose: "Convert a natural-language request into an Autoresearch loop plan.",
@@ -241,7 +248,6 @@ const CONTRACTS = {
 
 const READ_ONLY_TOOLS = new Set([
   "setup_plan",
-  "guided_setup",
   "prompt_plan",
   "onboarding_packet",
   "recommend_next",
@@ -253,6 +259,7 @@ const READ_ONLY_TOOLS = new Set([
 
 const DESTRUCTIVE_TOOLS = new Set(["log_experiment", "clear_session"]);
 const CONDITIONALLY_OPEN_WORLD_TOOLS = new Set([
+  "guided_setup",
   "benchmark_inspect",
   "benchmark_lint",
   "checks_inspect",
@@ -350,6 +357,7 @@ function outputFieldSchemas(): Record<string, JsonSchema> {
     doctor: objectSchema("Doctor readiness result."),
     drift: objectSchema("Runtime/source drift report."),
     dryRun: booleanSchema("Whether the mutation was previewed only."),
+    dashboard: objectSchema("Live dashboard startup status for guided setup."),
     entry: objectSchema("Ledger/config entry."),
     experiment: objectSchema("Logged experiment entry."),
     failedTests: arraySchema(stringSchema("Failed test or check."), "Failed tests or checks."),

--- a/plugins/codex-autoresearch/lib/tool-registry.ts
+++ b/plugins/codex-autoresearch/lib/tool-registry.ts
@@ -68,6 +68,9 @@ export function actionPolicyForTool(name: string, args: LooseObject = {}): Actio
   if (name === "gap_candidates" && (args.apply || args.apply === "true")) {
     return "state_mutation";
   }
+  if (name === "guided_setup" && (args.start_dashboard || args.startDashboard)) {
+    return "process_start";
+  }
   if (name === "doctor_session" && args.check_benchmark) return "process_start";
   if (name === "benchmark_inspect" && args.command) return "process_start";
   if (name === "checks_inspect" && (args.command || args.checks_command || args.checksCommand))

--- a/plugins/codex-autoresearch/package-lock.json
+++ b/plugins/codex-autoresearch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-autoresearch",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^1.8.0",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "private": true,
   "description": "Codex plugin for autonomous benchmark and optimization loops.",
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",

--- a/plugins/codex-autoresearch/scripts/autoresearch-mcp.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch-mcp.ts
@@ -6,6 +6,13 @@ import {
   requireUnsafeCommandGate,
   validateToolArguments,
 } from "../lib/mcp-interface.js";
+import {
+  getMcpPrompt,
+  listMcpPrompts,
+  listMcpResourceTemplates,
+  listMcpResources,
+  readMcpResource,
+} from "../lib/mcp-protocol.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 import { PLUGIN_VERSION } from "../lib/plugin-version.js";
 
@@ -84,7 +91,7 @@ async function handleMcpMessage(message) {
       id: message.id,
       result: {
         protocolVersion: "2024-11-05",
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, resources: {}, prompts: {} },
         serverInfo: { name: "codex-autoresearch", version: PLUGIN_VERSION },
       },
     });
@@ -95,6 +102,49 @@ async function handleMcpMessage(message) {
 
   if (message.method === "tools/list") {
     sendMcp({ jsonrpc: "2.0", id: message.id, result: { tools: mcpToolSchemas } });
+    return;
+  }
+
+  if (message.method === "resources/list") {
+    sendMcp({ jsonrpc: "2.0", id: message.id, result: listMcpResources() });
+    return;
+  }
+
+  if (message.method === "resources/templates/list") {
+    sendMcp({ jsonrpc: "2.0", id: message.id, result: listMcpResourceTemplates() });
+    return;
+  }
+
+  if (message.method === "resources/read") {
+    try {
+      const result = await readMcpResource(message.params?.uri, callValidatedCliTool);
+      sendMcp({ jsonrpc: "2.0", id: message.id, result });
+    } catch (error) {
+      sendMcp({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32602, message: error.message || String(error) },
+      });
+    }
+    return;
+  }
+
+  if (message.method === "prompts/list") {
+    sendMcp({ jsonrpc: "2.0", id: message.id, result: listMcpPrompts() });
+    return;
+  }
+
+  if (message.method === "prompts/get") {
+    try {
+      const result = getMcpPrompt(message.params?.name, message.params?.arguments || {});
+      sendMcp({ jsonrpc: "2.0", id: message.id, result });
+    } catch (error) {
+      sendMcp({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32602, message: error.message || String(error) },
+      });
+    }
     return;
   }
 
@@ -136,6 +186,12 @@ async function handleMcpMessage(message) {
       error: { code: -32601, message: `Unknown method: ${message.method}` },
     });
   }
+}
+
+async function callValidatedCliTool(name, args) {
+  const normalizedArgs = validateToolArguments(name, args || {});
+  requireUnsafeCommandGate(name, normalizedArgs, boolOption);
+  return await callCliTool(name, normalizedArgs);
 }
 
 function mcpSuccessEnvelope(tool, result) {

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -17,6 +17,13 @@ import { finalizePreview as buildFinalizePreview } from "../lib/finalize-preview
 import { integrationsCommand } from "../lib/integrations.js";
 import { createMcpInterface } from "../lib/mcp-interface.js";
 import {
+  getMcpPrompt,
+  listMcpPrompts,
+  listMcpResourceTemplates,
+  listMcpResources,
+  readMcpResource,
+} from "../lib/mcp-protocol.js";
+import {
   gapCandidates as buildGapCandidates,
   researchRoundGuidance,
   resolveResearchSlugForQualityGapSync,
@@ -1172,6 +1179,14 @@ async function guidedSetup(args: LooseObject): Promise<LooseObject> {
     firstRunChecklist: setup.firstRunChecklist,
     scopeWarnings: setup.scopeWarnings,
     settings: dashboardSettings(config),
+    dashboard: {
+      requested: boolOption(args.startDashboard ?? args.start_dashboard, false),
+      started: false,
+      url: "",
+      healthUrl: "",
+      verified: false,
+      modeGuidance: null,
+    },
     diversityGuidance: state.memory?.diversityGuidance || null,
     lanePortfolio: state.memory?.lanePortfolio || [],
     nextAction,
@@ -4236,7 +4251,7 @@ async function handleMcpMessage(message) {
       id: message.id,
       result: {
         protocolVersion: "2024-11-05",
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, resources: {}, prompts: {} },
         serverInfo: { name: "codex-autoresearch", version: PLUGIN_VERSION },
       },
     });
@@ -4245,6 +4260,49 @@ async function handleMcpMessage(message) {
   if (message.method === "notifications/initialized") return;
   if (message.method === "tools/list") {
     sendMcp({ jsonrpc: "2.0", id: message.id, result: { tools: toolSchemas } });
+    return;
+  }
+
+  if (message.method === "resources/list") {
+    sendMcp({ jsonrpc: "2.0", id: message.id, result: listMcpResources() });
+    return;
+  }
+
+  if (message.method === "resources/templates/list") {
+    sendMcp({ jsonrpc: "2.0", id: message.id, result: listMcpResourceTemplates() });
+    return;
+  }
+
+  if (message.method === "resources/read") {
+    try {
+      const result = await readMcpResource(message.params?.uri, callTool);
+      sendMcp({ jsonrpc: "2.0", id: message.id, result });
+    } catch (error) {
+      sendMcp({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32602, message: error.message || String(error) },
+      });
+    }
+    return;
+  }
+
+  if (message.method === "prompts/list") {
+    sendMcp({ jsonrpc: "2.0", id: message.id, result: listMcpPrompts() });
+    return;
+  }
+
+  if (message.method === "prompts/get") {
+    try {
+      const result = getMcpPrompt(message.params?.name, message.params?.arguments || {});
+      sendMcp({ jsonrpc: "2.0", id: message.id, result });
+    } catch (error) {
+      sendMcp({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32602, message: error.message || String(error) },
+      });
+    }
     return;
   }
   if (message.method === "tools/call") {

--- a/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
+++ b/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
@@ -684,13 +684,13 @@ const checks = [
   },
   {
     id: "full-product-cli-surface",
-    file: "scripts/autoresearch.mjs, lib/cli-handlers.mjs, lib/mcp-interface.mjs, lib/mcp-tool-schemas.ts",
+    file: "scripts/autoresearch.mjs, lib/cli-handlers.mjs, lib/mcp-interface.mjs, lib/mcp-tool-schemas.ts, lib/mcp-protocol.ts",
     description:
       "CLI and MCP expose guided setup, recipes, gap candidates, finalization preview, live mode, and integrations.",
     run: async () => {
       const cli = await readText("scripts/autoresearch.ts");
       const cliHandlers = await readText("lib/cli-handlers.ts");
-      const mcpInterface = `${await readText("lib/mcp-interface.ts")}\n${await readText("lib/mcp-tool-schemas.ts")}`;
+      const mcpInterface = `${await readText("lib/mcp-interface.ts")}\n${await readText("lib/mcp-tool-schemas.ts")}\n${await readText("lib/mcp-protocol.ts")}`;
       return includesAll(cli + cliHandlers + mcpInterface, [
         "setup-plan --cwd <project>",
         "prompt-plan --cwd <project>",
@@ -709,6 +709,11 @@ const checks = [
         "onboarding_packet",
         "recommend_next",
         "serve_dashboard",
+        "resources/list",
+        "resources/templates/list",
+        "prompts/list",
+        "autoresearch://state",
+        "first-valid-loop",
         "benchmark_lint",
         "checks_inspect",
         "new_segment",
@@ -731,6 +736,7 @@ const checks = [
         "lib/mcp-interface.ts",
         "lib/mcp-tool-schemas.ts",
         "lib/mcp-cli-adapter.ts",
+        "lib/mcp-protocol.ts",
         "lib/recipes.ts",
         "lib/dashboard-view-model.ts",
         "lib/research-gaps.ts",
@@ -762,6 +768,8 @@ const checks = [
         "visual aid",
         "Use CLI or MCP",
         "serve_dashboard",
+        "autoresearch://state",
+        "first-valid-loop",
         "recipes",
       ])
         ? pass()
@@ -786,6 +794,9 @@ const checks = [
         "integrations",
         "live server",
         "serve_dashboard",
+        "resources/list",
+        "resources/templates/list",
+        "prompts/get",
       ])
         ? pass()
         : fail("Missing focused full-product regression tests.");

--- a/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
+++ b/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
@@ -20,6 +20,8 @@ Target -> Onboard -> Setup -> Doctor -> Dashboard -> Packet -> Log -> Continue o
 AX, the AI experience:
 
 - Start by getting machine-readable context: MCP `onboarding_packet`, then `recommend_next`, `read_state`, `guided_setup`, or `doctor_session`.
+- Prefer MCP resource templates for read-only session truth when the host supports them: `autoresearch://state{?working_dir}`, `autoresearch://last-run{?working_dir}`, `autoresearch://quality-gaps{?working_dir,research_slug}`, and `autoresearch://dashboard-summary{?working_dir}`.
+- Prefer MCP prompts when available for common handoffs: `first-valid-loop`, `continue-loop`, and `review-last-packet`.
 - When the user gives a broad natural-language goal without a benchmark contract, call MCP `prompt_plan` first. It should infer metric defaults, experiment lanes, safe scope, missing essentials, and the read-only setup path before Codex edits files.
 - If the target repo already has `scripts/autoresearch-*` benchmark scripts, prefer those as the starting benchmark surface. Treat score-like metrics as quality-bearing until the session docs prove otherwise.
 - Prefer MCP tools when available. Use CLI helpers only as the deterministic fallback.
@@ -31,7 +33,7 @@ UX, the user experience:
 
 - Let the user ask in plain language: "Use Codex Autoresearch to improve this repo."
 - Ask only for essentials that materially change setup: goal, benchmark, primary metric, direction, scope, or correctness checks.
-- At session start and resume, start or reuse the live dashboard, verify `GET /health` or equivalent liveness, and directly provide the live dashboard URL after it is verified, normally `http://127.0.0.1:<port>/`. If a prior localhost URL fails, restart `serve` and say the old URL was stale.
+- At session start and resume, call MCP `guided_setup` with `start_dashboard=true` when available, or otherwise start/reuse the live dashboard, verify `GET /health` or equivalent liveness, and directly provide the live dashboard URL after it is verified, normally `http://127.0.0.1:<port>/`. If a prior localhost URL fails, restart `serve` and say the old URL was stale.
 - Report the operator story instead of helper mechanics: what was tried, what the metric means, the keep/discard/crash/checks decision, the next move, blockers, dashboard URL, and verification.
 
 ## Documentation Awareness
@@ -79,6 +81,8 @@ node scripts/autoresearch.mjs serve --cwd <project>
 ```
 
 Over MCP, pass `allow_unsafe_command: true` before materializing custom benchmark/check commands, model commands, or external recipe-catalog commands.
+
+Over MCP, `guided_setup` is read-only by default. Pass `start_dashboard: true` only when the operator wants Codex to start the local live dashboard process and return a verified URL in `dashboard.url`.
 
 ## Active Loop Contract
 

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -89,6 +89,10 @@ async function waitForMcpResponseById(stdoutFn, stderrFn, id) {
 }
 
 async function callMcpTool(name, args) {
+  return await callMcpRequest("tools/call", { name, arguments: args });
+}
+
+async function callMcpRequest(method, params = {}) {
   const child = spawn(process.execPath, [mcpServer], {
     cwd: pluginRoot,
     windowsHide: true,
@@ -114,7 +118,7 @@ async function callMcpTool(name, args) {
       params: { protocolVersion: "2024-11-05", capabilities: {} },
     });
     send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
-    send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name, arguments: args } });
+    send({ jsonrpc: "2.0", id: 2, method, params });
     return await waitForMcpResponseById(
       () => stdout,
       () => stderr,
@@ -2348,10 +2352,14 @@ test("mcp tools/list exposes output contracts and safety annotations", async () 
   const tools = response.result.tools;
   assert.ok(tools.length >= 6);
   const setupPlan = tools.find((tool) => tool.name === "setup_plan");
+  const guidedSetup = tools.find((tool) => tool.name === "guided_setup");
   const nextExperiment = tools.find((tool) => tool.name === "next_experiment");
   const clearSession = tools.find((tool) => tool.name === "clear_session");
   assert.equal(setupPlan.outputSchema.type, "object");
+  assert.equal(setupPlan.inputSchema.properties.start_dashboard, undefined);
   assert.equal(setupPlan.annotations.readOnlyHint, true);
+  assert.equal(guidedSetup.annotations.readOnlyHint, false);
+  assert.equal(guidedSetup.annotations.openWorldHint, true);
   assert.equal(nextExperiment.annotations.readOnlyHint, false);
   assert.equal(nextExperiment.annotations.destructiveHint, false);
   assert.equal(nextExperiment.annotations.openWorldHint, true);
@@ -2393,15 +2401,23 @@ test("mcp tools expose guidance and output contracts", async () => {
     doctor.annotations.safety,
     "Read-only unless benchmark check runs configured commands.",
   );
-  assert.equal(guided.annotations.readOnlyHint, true);
+  assert.equal(
+    guided.annotations.safety,
+    "Read-only by default; starts a local dashboard only when start_dashboard=true.",
+  );
+  assert.equal(guided.annotations.readOnlyHint, false);
+  assert.equal(guided.annotations.openWorldHint, true);
   assert.equal(next.annotations.readOnlyHint, false);
   assert.equal(next.annotations.openWorldHint, true);
 
   const richDoctor = mcpToolSchemasWithContracts.find((tool) => tool.name === "doctor_session");
   assert.equal(richDoctor.outputSchema.type, "object");
   assert.equal(guided.outputSchema.properties.workDir.type, "string");
+  assert.equal(guided.inputSchema.properties.start_dashboard.type, "boolean");
+  assert.equal(guided.inputSchema.properties.port.type, "number");
   assert.equal(guided.outputSchema.properties.commands.type, "array");
   assert.equal(guided.outputSchema.properties.commands.items.type, "string");
+  assert.equal(guided.outputSchema.properties.dashboard.type, "object");
   assert.equal(next.outputSchema.properties.parsedMetrics, undefined);
   assert.equal(next.outputSchema.properties.decision.type, "object");
   assert.equal(richDoctor.outputSchema.properties.issues.type, "array");
@@ -2549,6 +2565,8 @@ test("mcp server dispatches tool calls through the CLI wrapper", async () => {
   child.kill();
 
   assert.equal(init.result.serverInfo.name, "codex-autoresearch");
+  assert.ok(init.result.capabilities.resources);
+  assert.ok(init.result.capabilities.prompts);
   const payload = JSON.parse(tool.result.content[0].text);
   assert.equal(payload.ok, true);
   assert.equal(payload.tool, "setup_plan");
@@ -2569,6 +2587,92 @@ test("mcp server dispatches guided setup through the CLI wrapper", async () => {
     assert.equal(payload.ok, true);
     assert.equal(payload.workDir, dir);
     assert.equal(payload.setup.ok, true);
+    assert.equal(payload.dashboard.requested, false);
+  });
+});
+
+test("mcp guided_setup can explicitly start a verified live dashboard", async () => {
+  await withTempDir("mcp-guided-dashboard", async (dir) => {
+    await runCli([
+      "init",
+      "--cwd",
+      dir,
+      "--name",
+      "mcp guided dashboard",
+      "--metric-name",
+      "seconds",
+    ]);
+    const response = await callMcpTool("guided_setup", {
+      working_dir: dir,
+      start_dashboard: true,
+      port: 0,
+    });
+    assert.equal(response.result?.isError, undefined, response.result?.content?.[0]?.text);
+    const payload = JSON.parse(response.result.content[0].text);
+    assert.equal(payload.dashboard.requested, true);
+    assert.equal(payload.dashboard.started, true);
+    assert.equal(payload.dashboard.verified, true);
+    assert.match(payload.dashboard.url, /^http:\/\/127\.0\.0\.1:/);
+    assert.match(payload.dashboard.healthUrl, /\/health$/);
+  });
+});
+
+test("mcp resources and prompts expose read-only session truth", async () => {
+  await withTempDir("mcp-resources-prompts", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "mcp resources", "--metric-name", "seconds"]);
+    const researchDir = path.join(dir, "autoresearch.research", "resource-study");
+    await mkdir(researchDir, { recursive: true });
+    await writeFile(
+      path.join(researchDir, "quality-gaps.md"),
+      "- [ ] Resource gap\n- [x] Closed resource gap\n",
+      "utf8",
+    );
+
+    const resources = await callMcpRequest("resources/list");
+    assert.equal(resources.result.resources.length, 0);
+
+    const resourceTemplates = await callMcpRequest("resources/templates/list");
+    assert.equal(resourceTemplates.result.resourceTemplates.length, 4);
+    assert.ok(
+      resourceTemplates.result.resourceTemplates.some(
+        (resource) => resource.uriTemplate === "autoresearch://state{?working_dir}",
+      ),
+    );
+
+    const stateUri = `autoresearch://state?working_dir=${encodeURIComponent(dir)}`;
+    const state = await callMcpRequest("resources/read", { uri: stateUri });
+    assert.equal(state.result.contents[0].mimeType, "application/json");
+    const statePayload = JSON.parse(state.result.contents[0].text);
+    assert.equal(statePayload.ok, true);
+    assert.equal(statePayload.workDir, dir);
+
+    const qualityUri = `autoresearch://quality-gaps?working_dir=${encodeURIComponent(dir)}&research_slug=resource-study`;
+    const quality = await callMcpRequest("resources/read", { uri: qualityUri });
+    const qualityPayload = JSON.parse(quality.result.contents[0].text);
+    assert.equal(qualityPayload.open, 1);
+    assert.equal(qualityPayload.closed, 1);
+
+    const dashboardUri = `autoresearch://dashboard-summary?working_dir=${encodeURIComponent(dir)}`;
+    const dashboard = await callMcpRequest("resources/read", { uri: dashboardUri });
+    const dashboardPayload = JSON.parse(dashboard.result.contents[0].text);
+    assert.equal(dashboardPayload.workDir, dir);
+    assert.match(dashboardPayload.dashboardCommand, /serve --cwd/);
+
+    const missing = await callMcpRequest("resources/read", { uri: "autoresearch://state" });
+    assert.equal(missing.error.code, -32602);
+    assert.match(missing.error.message, /working_dir/);
+
+    const prompts = await callMcpRequest("prompts/list");
+    assert.ok(prompts.result.prompts.some((prompt) => prompt.name === "first-valid-loop"));
+
+    const prompt = await callMcpRequest("prompts/get", {
+      name: "first-valid-loop",
+      arguments: { working_dir: dir },
+    });
+    const text = prompt.result.messages[0].content.text;
+    assert.match(text, /guided_setup/);
+    assert.match(text, /start_dashboard=true/);
+    assert.match(text, /autoresearch:\/\/state/);
   });
 });
 

--- a/plugins/codex-autoresearch/tests/full-product.test.ts
+++ b/plugins/codex-autoresearch/tests/full-product.test.ts
@@ -90,6 +90,10 @@ const git = async (cwd, args) => {
 };
 
 async function callMcpTool(name, args) {
+  return await callMcpRequest("tools/call", { name, arguments: args });
+}
+
+async function callMcpRequest(method, params = {}) {
   const child = spawn(process.execPath, [cli, "--mcp"], {
     cwd: pluginRoot,
     windowsHide: true,
@@ -106,8 +110,8 @@ async function callMcpTool(name, args) {
   const request = JSON.stringify({
     jsonrpc: "2.0",
     id: 1,
-    method: "tools/call",
-    params: { name, arguments: args },
+    method,
+    params,
   });
   child.stdin.write(`Content-Length: ${Buffer.byteLength(request, "utf8")}\r\n\r\n${request}`);
   try {
@@ -512,6 +516,32 @@ test("MCP exposes onboarding, prompt planning, benchmark probes, recommend-next,
     });
     assert.equal(promote.result?.isError, undefined, promote.result?.content?.[0]?.text);
     assert.match(promote.result.content[0].text, /"queryCount": 20/);
+  });
+});
+
+test("MCP exposes resource templates and prompts/get for session truth handoffs", async () => {
+  await withTempDir("mcp-resources-prompts", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "mcp resources", "--metric-name", "seconds"]);
+
+    const resources = await callMcpRequest("resources/list");
+    assert.deepEqual(resources.result.resources, []);
+
+    const resourceTemplates = await callMcpRequest("resources/templates/list");
+    assert.ok(
+      resourceTemplates.result.resourceTemplates.some(
+        (resource) => resource.uriTemplate === "autoresearch://state{?working_dir}",
+      ),
+    );
+
+    const stateUri = `autoresearch://state?working_dir=${encodeURIComponent(dir)}`;
+    const state = await callMcpRequest("resources/read", { uri: stateUri });
+    assert.equal(JSON.parse(state.result.contents[0].text).workDir, dir);
+
+    const prompt = await callMcpRequest("prompts/get", {
+      name: "first-valid-loop",
+      arguments: { working_dir: dir },
+    });
+    assert.match(prompt.result.messages[0].content.text, /start_dashboard=true/);
   });
 });
 


### PR DESCRIPTION
## What changed

- Added MCP resources and prompts for Autoresearch session truth, including state, last-run, quality-gap, dashboard-summary, continue-loop, review-last-packet, and first-valid-loop surfaces.
- Extended `guided_setup` so callers can explicitly request live dashboard startup with `start_dashboard`, returning verified dashboard metadata.
- Updated MCP safety annotations, docs, skill guidance, changelog, product benchmark expectations, and regression coverage.
- Bumped public package, plugin manifest, CLI server, and MCP server version surfaces to `1.1.15`.

## Why

This makes the guided first-valid-loop path easier for MCP clients to follow without abusing tools for read-only state inspection, while keeping dashboard startup explicit and honest in the tool metadata.

## Validation

- `npm run check` from `plugins/codex-autoresearch`
- `node scripts/autoresearch.mjs mcp-smoke` from `plugins/codex-autoresearch`

## Notes

- `guided_setup` remains non-mutating by default.
- `start_dashboard=true` is the explicit process-starting path for a verified local dashboard URL.