### PR TITLE
Promote optimized CI workflow to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,10 @@ jobs:
           cache-dependency-path: plugins/codex-autoresearch/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Build node
-        run: npm run build:node
-
-      - name: Build dashboard
-        run: npm run build:dashboard
+        run: npm ci --prefer-offline --no-audit
 
       - name: Run full check gate
         run: npm run check
 
       - name: Run MCP smoke test
         run: node scripts/autoresearch.mjs mcp-smoke
-
-      - name: Run tests
-        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,22 +35,13 @@ jobs:
           cache-dependency-path: plugins/codex-autoresearch/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Build node
-        run: npm run build:node
-
-      - name: Build dashboard
-        run: npm run build:dashboard
+        run: npm ci --prefer-offline --no-audit
 
       - name: Run full check gate
         run: npm run check
 
       - name: Run MCP smoke test
         run: node scripts/autoresearch.mjs mcp-smoke
-
-      - name: Run tests
-        run: npm test
 
   publish:
     needs: test
@@ -78,7 +69,7 @@ jobs:
           cache-dependency-path: plugins/codex-autoresearch/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit
 
       - name: Verify release version
         id: version


### PR DESCRIPTION
## Summary
- promote the optimized CI/release workflow from dev to main
- keeps npm run check as the single full gate and preserves explicit MCP smoke

## Validation
- PR #23 checks passed: Ubuntu 32s, macOS 43s, Windows 1m18s
- local npm run check passed
- local MCP smoke passed
- git diff --check passed