### PR TITLE
[codex] Fix evidence redaction CodeQL alert

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/plugins/codex-autoresearch/lib/evidence-redaction.ts
+++ b/plugins/codex-autoresearch/lib/evidence-redaction.ts
@@ -10,8 +10,8 @@ const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/\-=]{12,}/gi;
 const URL_CREDENTIALS = /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/gi;
 const WINDOWS_HOME = /[A-Za-z]:\\Users\\[^\\\s"'<>]+/g;
 const POSIX_HOME = /\/(?:Users|home)\/[^/\s"'<>]+/g;
-const ENV_FILE_PATH =
-  /(?:[A-Za-z]:\\|\/|\.{1,2}[\\/])(?:[^\s"'<>|]+[\\/])*\.?env(?:\.[A-Za-z0-9_-]+)?/gi;
+const TOKEN = /[^\s"'<>|]+/g;
+const TRAILING_ENV_TOKEN_PUNCTUATION = new Set([")", ",", ".", ";", ":"]);
 const SENSITIVE_VALUE_KEYS = new Set([
   "apikey",
   "accesstoken",
@@ -48,7 +48,7 @@ export function redactEvidenceText(value: unknown, context: LooseObject = {}): s
   text = text.replace(SECRET_ASSIGNMENT, (_match, key) => `${key}=<redacted>`);
   text = text.replace(BEARER_TOKEN, "Bearer <redacted>");
   text = text.replace(SECRET_PHRASE, (_match, key) => `${key} <redacted>`);
-  text = text.replace(ENV_FILE_PATH, "<env-file>");
+  text = redactEnvFileTokens(text);
   text = text.replace(WINDOWS_HOME, "C:\\Users\\<user>");
   text = text.replace(POSIX_HOME, (match) =>
     match.startsWith("/Users/") ? "/Users/<user>" : "/home/<user>",
@@ -57,6 +57,26 @@ export function redactEvidenceText(value: unknown, context: LooseObject = {}): s
     text = text.split(String(context.workDir)).join("<workdir>");
   }
   return text;
+}
+
+function redactEnvFileTokens(text: string): string {
+  return text.replace(TOKEN, (token) => {
+    const { core, suffix } = splitTrailingEnvTokenPunctuation(token);
+    return isEnvFileToken(core) ? `<env-file>${suffix}` : token;
+  });
+}
+
+function splitTrailingEnvTokenPunctuation(token: string): { core: string; suffix: string } {
+  let end = token.length;
+  while (end > 0 && TRAILING_ENV_TOKEN_PUNCTUATION.has(token[end - 1] || "")) {
+    end -= 1;
+  }
+  return { core: token.slice(0, end), suffix: token.slice(end) };
+}
+
+function isEnvFileToken(token: string): boolean {
+  const normalized = token.replace(/\\/g, "/");
+  return /(^|[=/])\.env(\.[A-Za-z0-9_-]+)?$/.test(normalized);
 }
 
 function isSensitiveEvidenceKey(key: unknown): boolean {

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -188,6 +188,8 @@ test("evidence redactor hides secrets, credentials, home paths, and env files", 
     "https://user:pass@example.test/path",
     "C:\\Users\\albert\\project\\.env.local",
     "/home/albert/project/.env",
+    "--packet-env-file=.env.production",
+    `/${"!/".repeat(200)}not-env`,
     "/Users/albert/project/file.txt",
   ].join("\n");
   const redacted = redactCommandDisplay(text);
@@ -196,6 +198,7 @@ test("evidence redactor hides secrets, credentials, home paths, and env files", 
   assert.doesNotMatch(redacted, /sk-test/);
   assert.doesNotMatch(redacted, /user:pass/);
   assert.doesNotMatch(redacted, /albert/);
+  assert.doesNotMatch(redacted, /\.env\.production/);
   assert.match(redacted, /<redacted>|<credentials>|<env-file>|<user>/);
 
   const object = redactEvidenceObject({


### PR DESCRIPTION
Fixes the CodeQL regex alert that surfaced on the dev-to-main promotion PR and makes CodeQL coverage explicit for both release branches.

Changes:
- Replace the env-file path regex with token classification to avoid pathological backtracking.
- Add a regression case for the flagged adversarial input and CLI env-file argument redaction.
- Add a checked-in CodeQL workflow that runs on push and pull_request for both dev and main, so dev PRs get the same CodeQL coverage as main PRs.
- Replaced repo CodeQL default setup with this explicit workflow because GitHub rejects advanced workflow uploads while default setup is configured.

Validation:
- npm run build:node
- node --test dist/tests/evidence-core.test.mjs
- node --check dist/lib/evidence-redaction.mjs
- npm run check
- git diff --check
- GitHub PR checks: CI matrix, CodeQL aggregate, Analyze (actions), Analyze (javascript-typescript)