### PR TITLE
[codex] Resolve CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable user-facing changes to Codex Autoresearch are recorded here.
 
 This project uses a root-only changelog because the root README is the public documentation surface for the plugin wrapper.
 
-## 1.3.2
+## 1.3.3
 
 ### Fixed
 
@@ -17,7 +17,7 @@ This project uses a root-only changelog because the root README is the public do
 - Removed the MCP server declaration and launcher surface. Codex Autoresearch now runs as a CLI/skill-only plugin to avoid Codex startup hangs from automatic MCP registration.
 - Updated package checks, CI/release smoke tests, docs, and skill guidance to use `node scripts/autoresearch.mjs --help` and normal CLI commands instead of `mcp-smoke`.
 
-Bumped public package and plugin manifest version surfaces to `1.3.2`.
+Bumped public package and plugin manifest version surfaces to `1.3.3`.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses a root-only changelog because the root README is the public do
 
 ### Fixed
 
+- Hardened CI token permissions, generated command display escaping, Markdown table escaping, and live dashboard action error output to resolve CodeQL code-scanning findings.
 - Fixed recipe-backed setup planning so recommended recipes can supply their default benchmark command before missing setup fields are reported.
 - Fixed packet artifact evidence so relative artifact paths are checked against the target working directory instead of the plugin process directory.
 

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "One Codex skill for measured autoresearch loops: set up or resume, run packets, log decisions, use the live dashboard, and finalize kept changes.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/lib/finalize-preview.ts
+++ b/plugins/codex-autoresearch/lib/finalize-preview.ts
@@ -730,7 +730,7 @@ function safeSlug(value: unknown): string {
 function shellQuote(value: unknown): string {
   const text = String(value);
   if (/^--[A-Za-z0-9-]+$/.test(text) || text === "plan") return text;
-  return `"${text.replace(/"/g, '\\"')}"`;
+  return `"${text.replace(/[\\"]/g, "\\$&")}"`;
 }
 
 async function git(args: string[], cwd: string): Promise<GitResult> {

--- a/plugins/codex-autoresearch/lib/live-server.ts
+++ b/plugins/codex-autoresearch/lib/live-server.ts
@@ -184,31 +184,15 @@ export async function serveAutoresearch(args: LooseObject) {
           const result = await runDashboardCliAction(scriptPath, cliArgs, workDir, policy);
           sendJson(res, actionResultEnvelope(action, cliArgs, result), result.timedOut ? 504 : 200);
         } catch (error) {
-          const failure = error as DashboardActionError;
-          sendJson(
-            res,
-            actionErrorEnvelope(
-              action,
-              failure.message || String(failure),
-              failure.code || "dashboard_action_failed",
-            ),
-            failure.statusCode || 500,
-          );
+          const failure = dashboardActionFailure(action, error);
+          sendJson(res, failure.body, failure.status);
         }
         return;
       }
       sendJson(res, { ok: false, error: "Not found" }, 404);
     } catch (error) {
-      const failure = error as DashboardActionError;
-      sendJson(
-        res,
-        actionErrorEnvelope(
-          "dashboard",
-          failure.message || String(failure),
-          failure.code || "dashboard_action_failed",
-        ),
-        failure.statusCode || 500,
-      );
+      const failure = dashboardActionFailure("dashboard", error);
+      sendJson(res, failure.body, failure.status);
     }
   });
   await new Promise<void>((resolve) => {
@@ -537,12 +521,7 @@ async function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<Loo
     return parsed;
   } catch (error) {
     if (error instanceof DashboardActionError) throw error;
-    const message = error instanceof Error ? error.message : String(error);
-    throw new DashboardActionError(
-      `Malformed dashboard action JSON: ${message}`,
-      400,
-      "body_malformed_json",
-    );
+    throw new DashboardActionError("Malformed dashboard action JSON.", 400, "body_malformed_json");
   }
 }
 
