### PR TITLE
[codex] Add auto release on version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,100 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - plugins/codex-autoresearch/package.json
+      - plugins/codex-autoresearch/package-lock.json
+      - plugins/codex-autoresearch/.codex-plugin/plugin.json
+      - CHANGELOG.md
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  detect-version:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.version.outputs.should_release }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compare package versions
+        id: version
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          package_path="plugins/codex-autoresearch/package.json"
+          lock_path="plugins/codex-autoresearch/package-lock.json"
+          manifest_path="plugins/codex-autoresearch/.codex-plugin/plugin.json"
+
+          echo "Comparing $BEFORE_SHA to $AFTER_SHA."
+
+          read_json_version() {
+            node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(data.version || '');" "$1"
+          }
+
+          read_lock_root_version() {
+            node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log((data.packages && data.packages[''] && data.packages[''].version) || '');" "$1"
+          }
+
+          new_version="$(read_json_version "$package_path")"
+          old_version=""
+
+          if [[ -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
+            old_package="$RUNNER_TEMP/old-package.json"
+            if git show "$BEFORE_SHA:$package_path" > "$old_package" 2>/dev/null; then
+              old_version="$(read_json_version "$old_package")"
+            fi
+          fi
+
+          echo "Previous package version: ${old_version:-<missing>}"
+          echo "Current package version: $new_version"
+
+          if [ "$old_version" = "$new_version" ]; then
+            echo "Package version did not change; skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "version=$new_version" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ ! "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Package version must look like 1.2.3, got $new_version."
+            exit 1
+          fi
+
+          lock_version="$(read_json_version "$lock_path")"
+          lock_root_version="$(read_lock_root_version "$lock_path")"
+          manifest_version="$(read_json_version "$manifest_path")"
+
+          if [ "$new_version" != "$lock_version" ] || [ "$new_version" != "$lock_root_version" ] || [ "$new_version" != "$manifest_version" ]; then
+            echo "::error::Version surfaces are not synchronized. package.json=$new_version package-lock.json=$lock_version package-lock root=$lock_root_version plugin.json=$manifest_version."
+            exit 1
+          fi
+
+          echo "Detected release version $new_version."
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Release
+    needs: detect-version
+    if: needs.detect-version.outputs.should_release == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.detect-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version from plugins/codex-autoresearch/package.json, for example 1.1.12'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -83,9 +89,11 @@ jobs:
             exit 1
           fi
           package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+          lock_version="$(node -p "JSON.parse(require('fs').readFileSync('package-lock.json', 'utf8')).version")"
+          lock_root_version="$(node -p "JSON.parse(require('fs').readFileSync('package-lock.json', 'utf8')).packages[''].version")"
           manifest_version="$(node -p "JSON.parse(require('fs').readFileSync('.codex-plugin/plugin.json', 'utf8')).version")"
-          if [ "$version" != "$package_version" ] || [ "$version" != "$manifest_version" ]; then
-            echo "::error::Input version $version does not match package.json $package_version and plugin.json $manifest_version."
+          if [ "$version" != "$package_version" ] || [ "$version" != "$lock_version" ] || [ "$version" != "$lock_root_version" ] || [ "$version" != "$manifest_version" ]; then
+            echo "::error::Input version $version does not match package.json $package_version, package-lock.json $lock_version, package-lock root $lock_root_version, and plugin.json $manifest_version."
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -75,15 +75,15 @@ node scripts/autoresearch.mjs export --cwd examples/demo-session --output autore
 
 Before publishing, inspect the package artifact itself. The shipped `scripts/*.mjs` shims depend on `dist/`, but `dist/` is generated and ignored in the Git tree. If a Git marketplace source checkout is missing `dist/`, the CLI launcher downloads and extracts the matching GitHub release tarball into the plugin cache before importing the runtime. A publishable release tarball must include the built runtime, exclude authored source and tests, ship no MCP launcher/config, and pass `node <extracted-package>/scripts/autoresearch.mjs --help`.
 
-Do not push release tags by hand. After the version bump lands on `main`, run the `Release` GitHub Actions workflow manually with the package version. The workflow runs the checks, builds and smoke-tests the tarball, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. This keeps update clients on the previous release until the new install artifact exists.
+Do not push release tags by hand. After a synchronized version bump lands on `main`, the `Auto Release` GitHub Actions workflow compares the previous and current package versions and calls the reusable `Release` workflow when the package version changed. The release workflow still runs the checks, builds and smoke-tests the tarball, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. Use manual `Release` dispatch only as an explicit recovery path with the package version. This keeps update clients on the previous release until the new install artifact exists.
 
 ## Version Surfaces
 
 For a version bump, update all version surfaces together:
 
 - `plugins/codex-autoresearch/package.json`
+- `plugins/codex-autoresearch/package-lock.json`
 - `plugins/codex-autoresearch/.codex-plugin/plugin.json`
-- `plugins/codex-autoresearch/scripts/autoresearch.mjs` `serverInfo.version`
 - root `CHANGELOG.md`
 - any tests or docs that intentionally assert or display the version
 


### PR DESCRIPTION
## What changed

- Added an `Auto Release` workflow that runs on release-adjacent pushes to `main`, compares the previous and current package versions, and skips when `package.json` did not change.
- Made the existing `Release` workflow reusable with `workflow_call` while keeping manual dispatch as a recovery path.
- Tightened release version validation to include `package-lock.json` and updated the maintainer runbook for the automatic release path.

## Why

A release should happen only after a synchronized version bump reaches `main`, while keeping the existing release workflow as the single build, pack, smoke-test, tag, and GitHub release engine.

## Validation

- `npx --yes github-actionlint .github/workflows/ci.yml .github/workflows/main-branch-source-guard.yml .github/workflows/release.yml .github/workflows/auto-release.yml`
- `git diff --check`
- `node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('plugins/codex-autoresearch/package.json','utf8')); const lock=JSON.parse(fs.readFileSync('plugins/codex-autoresearch/package-lock.json','utf8')); const manifest=JSON.parse(fs.readFileSync('plugins/codex-autoresearch/.codex-plugin/plugin.json','utf8')); if (pkg.version !== lock.version || pkg.version !== lock.packages[''].version || pkg.version !== manifest.version) process.exit(1); console.log(pkg.version);"`
- `npm run check` from `plugins/codex-autoresearch`