### PR TITLE
Fix shell quote escaping

### DIFF
--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -329,7 +329,7 @@ function safeSlug(value: unknown, fallback = "research"): string {
 }
 
 function shellQuote(value: unknown): string {
-  return `"${String(value).replace(/"/g, '\\"')}"`;
+  return JSON.stringify(String(value));
 }
 
 function slashPath(value: unknown): string {


### PR DESCRIPTION
## What changed

- Uses JSON string encoding for `shellQuote` so backslashes and quotes are escaped consistently.

## Why

CodeQL flagged the previous quote-only escaping in PR #29 as incomplete string escaping. This keeps the `dev` -> `main` promotion unblocked.

## Validation

- `npm run check` from `plugins/codex-autoresearch`
- `git diff --check`

Refs #29