@@ -566,6 +545,12 @@ function actionResultEnvelope(
 ): DashboardActionResult {
   const ok = result.exitCode === 0 && !result.timedOut;
   const parsed = parseJsonObject(result.stdout);
+  const stdout = dashboardSafeText(result.stdout || "");
+  const stderr = dashboardSafeText(result.stderr || "");
+  const parsedNextStep =
+    parsed?.continuation?.nextAction ||
+    parsed?.nextAction ||
+    (ok ? "Refresh complete." : "Inspect the action output before retrying.");
   const receipt = {
     ok,
     action,
@@ -581,23 +566,39 @@ function actionResultEnvelope(
     exitCode: result.exitCode,
     timedOut: result.timedOut,
     outputTruncated: result.outputTruncated,
-    stdoutSummary: tailText(result.stdout || "", 10, 4096),
-    stderrSummary: tailText(result.stderr || "", 10, 4096),
+    stdoutSummary: tailText(stdout, 10, 4096),
+    stderrSummary: tailText(stderr, 10, 4096),
     lastRunCleared: parsed?.lastRunCleared,
     ledgerRun: parsed?.run || null,
     nextStep:
-      parsed?.continuation?.nextAction ||
-      parsed?.nextAction ||
-      (ok ? "Refresh complete." : "Inspect the action output before retrying."),
+      typeof parsedNextStep === "string" ? dashboardSafeText(parsedNextStep) : parsedNextStep,
   };
   return {
     ok,
     action,
     receipt,
-    stdout: result.stdout,
-    stderr: result.stderr,
     code: result.exitCode,
     timedOut: result.timedOut,
+  };
+}
+
+function dashboardActionFailure(
+  action: string,
+  error: unknown,
+): { body: DashboardActionResult; status: number } {
+  if (error instanceof DashboardActionError) {
+    return {
+      body: actionErrorEnvelope(action, dashboardSafeText(error.message), error.code),
+      status: error.statusCode,
+    };
+  }
+  return {
+    body: actionErrorEnvelope(
+      action,
+      "Dashboard action failed unexpectedly. Check the server terminal for details.",
+      "dashboard_action_failed",
+    ),
+    status: 500,
   };
 }
 
@@ -622,6 +623,24 @@ function actionErrorEnvelope(
       nextStep: "Refresh the dashboard state before retrying.",
     },
   };
