### PR TITLE
[codex] Fix release workflow no-commits false negative

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,5 +136,4 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "$TAG" \
-            --generate-notes \
-            --fail-on-no-commits
+            --generate-notes


### PR DESCRIPTION
## Summary
- remove the `gh release create --fail-on-no-commits` flag from the release workflow
- keep the existing duplicate tag/release guard as the idempotency check

## Why
The v1.3.2 release workflow passed the cross-platform test/package smoke path, then failed at the final release creation step with `no new commits since the last release`. For this manual versioned release workflow, that guard is too brittle: version/tag/release uniqueness is already checked before packing, and a false negative forces a manual release even when the artifact is valid.

## Validation
- `git diff --check`
- parsed `.github/workflows/release.yml` with the `yaml` npm package