+}
+
+function dashboardSafeText(value: unknown): string {
+  const text = String(value || "");
+  const lines = text.split(/\r?\n/);
+  let omitted = 0;
+  const safeLines = lines.filter((line) => {
+    if (!isStackTraceLine(line)) return true;
+    omitted += 1;
+    return false;
+  });
+  if (omitted === 0) return text;
+  const suffix = `[${omitted} stack trace line${omitted === 1 ? "" : "s"} omitted]`;
+  return [...safeLines, suffix].filter(Boolean).join("\n");
+}
+
+function isStackTraceLine(line: string): boolean {
+  return /^\s*at\s+\S/.test(line) || /^\s*(?:file|node):.+:\d+:\d+/.test(line);
 }
 
 function parseJsonObject(text: string): LooseObject | null {

--- a/plugins/codex-autoresearch/lib/recipes.ts
+++ b/plugins/codex-autoresearch/lib/recipes.ts
@@ -197,7 +197,7 @@ const BUILT_IN_RECIPES: Recipe[] = [
 ];
 
 function quoteCommandArg(value: unknown): string {
-  return `"${String(value).replace(/"/g, '\\"')}"`;
+  return `"${String(value).replace(/[\\"]/g, "\\$&")}"`;
 }
 
 export function listBuiltInRecipes(): Recipe[] {

--- a/plugins/codex-autoresearch/lib/runner.ts
+++ b/plugins/codex-autoresearch/lib/runner.ts
@@ -440,7 +440,7 @@ function processResult({
 
 function shellDisplayPart(value: string): string {
   const text = String(value);
-  return /^[A-Za-z0-9_./:=@-]+$/.test(text) ? text : `"${text.replace(/"/g, '\\"')}"`;
+  return /^[A-Za-z0-9_./:=@-]+$/.test(text) ? text : `"${text.replace(/[\\"]/g, "\\$&")}"`;
 }
 
 function metricLineName(line: string): string {

--- a/plugins/codex-autoresearch/lib/session-core.ts
+++ b/plugins/codex-autoresearch/lib/session-core.ts
@@ -50,7 +50,7 @@ export function safeSlug(value: unknown, fallback = "research"): string {
 }
 
 export function shellQuote(value: unknown): string {
-  return `"${String(value).replace(/"/g, '\\"')}"`;
+  return `"${String(value).replace(/[\\"]/g, "\\$&")}"`;
 }
 
 const METRIC_VALUE_PATTERN = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i;

--- a/plugins/codex-autoresearch/package-lock.json
+++ b/plugins/codex-autoresearch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-autoresearch",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^1.8.0",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Codex plugin for autonomous benchmark and optimization loops.",
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -451,6 +451,7 @@ function shortHash(hash: string): string {
 
 function markdownEscape(text: string): string {
   return String(text || "")
+    .replace(/\\/g, "\\\\")
     .replace(/\|/g, "\\|")
     .replace(/\r?\n/g, "<br>");
 }

--- a/plugins/codex-autoresearch/tests/full-product.test.ts
+++ b/plugins/codex-autoresearch/tests/full-product.test.ts
@@ -7,10 +7,12 @@ import {
   currentState,
   iterationLimitInfo,
   parseQualityGaps,
+  shellQuote as sessionShellQuote,
 } from "../lib/session-core.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
-import { parseMetricLines, runShell, tailText } from "../lib/runner.js";
+import { parseMetricLines, runProcess, runShell, tailText } from "../lib/runner.js";
 import { PLUGIN_VERSION } from "../lib/plugin-version.js";
+import { serveAutoresearch } from "../lib/live-server.js";
 import {
   createCliRunner,
   createInteractiveCliRunner,
@@ -71,6 +73,20 @@ test("session core handles finite metrics, segments, limits, and quality gaps", 
       total: 3,
     });
   });
+});
+
+test("displayed command quoting preserves backslashes before quotes", async () => {
+  const trickyArg = String.raw`C:\tmp"name`;
+  const expectedDisplay = String.raw`"C:\\tmp\"name"`;
+
+  assert.equal(sessionShellQuote(trickyArg), expectedDisplay);
+
+  const result = await runProcess(process.execPath, ["-e", "", trickyArg], {
+    cwd: pluginRoot,
+    timeoutSeconds: 10,
+  });
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.ok(result.commandDisplay.includes(expectedDisplay), result.commandDisplay);
 });
 
 test("runner parses metrics, truncates tails, and reports timeouts", async () => {
@@ -949,6 +965,59 @@ test("live server rejects dashboard actions because CLI owns mutations", async (
       assert.equal(body.ok, false);
       assert.equal(body.code, "actions_disabled");
     });
+  });
+});
+
+test("live server action receipts redact stack traces", async () => {
+  await withTempDir("live-stack-redaction", async (dir) => {
+    const stackScript = path.join(dir, "stack-action.mjs");
+    await writeFile(
+      stackScript,
+      [
+        "console.error('Error: hidden failure');",
+        "console.error('    at leak (file:///C:/secret/live-server.ts:1:2)');",
+        "console.error('    at run (node:internal/modules/run_main:1:2)');",
+        "process.exit(1);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const served = await serveAutoresearch({
+      cwd: dir,
+      port: 0,
+      scriptPath: stackScript,
+      actionsEnabled: true,
+      dashboardHtml: async () => "<html></html>",
+      viewModel: async () => ({ ok: true }),
+    });
+
+    try {
+      const action = await fetch(`${served.url}actions/doctor`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-autoresearch-action-nonce": served.actionNonce,
+          Origin: new URL(served.url).origin,
+        },
+        body: JSON.stringify({}),
+      });
+      assert.equal(action.status, 200);
+      const body = await action.json();
+      assert.equal(body.ok, false);
+      assert.equal(body.receipt.status, "failed");
+      assert.match(body.receipt.stderrSummary, /Error: hidden failure/);
+      assert.match(body.receipt.stderrSummary, /2 stack trace lines omitted/);
+      assert.equal("stdout" in body, false);
+      assert.equal("stderr" in body, false);
+      const serialized = JSON.stringify(body);
+      assert.doesNotMatch(serialized, /at leak/);
+      assert.doesNotMatch(serialized, /node:internal/);
+      assert.doesNotMatch(serialized, /file:\/\/\/C:\/secret/);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        served.server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add least-privilege `contents: read` permissions to CI
- harden generated command and Markdown escaping for backslashes before metacharacters
- redact stack-trace lines from live dashboard action receipts and stop returning raw action stdout/stderr
- bump Codex Autoresearch patch surfaces to `1.3.3`

## Root cause
CodeQL flagged several display-oriented sanitizers that escaped quotes or table pipes without first escaping backslashes. It also flagged live dashboard action responses because raw exception or CLI output could expose stack-trace details back to the browser.

## Validation
- `node --test dist/tests/full-product.test.mjs`
- `npm run check`
- `git diff --check`