### PR TITLE
Add session forensics context capsule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project uses a root-only changelog because the root README is the public do
 
 - Added `codex-goal-brief` / `codex_goal_bridge`, a read-only Codex Goal bridge that turns Autoresearch state into a Goal objective draft, completion audit, and explicit ownership boundary.
 - Added durable `goal` state in config/readouts plus `goalAdvice` in the decision envelope so resumed loops keep the objective visible without relying on chat memory.
+- Added `session-forensics` / `session_forensics`, a safe import path for long Codex session JSONL that writes bounded session digests, quality-gap candidates, decision notes, and evidence-index claims into `autoresearch.research/<slug>/`.
+- Added shared decision thresholds, safe research-slug path guards, and canonical `context-distillation` next-action guidance for sessions that exceed compaction, token, tool-call, polling, or output-budget limits.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ Codex Autoresearch helps Codex:
 1. identify the target repo or child package
 2. check for an existing session
 3. preserve the goal as machine-readable session state
-4. return a shared next-step contract with stage, reason, CLI command, safety, and missing essentials
-5. verify the benchmark contract
-6. run a measured packet with command identity, output tails, metrics, artifacts, checks, and a freshness fingerprint
-7. log the result as `keep`, `discard`, `crash`, or `checks_failed`
-8. preserve ASI, packet fingerprints, promotion labels, and metrics in durable files
-9. continue safely or preview finalization into reviewable branches
+4. import bounded forensics from long Codex sessions into durable research notes when context loss becomes the bottleneck
+5. return a shared next-step contract with stage, reason, CLI command, safety, and missing essentials
+6. verify the benchmark contract
+7. run a measured packet with command identity, output tails, metrics, artifacts, checks, and a freshness fingerprint
+8. log the result as `keep`, `discard`, `crash`, or `checks_failed`
+9. preserve ASI, packet fingerprints, promotion labels, and metrics in durable files
+10. continue safely or preview finalization into reviewable branches
 
 When you use Codex Goal mode, `codex-goal-brief` turns Autoresearch state into a Goal objective draft and completion audit. It does not mutate Codex Goal state. That boundary matters; otherwise everything starts wearing a fake mustache and calling itself done.
 

--- a/plugins/codex-autoresearch/docs/architecture.md
+++ b/plugins/codex-autoresearch/docs/architecture.md
@@ -11,10 +11,12 @@ flowchart TD
   A["Future AI / resumed context"] --> S
   S --> CLI["CLI commands"]
   CLI --> GoalBridge["codex-goal-brief"]
+  CLI --> Forensics["session-forensics"]
   CLI --> H["cli-handlers"]
   GoalBridge --> Files
+  Forensics --> Files
   H --> Core["session, runner, recipes, dashboard view-model"]
-  Core --> Files["autoresearch.md / jsonl / config / ideas / research"]
+  Core --> Files["autoresearch.md / jsonl / config / ideas / research / evidence index"]
   Core --> Dash["Live readout server"]
   Dash --> Browser["Human-readable readout"]
 ```

--- a/plugins/codex-autoresearch/docs/operate.md
+++ b/plugins/codex-autoresearch/docs/operate.md
@@ -25,6 +25,15 @@ Read existing files before editing:
 - `autoresearch.ideas.md`
 - `autoresearch.research/<slug>/` for research loops
 
+When the best evidence lives in a previous Codex session JSONL, import only a bounded capsule:
+
+```bash
+node scripts/autoresearch.mjs session-forensics --cwd <project> --session-jsonl <path> --research-slug <slug> --dry-run
+node scripts/autoresearch.mjs session-forensics --cwd <project> --session-jsonl <path> --research-slug <slug> --apply
+```
+
+The command writes `session-digest.md`, `decisions.jsonl`, `quality-gaps.md`, and `evidence-index.json` under `autoresearch.research/<slug>/`. Leave snippets off by default so transcript bodies do not become durable session state.
+
 ## Dashboard
 
 Serve the live local readout:

--- a/plugins/codex-autoresearch/lib/cli-handlers.ts
+++ b/plugins/codex-autoresearch/lib/cli-handlers.ts
@@ -142,6 +142,18 @@ export function createCliCommandHandlers(deps: LooseObject): Record<string, CliH
         completionConfirmed: args.completionConfirmed,
       }),
     }),
+    "session-forensics": async (args) => ({
+      result: await deps.sessionForensics({
+        cwd: args.cwd,
+        sessionJsonl: args.sessionJsonl,
+        researchSlug: args.researchSlug,
+        dryRun: args.dryRun,
+        apply: args.apply,
+        allowSnippets: args.allowSnippets,
+        maxSnippets: args.maxSnippets,
+        maxSnippetChars: args.maxSnippetChars,
+      }),
+    }),
     recipes: async (args) => ({
       result: await deps.recipeCommand(args._[1] || "list", args),
     }),

--- a/plugins/codex-autoresearch/lib/context-capsule.ts
+++ b/plugins/codex-autoresearch/lib/context-capsule.ts
@@ -1,0 +1,172 @@
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import {
+  evidenceClaim,
+  mergeEvidenceClaims,
+  type EvidenceClaim,
+  type EvidenceIndex,
+} from "./evidence-index.js";
+import { resolveSafeResearchPath } from "./research-path-guard.js";
+import { type SessionForensicsSummary } from "./session-forensics.js";
+
+export interface ContextCapsuleWriteOptions {
+  cwd: string;
+  researchSlug: string;
+  summary: SessionForensicsSummary;
+  apply: boolean;
+}
+
+export interface ContextCapsuleResult {
+  dryRun: boolean;
+  outputDir: string;
+  files: string[];
+  warnings: string[];
+  evidenceIndex?: EvidenceIndex;
+}
+
+const CAPSULE_FILES = [
+  "session-digest.md",
+  "decisions.jsonl",
+  "quality-gaps.md",
+  "evidence-index.json",
+];
+
+export async function writeContextCapsule(
+  options: ContextCapsuleWriteOptions,
+): Promise<ContextCapsuleResult> {
+  const safe = await resolveSafeResearchPath(options.cwd, options.researchSlug);
+  const files = CAPSULE_FILES.map((file) => path.join(safe.outputDir, file));
+  if (!options.apply) {
+    return { dryRun: true, outputDir: safe.outputDir, files, warnings: [] };
+  }
+  const claims = claimsForSummary(options.summary);
+  const digest = digestMarkdown(options.summary, claims);
+  const gaps = qualityGapsMarkdown(options.summary, claims);
+  await fsp.mkdir(safe.outputDir, { recursive: true });
+  await appendMarkdown(path.join(safe.outputDir, "session-digest.md"), digest);
+  await appendJsonl(path.join(safe.outputDir, "decisions.jsonl"), {
+    type: "session_forensics_import",
+    sourcePath: options.summary.sourcePath,
+    importedAt: new Date().toISOString(),
+    claimIds: claims.map((claim) => claim.id),
+  });
+  await appendMarkdown(path.join(safe.outputDir, "quality-gaps.md"), gaps);
+  const evidenceIndex = await mergeEvidenceClaims(options.cwd, safe.slug, claims);
+  return { dryRun: false, outputDir: safe.outputDir, files, warnings: [], evidenceIndex };
+}
+
+function claimsForSummary(summary: SessionForensicsSummary): EvidenceClaim[] {
+  const source = summary.sourcePath;
+  const signals = [
+    ...summary.userCorrections,
+    ...summary.productSignals,
+    ...summary.repeatedFamilies,
+    ...summary.workflowWaste,
+    ...summary.blockers,
+  ];
+  const claims = signals.slice(0, 40).map((signal) =>
+    evidenceClaim({
+      claim: `${signal.kind}: ${signal.message}`,
+      source,
+      evidenceType: "session",
+      freshness: "current",
+      confidence: signal.severity === "blocker" ? "high" : "medium",
+      promotionRelevance: "diagnostic",
+    }),
+  );
+  claims.unshift(
+    evidenceClaim({
+      claim: `Session import covered ${summary.counts.response_item || 0} response items and ${summary.compactions} compactions.`,
+      source,
+      evidenceType: "session",
+      freshness: "current",
+      confidence: "high",
+      promotionRelevance: "diagnostic",
+    }),
+  );
+  return dedupeClaims(claims);
+}
+
+function digestMarkdown(summary: SessionForensicsSummary, claims: EvidenceClaim[]): string {
+  const topTools = topEntries(summary.toolCounts, 8);
+  const topCommands = topEntries(summary.commandClasses, 8);
+  return [
+    `## Session Forensics Import - ${new Date().toISOString()}`,
+    "",
+    `Source: \`${summary.sourcePath}\``,
+    `Window: ${summary.timeWindow.first || "unknown"} to ${summary.timeWindow.last || "unknown"}`,
+    `Compactions: ${summary.compactions}`,
+    `Goal: ${summary.goal.status || "unknown"}; tokens=${summary.goal.tokensUsed ?? "unknown"}; seconds=${summary.goal.timeUsedSeconds ?? "unknown"}`,
+    "",
+    "### Counts",
+    "",
+    `- Event types: ${JSON.stringify(summary.counts)}`,
+    `- Response item types: ${JSON.stringify(summary.responseCounts)}`,
+    `- Top tools: ${JSON.stringify(Object.fromEntries(topTools))}`,
+    `- Top command heads: ${JSON.stringify(Object.fromEntries(topCommands))}`,
+    "",
+    "### Evidence Claims",
+    "",
+    ...claims.map((claim) => `- [evidence:${claim.id}] ${claim.claim}`),
+    "",
+  ].join("\n");
+}
+
+function qualityGapsMarkdown(summary: SessionForensicsSummary, claims: EvidenceClaim[]): string {
+  const signals = [
+    ...summary.productSignals,
+    ...summary.workflowWaste,
+    ...summary.blockers,
+    ...summary.userCorrections,
+  ].slice(0, 24);
+  if (!signals.length) {
+    return [
+      `## Imported Session Quality Gaps - ${new Date().toISOString()}`,
+      "",
+      "- [x] No imported quality gaps were detected by the allowlist parser.",
+      "",
+    ].join("\n");
+  }
+  const claimByMessage = new Map(claims.map((claim) => [claim.claim, claim.id]));
+  return [
+    `## Imported Session Quality Gaps - ${new Date().toISOString()}`,
+    "",
+    ...signals.map((signal) => {
+      const claim = `Claim from ${signal.kind}: ${signal.message}`;
+      const claimId =
+        claimByMessage.get(`${signal.kind}: ${signal.message}`) ||
+        claimByMessage.get(claim) ||
+        "missing";
+      return `- [ ] ${signal.kind}: ${signal.message} [evidence:${claimId}]`;
+    }),
+    "",
+  ].join("\n");
+}
+
+async function appendMarkdown(filePath: string, text: string) {
+  const existing = await fsp.readFile(filePath, "utf8").catch(() => "");
+  const prefix = existing.trim() ? "\n\n" : "";
+  await fsp.writeFile(filePath, `${existing}${prefix}${text}`);
+}
+
+async function appendJsonl(filePath: string, value: unknown) {
+  await fsp.appendFile(filePath, `${JSON.stringify(value)}\n`);
+}
+
+function topEntries(values: Record<string, number>, limit: number): [string, number][] {
+  return Object.entries(values)
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, limit);
+}
+
+function dedupeClaims(claims: EvidenceClaim[]): EvidenceClaim[] {
+  const seen = new Set<string>();
+  const out = [];
+  for (const claim of claims) {
+    if (seen.has(claim.id)) continue;
+    seen.add(claim.id);
+    out.push(claim);
+  }
+  return out;
+}

--- a/plugins/codex-autoresearch/lib/decision-thresholds.ts
+++ b/plugins/codex-autoresearch/lib/decision-thresholds.ts
@@ -1,0 +1,107 @@
+export interface DecisionThresholdConfig {
+  compactions: number;
+  goalTokensUsed: number;
+  goalTimeUsedSeconds: number;
+  functionCalls: number;
+  shellPolls: number;
+  rejectedOrRegressedRunsInFamily: number;
+  repeatedSmallProbeWindow: number;
+  repeatedSmallProbeMinimum: number;
+  shelfRelativeEpsilon: number;
+  outputCommandTokenBudget: number;
+  outputCommandLineBudget: number;
+  outputSegmentTokenBudget: number;
+  repeatedCommandHeadCount: number;
+  repeatedCheckHeadCount: number;
+  segmentVisibleLabelChars: number;
+}
+
+export const DEFAULT_DECISION_THRESHOLDS: DecisionThresholdConfig = {
+  compactions: 3,
+  goalTokensUsed: 1_000_000,
+  goalTimeUsedSeconds: 14_400,
+  functionCalls: 500,
+  shellPolls: 50,
+  rejectedOrRegressedRunsInFamily: 3,
+  repeatedSmallProbeWindow: 6,
+  repeatedSmallProbeMinimum: 4,
+  shelfRelativeEpsilon: 0.001,
+  outputCommandTokenBudget: 20_000,
+  outputCommandLineBudget: 500,
+  outputSegmentTokenBudget: 100_000,
+  repeatedCommandHeadCount: 10,
+  repeatedCheckHeadCount: 5,
+  segmentVisibleLabelChars: 48,
+};
+
+export function resolveDecisionThresholds(
+  config: Record<string, unknown> = {},
+): DecisionThresholdConfig {
+  const nested =
+    config.decisionThresholds && typeof config.decisionThresholds === "object"
+      ? (config.decisionThresholds as Record<string, unknown>)
+      : {};
+  const merged = { ...config, ...nested };
+  return {
+    compactions: positiveInt(merged.compactions, DEFAULT_DECISION_THRESHOLDS.compactions),
+    goalTokensUsed: positiveInt(merged.goalTokensUsed, DEFAULT_DECISION_THRESHOLDS.goalTokensUsed),
+    goalTimeUsedSeconds: positiveInt(
+      merged.goalTimeUsedSeconds,
+      DEFAULT_DECISION_THRESHOLDS.goalTimeUsedSeconds,
+    ),
+    functionCalls: positiveInt(merged.functionCalls, DEFAULT_DECISION_THRESHOLDS.functionCalls),
+    shellPolls: positiveInt(merged.shellPolls, DEFAULT_DECISION_THRESHOLDS.shellPolls),
+    rejectedOrRegressedRunsInFamily: positiveInt(
+      merged.rejectedOrRegressedRunsInFamily,
+      DEFAULT_DECISION_THRESHOLDS.rejectedOrRegressedRunsInFamily,
+    ),
+    repeatedSmallProbeWindow: positiveInt(
+      merged.repeatedSmallProbeWindow,
+      DEFAULT_DECISION_THRESHOLDS.repeatedSmallProbeWindow,
+    ),
+    repeatedSmallProbeMinimum: positiveInt(
+      merged.repeatedSmallProbeMinimum,
+      DEFAULT_DECISION_THRESHOLDS.repeatedSmallProbeMinimum,
+    ),
+    shelfRelativeEpsilon: positiveNumber(
+      merged.shelfRelativeEpsilon,
+      DEFAULT_DECISION_THRESHOLDS.shelfRelativeEpsilon,
+    ),
+    outputCommandTokenBudget: positiveInt(
+      merged.outputCommandTokenBudget,
+      DEFAULT_DECISION_THRESHOLDS.outputCommandTokenBudget,
+    ),
+    outputCommandLineBudget: positiveInt(
+      merged.outputCommandLineBudget,
+      DEFAULT_DECISION_THRESHOLDS.outputCommandLineBudget,
+    ),
+    outputSegmentTokenBudget: positiveInt(
+      merged.outputSegmentTokenBudget,
+      DEFAULT_DECISION_THRESHOLDS.outputSegmentTokenBudget,
+    ),
+    repeatedCommandHeadCount: positiveInt(
+      merged.repeatedCommandHeadCount,
+      DEFAULT_DECISION_THRESHOLDS.repeatedCommandHeadCount,
+    ),
+    repeatedCheckHeadCount: positiveInt(
+      merged.repeatedCheckHeadCount,
+      DEFAULT_DECISION_THRESHOLDS.repeatedCheckHeadCount,
+    ),
+    segmentVisibleLabelChars: positiveInt(
+      merged.segmentVisibleLabelChars,
+      DEFAULT_DECISION_THRESHOLDS.segmentVisibleLabelChars,
+    ),
+  };
+}
+
+function positiveInt(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}

--- a/plugins/codex-autoresearch/lib/evidence-index.ts
+++ b/plugins/codex-autoresearch/lib/evidence-index.ts
@@ -1,0 +1,190 @@
+import { createHash } from "node:crypto";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { resolveSafeResearchPath } from "./research-path-guard.js";
+
+export interface EvidenceIndex {
+  schemaVersion: 1;
+  claims: EvidenceClaim[];
+}
+
+export interface EvidenceClaim {
+  id: string;
+  claim: string;
+  source: string;
+  evidenceType: "session" | "benchmark-artifact" | "commit" | "doc" | "test" | "manual-report";
+  freshness: "current" | "historical" | "stale" | "unknown";
+  confidence: "low" | "medium" | "high";
+  promotionRelevance: "none" | "diagnostic" | "setup-gate" | "promotion-gate";
+  validatedBy?: string;
+}
+
+export interface EvidenceClaimSummary {
+  id: string;
+  claim: string;
+  evidenceType: EvidenceClaim["evidenceType"];
+  confidence: EvidenceClaim["confidence"];
+  promotionRelevance: EvidenceClaim["promotionRelevance"];
+}
+
+export function claimIdFor(input: { claim: string; source: string }): string {
+  const normalized = `${normalize(input.claim)}\n${normalize(input.source)}`;
+  return `ev-${createHash("sha256").update(normalized).digest("hex").slice(0, 12)}`;
+}
+
+export async function readEvidenceIndex(cwd: string, slug: string): Promise<EvidenceIndex> {
+  const { outputDir } = await resolveSafeResearchPath(cwd, slug);
+  const filePath = path.join(outputDir, "evidence-index.json");
+  try {
+    return normalizeEvidenceIndex(JSON.parse(await fsp.readFile(filePath, "utf8")));
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return emptyEvidenceIndex();
+    throw new Error(`Invalid evidence-index.json: ${error.message || error}`);
+  }
+}
+
+export async function mergeEvidenceClaims(
+  cwd: string,
+  slug: string,
+  claims: EvidenceClaim[],
+): Promise<EvidenceIndex> {
+  const { outputDir } = await resolveSafeResearchPath(cwd, slug);
+  const current = await readEvidenceIndex(cwd, slug);
+  const byId = new Map(current.claims.map((claim) => [claim.id, claim]));
+  for (const claim of claims.map(normalizeEvidenceClaim)) {
+    const existing = byId.get(claim.id);
+    if (existing && !sameClaimIdentity(existing, claim)) {
+      throw new Error(`Evidence claim id collision for ${claim.id}`);
+    }
+    byId.set(claim.id, existing ? mergeClaim(existing, claim) : claim);
+  }
+  const index = normalizeEvidenceIndex({
+    schemaVersion: 1,
+    claims: [...byId.values()].sort((left, right) => left.id.localeCompare(right.id)),
+  });
+  await fsp.mkdir(outputDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(outputDir, "evidence-index.json"),
+    `${JSON.stringify(index, null, 2)}\n`,
+  );
+  return index;
+}
+
+export function validateClaimReferences(markdown: string, index: EvidenceIndex): string[] {
+  const known = new Set(index.claims.map((claim) => claim.id));
+  const missing = new Set<string>();
+  const pattern = /\[evidence:([a-z0-9-]+)\]|\bevidence:([a-z0-9-]+)\b/g;
+  for (const match of String(markdown || "").matchAll(pattern)) {
+    const id = match[1] || match[2];
+    if (id && !known.has(id)) missing.add(id);
+  }
+  return [...missing].sort();
+}
+
+export function compactEvidenceSummaries(index: EvidenceIndex): EvidenceClaimSummary[] {
+  return normalizeEvidenceIndex(index).claims.map((claim) => ({
+    id: claim.id,
+    claim: claim.claim,
+    evidenceType: claim.evidenceType,
+    confidence: claim.confidence,
+    promotionRelevance: claim.promotionRelevance,
+  }));
+}
+
+export function evidenceClaim(input: Omit<EvidenceClaim, "id"> & { id?: string }): EvidenceClaim {
+  return normalizeEvidenceClaim({
+    ...input,
+    id: input.id || claimIdFor({ claim: input.claim, source: input.source }),
+  });
+}
+
+function emptyEvidenceIndex(): EvidenceIndex {
+  return { schemaVersion: 1, claims: [] };
+}
+
+function normalizeEvidenceIndex(value: any): EvidenceIndex {
+  if (!value || typeof value !== "object") return emptyEvidenceIndex();
+  if (value.schemaVersion !== 1) {
+    if (value.claims == null) return emptyEvidenceIndex();
+    throw new Error(`unsupported schema version ${value.schemaVersion}`);
+  }
+  const claims = Array.isArray(value.claims) ? value.claims.map(normalizeEvidenceClaim) : [];
+  const seen = new Set<string>();
+  for (const claim of claims) {
+    if (seen.has(claim.id)) throw new Error(`duplicate evidence claim id ${claim.id}`);
+    seen.add(claim.id);
+  }
+  return { schemaVersion: 1, claims };
+}
+
+function normalizeEvidenceClaim(value: any): EvidenceClaim {
+  const claim = String(value?.claim || "").trim();
+  const source = String(value?.source || "").trim();
+  if (!claim) throw new Error("evidence claim is required");
+  if (!source) throw new Error("evidence source is required");
+  const id = String(value?.id || claimIdFor({ claim, source })).trim();
+  if (!/^ev-[a-f0-9]{12}$/.test(id)) throw new Error(`invalid evidence claim id: ${id}`);
+  return {
+    id,
+    claim,
+    source,
+    evidenceType: enumValue(value.evidenceType, [
+      "session",
+      "benchmark-artifact",
+      "commit",
+      "doc",
+      "test",
+      "manual-report",
+    ]),
+    freshness: enumValue(value.freshness, ["current", "historical", "stale", "unknown"]),
+    confidence: enumValue(value.confidence, ["low", "medium", "high"]),
+    promotionRelevance: enumValue(value.promotionRelevance, [
+      "none",
+      "diagnostic",
+      "setup-gate",
+      "promotion-gate",
+    ]),
+    ...(value.validatedBy ? { validatedBy: String(value.validatedBy) } : {}),
+  };
+}
+
+function mergeClaim(existing: EvidenceClaim, next: EvidenceClaim): EvidenceClaim {
+  return {
+    ...existing,
+    ...next,
+    confidence: maxConfidence(existing.confidence, next.confidence),
+    promotionRelevance: maxPromotionRelevance(existing.promotionRelevance, next.promotionRelevance),
+  };
+}
+
+function sameClaimIdentity(left: EvidenceClaim, right: EvidenceClaim): boolean {
+  return (
+    normalize(left.claim) === normalize(right.claim) &&
+    normalize(left.source) === normalize(right.source)
+  );
+}
+
+function normalize(value: string): string {
+  return String(value || "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function enumValue<T extends string>(value: unknown, allowed: T[]): T {
+  return allowed.includes(value as T) ? (value as T) : allowed[0];
+}
+
+function maxConfidence(left: EvidenceClaim["confidence"], right: EvidenceClaim["confidence"]) {
+  const order = ["low", "medium", "high"];
+  return order.indexOf(right) > order.indexOf(left) ? right : left;
+}
+
+function maxPromotionRelevance(
+  left: EvidenceClaim["promotionRelevance"],
+  right: EvidenceClaim["promotionRelevance"],
+) {
+  const order = ["none", "diagnostic", "setup-gate", "promotion-gate"];
+  return order.indexOf(right) > order.indexOf(left) ? right : left;
+}

--- a/plugins/codex-autoresearch/lib/research-path-guard.ts
+++ b/plugins/codex-autoresearch/lib/research-path-guard.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { RESEARCH_DIR } from "./session-core.js";
+
+export interface SafeResearchPath {
+  root: string;
+  slug: string;
+  outputDir: string;
+}
+
+const RESERVED_WINDOWS_NAMES = new Set([
+  "aux",
+  "con",
+  "nul",
+  "prn",
+  ...Array.from({ length: 9 }, (_, index) => `com${index + 1}`),
+  ...Array.from({ length: 9 }, (_, index) => `lpt${index + 1}`),
+]);
+
+export function validateResearchSlug(slug: string): string {
+  const value = String(slug || "").trim();
+  if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(value)) {
+    throw new Error("research slug must match ^[a-z0-9][a-z0-9-]{0,63}$ and cannot contain paths");
+  }
+  if (RESERVED_WINDOWS_NAMES.has(value.toLowerCase())) {
+    throw new Error(`research slug uses a reserved name: ${value}`);
+  }
+  if (value === "." || value === ".." || value.includes("/") || value.includes("\\")) {
+    throw new Error(`research slug cannot be a path: ${value}`);
+  }
+  if (path.isAbsolute(value)) throw new Error(`research slug cannot be absolute: ${value}`);
+  return value;
+}
+
+export async function resolveSafeResearchPath(
+  cwd: string,
+  slug: string,
+): Promise<SafeResearchPath> {
+  const workDir = path.resolve(cwd || process.cwd());
+  const safeSlug = validateResearchSlug(slug);
+  const root = path.join(workDir, RESEARCH_DIR);
+  const outputDir = path.join(root, safeSlug);
+  await assertInsideResearchRoot(root, outputDir);
+  return { root, slug: safeSlug, outputDir };
+}
+
+export async function assertInsideResearchRoot(root: string, target: string): Promise<void> {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  const rootReal = await realPathForTarget(resolvedRoot);
+  const targetReal = await realPathForTarget(resolvedTarget);
+  if (!isPathInside(rootReal, targetReal)) {
+    throw new Error(`target path escapes ${RESEARCH_DIR}: ${target}`);
+  }
+}
+
+async function realPathForTarget(target: string): Promise<string> {
+  if (fs.existsSync(target)) return await fsp.realpath(target);
+  const parent = await nearestExistingParent(path.dirname(target));
+  const parentReal = await realPathOrResolved(parent);
+  return path.join(parentReal, path.relative(parent, target));
+}
+
+async function nearestExistingParent(start: string): Promise<string> {
+  let cursor = path.resolve(start);
+  while (!fs.existsSync(cursor)) {
+    const next = path.dirname(cursor);
+    if (next === cursor) return cursor;
+    cursor = next;
+  }
+  return cursor;
+}
+
+async function realPathOrResolved(value: string): Promise<string> {
+  try {
+    return await fsp.realpath(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function isPathInside(root: string, target: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}

--- a/plugins/codex-autoresearch/lib/session-core.ts
+++ b/plugins/codex-autoresearch/lib/session-core.ts
@@ -377,6 +377,7 @@ export function buildDecisionEnvelope({
   researchIntegrity = null,
   finalization = null,
   qualityGap = null,
+  contextDistillation = null,
 }: LooseObject): LooseObject {
   const current: RunRecord[] = Array.isArray(state?.current) ? state.current : [];
   const all: RunRecord[] = Array.isArray(state?.results) ? state.results : current;
@@ -395,7 +396,7 @@ export function buildDecisionEnvelope({
         .filter((check: any) => check?.severity === "blocker")
         .map((check: any) => check.message || check.code)
     : [];
-  return {
+  const envelope = {
     activeSegment: {
       segment: state?.segment ?? 0,
       runs: current.length,
@@ -464,6 +465,81 @@ export function buildDecisionEnvelope({
         }
       : { available: false, ready: null, nextAction: "", warnings: [] },
     nextAction: nextAction || "Run doctor, then next.",
+  };
+  return {
+    ...envelope,
+    canonicalNextAction: canonicalNextActionForEnvelope({
+      ...envelope,
+      contextDistillation,
+      nextAction: nextAction || "Run doctor, then next.",
+    }),
+  };
+}
+
+function canonicalNextActionForEnvelope(envelope: LooseObject): LooseObject {
+  const scaffoldBlockers = envelope.scaffoldHealth?.blockers || [];
+  if (Array.isArray(scaffoldBlockers) && scaffoldBlockers.length > 0) {
+    return {
+      kind: "safety-blocker",
+      priority: 1,
+      reason: String(scaffoldBlockers[0] || "Resolve scaffold blockers."),
+      command: "",
+      triggeredBy: ["scaffoldHealth"],
+    };
+  }
+  if (envelope.dirtySourceDrift?.dirty === true) {
+    return {
+      kind: "workflow-friction",
+      priority: 2,
+      reason: "Review dirty source drift before another packet.",
+      command: "",
+      triggeredBy: ["dirtySourceDrift"],
+    };
+  }
+  if (envelope.latestPacketFreshness?.fresh === false) {
+    return {
+      kind: "stale-packet",
+      priority: 4,
+      reason: envelope.latestPacketFreshness.reason || "Last-run packet is stale.",
+      command: "",
+      triggeredBy: ["latestPacketFreshness"],
+    };
+  }
+  if (envelope.contextDistillation?.required === true) {
+    return {
+      kind: "context-distillation",
+      priority: 6,
+      reason:
+        envelope.contextDistillation.reason ||
+        "Refresh a context capsule before running another packet.",
+      command: envelope.contextDistillation.command || "",
+      triggeredBy: envelope.contextDistillation.triggeredBy || ["contextDistillation"],
+    };
+  }
+  if (envelope.qualityRound?.active && envelope.qualityRound.done === false) {
+    return {
+      kind: "quality-gap",
+      priority: 7,
+      reason: `${envelope.qualityRound.open ?? "Open"} accepted quality gaps remain.`,
+      command: "",
+      triggeredBy: ["qualityRound"],
+    };
+  }
+  if (envelope.finalizationReadiness?.ready === true) {
+    return {
+      kind: "finalization",
+      priority: 9,
+      reason: envelope.finalizationReadiness.nextAction || "Finalize reviewable kept work.",
+      command: "",
+      triggeredBy: ["finalizationReadiness"],
+    };
+  }
+  return {
+    kind: "next-packet",
+    priority: 10,
+    reason: envelope.nextAction || "Run the next measured packet.",
+    command: "",
+    triggeredBy: ["continuation"],
   };
 }
 

--- a/plugins/codex-autoresearch/lib/session-forensics.ts
+++ b/plugins/codex-autoresearch/lib/session-forensics.ts
@@ -1,0 +1,434 @@
+import fs from "node:fs";
+import { createInterface } from "node:readline";
+
+import { redactEvidenceText } from "./evidence-redaction.js";
+import {
+  DEFAULT_DECISION_THRESHOLDS,
+  resolveDecisionThresholds,
+  type DecisionThresholdConfig,
+} from "./decision-thresholds.js";
+
+type LooseObject = Record<string, any>;
+
+export interface SessionForensicsOptions {
+  sessionJsonl: string;
+  allowSnippets?: boolean;
+  maxSnippets?: number;
+  maxSnippetChars?: number;
+  thresholds?: Partial<DecisionThresholdConfig>;
+}
+
+export interface SessionForensicsError {
+  ok: false;
+  code: "missing_file" | "unreadable_file" | "malformed_jsonl" | "unsupported_session";
+  message: string;
+  path?: string;
+  line?: number;
+}
+
+export interface ForensicsSignal {
+  kind: string;
+  severity: "info" | "warning" | "blocker";
+  message: string;
+  count?: number;
+  source?: string;
+  commandHead?: string;
+  size?: { tokens?: number; lines?: number };
+}
+
+export interface RedactedSnippet {
+  source: string;
+  text: string;
+}
+
+export interface SessionForensicsSummary {
+  ok: true;
+  sourcePath: string;
+  timeWindow: { first: string | null; last: string | null };
+  counts: Record<string, number>;
+  responseCounts: Record<string, number>;
+  toolCounts: Record<string, number>;
+  commandClasses: Record<string, number>;
+  compactions: number;
+  goal: { status: string | null; tokensUsed: number | null; timeUsedSeconds: number | null };
+  userCorrections: ForensicsSignal[];
+  productSignals: ForensicsSignal[];
+  repeatedFamilies: ForensicsSignal[];
+  workflowWaste: ForensicsSignal[];
+  blockers: ForensicsSignal[];
+  snippets: RedactedSnippet[];
+  thresholds: DecisionThresholdConfig;
+}
+
+export type SessionForensicsResult = SessionForensicsSummary | SessionForensicsError;
+
+export async function parseSessionForensics(
+  options: SessionForensicsOptions,
+): Promise<SessionForensicsResult> {
+  const sessionJsonl = String(options.sessionJsonl || "");
+  if (!sessionJsonl || !fs.existsSync(sessionJsonl)) {
+    return {
+      ok: false,
+      code: "missing_file",
+      message: `Session JSONL does not exist: ${sessionJsonl}`,
+      path: sessionJsonl,
+    };
+  }
+  const thresholds = resolveDecisionThresholds({
+    decisionThresholds: { ...DEFAULT_DECISION_THRESHOLDS, ...options.thresholds },
+  });
+  const state = createAccumulator(sessionJsonl, thresholds);
+  const stream = fs.createReadStream(sessionJsonl, { encoding: "utf8" });
+  stream.on("error", () => {});
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+  let lineNumber = 0;
+  try {
+    for await (const rawLine of lines) {
+      lineNumber += 1;
+      const line = String(rawLine).trim();
+      if (!line) continue;
+      let entry: LooseObject;
+      try {
+        entry = JSON.parse(line);
+      } catch (error: any) {
+        stream.destroy();
+        return {
+          ok: false,
+          code: "malformed_jsonl",
+          message: `Invalid JSONL at line ${lineNumber}: ${error.message || error}`,
+          path: sessionJsonl,
+          line: lineNumber,
+        };
+      }
+      observeEntry(state, entry, {
+        allowSnippets: options.allowSnippets === true,
+        maxSnippetChars: positiveInt(options.maxSnippetChars, 320),
+        maxSnippets: positiveInt(options.maxSnippets, 8),
+      });
+    }
+  } catch (error: any) {
+    return {
+      ok: false,
+      code: "unreadable_file",
+      message: error.message || String(error),
+      path: sessionJsonl,
+      line: lineNumber || undefined,
+    };
+  }
+  return finalizeSummary(state);
+}
+
+function createAccumulator(sourcePath: string, thresholds: DecisionThresholdConfig) {
+  return {
+    sourcePath,
+    thresholds,
+    first: null as string | null,
+    last: null as string | null,
+    counts: new Map<string, number>(),
+    responseCounts: new Map<string, number>(),
+    toolCounts: new Map<string, number>(),
+    commandClasses: new Map<string, number>(),
+    commandTokenCounts: new Map<string, number>(),
+    commandLineCounts: new Map<string, number>(),
+    totalOutputTokens: 0,
+    compactions: 0,
+    goalStatus: null as string | null,
+    goalTokensUsed: null as number | null,
+    goalTimeUsedSeconds: null as number | null,
+    snippets: [] as RedactedSnippet[],
+    userCorrections: [] as ForensicsSignal[],
+    productSignals: [] as ForensicsSignal[],
+    repeatedFamilies: [] as ForensicsSignal[],
+    workflowWaste: [] as ForensicsSignal[],
+    blockers: [] as ForensicsSignal[],
+  };
+}
+
+function observeEntry(
+  state: ReturnType<typeof createAccumulator>,
+  entry: LooseObject,
+  snippetOptions: { allowSnippets: boolean; maxSnippetChars: number; maxSnippets: number },
+) {
+  increment(state.counts, String(entry.type || "unknown"));
+  if (entry.timestamp) {
+    state.first ??= String(entry.timestamp);
+    state.last = String(entry.timestamp);
+  }
+  if (entry.type === "compacted") state.compactions += 1;
+  const payload = entry.payload || {};
+  if (entry.type !== "response_item") {
+    scanGoalSnapshot(state, entry);
+    return;
+  }
+  const payloadType = String(payload.type || "unknown");
+  increment(state.responseCounts, payloadType);
+  scanGoalSnapshot(state, payload);
+  if (payloadType === "message") {
+    observeMessage(state, payload, snippetOptions);
+    return;
+  }
+  if (payloadType === "function_call" || payloadType === "custom_tool_call") {
+    observeFunctionCall(state, payload);
+    return;
+  }
+  if (payloadType === "function_call_output" || payloadType === "custom_tool_call_output") {
+    observeFunctionOutput(state, payload, snippetOptions);
+  }
+}
+
+function observeMessage(
+  state: ReturnType<typeof createAccumulator>,
+  payload: LooseObject,
+  snippetOptions: { allowSnippets: boolean; maxSnippetChars: number; maxSnippets: number },
+) {
+  const text = messageText(payload);
+  if (
+    payload.role === "user" &&
+    /\b(no|not|rather|actually|instead|wrong|don't|do not)\b/i.test(text)
+  ) {
+    state.userCorrections.push(signal("user_correction", "info", summarize(text), "message"));
+  }
+  if (/segment.+not.+best|metric formula|metric details|tell me nothing|chart/i.test(text)) {
+    state.productSignals.push(
+      signal("dashboard_ux_feedback", "warning", summarize(text), "message"),
+    );
+  }
+  if (/quality_gap|quality gap/i.test(text)) {
+    state.productSignals.push(
+      signal(
+        "quality_gap_wording",
+        "warning",
+        "Quality-gap wording appeared in session feedback.",
+        "message",
+      ),
+    );
+  }
+  addSnippet(state, "message", text, snippetOptions);
+}
+
+function observeFunctionCall(state: ReturnType<typeof createAccumulator>, payload: LooseObject) {
+  const name = String(payload.name || "unknown");
+  increment(state.toolCounts, name);
+  if (name === "write_stdin") increment(state.toolCounts, "shell_poll");
+  if (name !== "exec_command") return;
+  const args = parseMaybeJson(payload.arguments);
+  const command = String(args?.cmd || "");
+  const head = commandHead(command);
+  if (head) increment(state.commandClasses, head);
+}
+
+function observeFunctionOutput(
+  state: ReturnType<typeof createAccumulator>,
+  payload: LooseObject,
+  snippetOptions: { allowSnippets: boolean; maxSnippetChars: number; maxSnippets: number },
+) {
+  const output = String(payload.output || "");
+  const tokenCount = Number(output.match(/Original token count:\s*(\d+)/)?.[1] || 0);
+  const lineCount = Number(output.match(/Total output lines:\s*(\d+)/)?.[1] || 0);
+  state.totalOutputTokens += Number.isFinite(tokenCount) ? tokenCount : 0;
+  const callId = String(payload.call_id || "tool-output");
+  if (tokenCount) state.commandTokenCounts.set(callId, tokenCount);
+  if (lineCount) state.commandLineCounts.set(callId, lineCount);
+  if (/exited with code [1-9]/.test(output)) {
+    state.blockers.push(signal("command_failed", "warning", summarize(output), callId));
+  }
+  if (/unknown recipe/i.test(output)) {
+    state.blockers.push(signal("unknown_recipe", "warning", summarize(output), callId));
+  }
+  if (/timed out|timeout/i.test(output)) {
+    state.blockers.push(signal("timeout", "warning", summarize(output), callId));
+  }
+  if (/polling/i.test(output)) {
+    state.workflowWaste.push(signal("progress_polling", "warning", summarize(output), callId));
+  }
+  if (tokenCount >= state.thresholds.outputCommandTokenBudget) {
+    state.workflowWaste.push({
+      kind: "output_budget_exceeded",
+      severity: "warning",
+      message: `One command output reported ${tokenCount} tokens.`,
+      source: callId,
+      size: { tokens: tokenCount, lines: lineCount || undefined },
+    });
+  }
+  if (lineCount >= state.thresholds.outputCommandLineBudget) {
+    state.workflowWaste.push({
+      kind: "output_budget_exceeded",
+      severity: "warning",
+      message: `One command output reported ${lineCount} lines.`,
+      source: callId,
+      size: { tokens: tokenCount || undefined, lines: lineCount },
+    });
+  }
+  addSnippet(state, callId, output, snippetOptions);
+}
+
+function finalizeSummary(state: ReturnType<typeof createAccumulator>): SessionForensicsSummary {
+  for (const [commandHeadValue, count] of state.commandClasses.entries()) {
+    if (count >= state.thresholds.repeatedCommandHeadCount) {
+      state.workflowWaste.push({
+        kind: "verification_churn",
+        severity: "warning",
+        message: `Command head repeated ${count} times: ${commandHeadValue}`,
+        count,
+        commandHead: commandHeadValue,
+      });
+    }
+  }
+  if ((state.toolCounts.get("shell_poll") || 0) >= state.thresholds.shellPolls) {
+    state.workflowWaste.push({
+      kind: "progress_polling",
+      severity: "warning",
+      message: `Shell polling exceeded threshold: ${state.toolCounts.get("shell_poll")} polls.`,
+      count: state.toolCounts.get("shell_poll"),
+    });
+  }
+  if (state.totalOutputTokens >= state.thresholds.outputSegmentTokenBudget) {
+    state.workflowWaste.push({
+      kind: "output_budget_exceeded",
+      severity: "warning",
+      message: `Session output reported ${state.totalOutputTokens} cumulative tokens.`,
+      size: { tokens: state.totalOutputTokens },
+    });
+  }
+  if (state.compactions >= state.thresholds.compactions) {
+    state.productSignals.push({
+      kind: "context_distillation_required",
+      severity: "warning",
+      message: `Compactions reached ${state.compactions}; refresh a context capsule before more packets.`,
+      count: state.compactions,
+    });
+  }
+  if ((state.toolCounts.get("exec_command") || 0) >= state.thresholds.functionCalls) {
+    state.productSignals.push({
+      kind: "context_distillation_required",
+      severity: "warning",
+      message: `Function calls exceeded threshold: ${state.toolCounts.get("exec_command")} exec commands.`,
+      count: state.toolCounts.get("exec_command"),
+    });
+  }
+  return {
+    ok: true,
+    sourcePath: state.sourcePath,
+    timeWindow: { first: state.first, last: state.last },
+    counts: toObject(state.counts),
+    responseCounts: toObject(state.responseCounts),
+    toolCounts: toObject(state.toolCounts),
+    commandClasses: toObject(state.commandClasses),
+    compactions: state.compactions,
+    goal: {
+      status: state.goalStatus,
+      tokensUsed: state.goalTokensUsed,
+      timeUsedSeconds: state.goalTimeUsedSeconds,
+    },
+    userCorrections: dedupeSignals(state.userCorrections),
+    productSignals: dedupeSignals(state.productSignals),
+    repeatedFamilies: dedupeSignals(state.repeatedFamilies),
+    workflowWaste: dedupeSignals(state.workflowWaste),
+    blockers: dedupeSignals(state.blockers),
+    snippets: state.snippets,
+    thresholds: state.thresholds,
+  };
+}
+
+function scanGoalSnapshot(state: ReturnType<typeof createAccumulator>, value: unknown) {
+  const text = JSON.stringify(value);
+  const status = text.match(
+    /"status"\s*:\s*"(active|complete|blocked|paused|budget_limited)"/,
+  )?.[1];
+  if (status) state.goalStatus = status;
+  for (const match of text.matchAll(/"tokensUsed"\s*:\s*(\d+)/g)) {
+    state.goalTokensUsed = Math.max(state.goalTokensUsed || 0, Number(match[1]));
+  }
+  for (const match of text.matchAll(/"timeUsed(?:Seconds)?"\s*:\s*(\d+)/g)) {
+    state.goalTimeUsedSeconds = Math.max(state.goalTimeUsedSeconds || 0, Number(match[1]));
+  }
+}
+
+function addSnippet(
+  state: ReturnType<typeof createAccumulator>,
+  source: string,
+  text: string,
+  options: { allowSnippets: boolean; maxSnippetChars: number; maxSnippets: number },
+) {
+  if (!options.allowSnippets || state.snippets.length >= options.maxSnippets) return;
+  const clean = redactEvidenceText(summarize(text, options.maxSnippetChars));
+  if (!clean) return;
+  state.snippets.push({ source, text: clean });
+}
+
+function messageText(payload: LooseObject): string {
+  const content = payload.content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object")
+          return part.text || part.input_text || part.output_text || "";
+        return "";
+      })
+      .join("\n");
+  }
+  return String(content || "");
+}
+
+function signal(
+  kind: string,
+  severity: ForensicsSignal["severity"],
+  message: string,
+  source?: string,
+): ForensicsSignal {
+  return { kind, severity, message, ...(source ? { source } : {}) };
+}
+
+function summarize(text: string, maxChars = 220): string {
+  return redactEvidenceText(
+    String(text || "")
+      .replace(/\s+/g, " ")
+      .trim(),
+  ).slice(0, maxChars);
+}
+
+function commandHead(command: string): string {
+  return String(command || "")
+    .trim()
+    .split(/\s+/)
+    .slice(0, 5)
+    .join(" ");
+}
+
+function parseMaybeJson(value: unknown): LooseObject | null {
+  if (!value) return null;
+  if (typeof value === "object") return value as LooseObject;
+  try {
+    return JSON.parse(String(value));
+  } catch {
+    return null;
+  }
+}
+
+function increment(map: Map<string, number>, key: string) {
+  map.set(key, (map.get(key) || 0) + 1);
+}
+
+function toObject(map: Map<string, number>): Record<string, number> {
+  return Object.fromEntries(
+    [...map.entries()].sort((left, right) => left[0].localeCompare(right[0])),
+  );
+}
+
+function dedupeSignals(signals: ForensicsSignal[]): ForensicsSignal[] {
+  const seen = new Set<string>();
+  const out = [];
+  for (const signalValue of signals) {
+    const key = `${signalValue.kind}\n${signalValue.message}\n${signalValue.source || ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(signalValue);
+  }
+  return out.slice(0, 50);
+}
+
+function positiveInt(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/plugins/codex-autoresearch/lib/tool-contracts.ts
+++ b/plugins/codex-autoresearch/lib/tool-contracts.ts
@@ -82,10 +82,8 @@ const CONTRACTS = {
   },
   codex_goal_bridge: {
     purpose: "Bridge Autoresearch state into Codex Goal objective and completion-audit language.",
-    whenToUse:
-      "Use when the operator explicitly wants Codex Goal mode or an active Codex Goal needs an Autoresearch evidence audit.",
-    contrast:
-      "Use recommend_next for ordinary Autoresearch continuation without Goal-mode framing.",
+    whenToUse: "Use for Codex Goal handoff or completion-audit evidence.",
+    contrast: "Use recommend_next for ordinary continuation.",
     safety: "Read-only; does not read or mutate Codex private goal state.",
     outputSchema: basicOutputSchema([
       "ok",
@@ -94,6 +92,23 @@ const CONTRACTS = {
       "objectiveDraft",
       "completionAudit",
       "commands",
+    ]),
+  },
+  session_forensics: {
+    purpose: "Parse Codex rollout JSONL into bounded session and waste signals.",
+    whenToUse: "Use to import a long Codex session before more Autoresearch packets.",
+    contrast: "Use read_state for the current Autoresearch ledger only.",
+    safety: "Dry-run is read-only; apply writes only validated research capsule files.",
+    outputSchema: basicOutputSchema([
+      "ok",
+      "workDir",
+      "dryRun",
+      "wrote",
+      "outputDir",
+      "plannedFiles",
+      "counts",
+      "workflowWaste",
+      "nextAction",
     ]),
   },
   list_recipes: {

--- a/plugins/codex-autoresearch/lib/tool-registry.ts
+++ b/plugins/codex-autoresearch/lib/tool-registry.ts
@@ -26,6 +26,7 @@ const TOOL_REGISTRY = [
   { name: "onboarding_packet", cliCommand: "onboarding-packet", actionPolicy: "read" },
   { name: "recommend_next", cliCommand: "recommend-next", actionPolicy: "read" },
   { name: "codex_goal_bridge", cliCommand: "codex-goal-brief", actionPolicy: "read" },
+  { name: "session_forensics", cliCommand: "session-forensics", actionPolicy: "read" },
   { name: "list_recipes", cliCommand: "recipes", actionPolicy: "read" },
   { name: "setup_session", cliCommand: "setup", actionPolicy: "state_mutation" },
   { name: "setup_research_session", cliCommand: "research-setup", actionPolicy: "state_mutation" },
@@ -73,6 +74,9 @@ export function actionPolicyForTool(name: string, args: LooseObject = {}): Actio
   const base = (toolMetadata(name)?.actionPolicy || "read") as ActionPolicy;
   if (name === "gap_candidates" && (args.apply || args.apply === "true")) {
     return "state_mutation";
+  }
+  if (name === "session_forensics" && (args.apply || args.apply === "true")) {
+    return "artifact_write";
   }
   if (name === "guided_setup" && (args.start_dashboard || args.startDashboard)) {
     return "process_start";

--- a/plugins/codex-autoresearch/lib/tool-schemas.ts
+++ b/plugins/codex-autoresearch/lib/tool-schemas.ts
@@ -139,6 +139,25 @@ export const toolSchemas = applyToolContracts([
     },
   },
   {
+    name: "session_forensics",
+    description:
+      "Parse a Codex rollout JSONL into bounded session counts, waste signals, and optional safe context-capsule artifacts.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        working_dir: { type: "string" },
+        session_jsonl: { type: "string" },
+        research_slug: { type: "string" },
+        dry_run: { type: "boolean" },
+        apply: { type: "boolean" },
+        allow_snippets: { type: "boolean" },
+        max_snippets: { type: "integer" },
+        max_snippet_chars: { type: "integer" },
+      },
+      required: ["working_dir", "session_jsonl", "research_slug"],
+    },
+  },
+  {
     name: "list_recipes",
     description: "List or recommend built-in and optional catalog benchmark recipes.",
     inputSchema: {
@@ -555,6 +574,7 @@ const CLI_COMMAND_TO_TOOL: Record<string, string> = {
   "onboarding-packet": "onboarding_packet",
   "recommend-next": "recommend_next",
   "codex-goal-brief": "codex_goal_bridge",
+  "session-forensics": "session_forensics",
   recipes: "list_recipes",
   "research-setup": "setup_research_session",
   config: "configure_session",
@@ -582,6 +602,7 @@ const CLI_COMMAND_TO_TOOL: Record<string, string> = {
 const RUNTIME_ARG_ALIASES: Record<string, string> = {
   allow_add_all: "allowAddAll",
   allow_dirty_revert: "allowDirtyRevert",
+  allow_snippets: "allowSnippets",
   autonomy_mode: "autonomyMode",
   benchmark_command: "benchmarkCommand",
   benchmark_prints_metric: "benchmarkPrintsMetric",
@@ -611,6 +632,8 @@ const RUNTIME_ARG_ALIASES: Record<string, string> = {
   json_full: "jsonFull",
   keep_policy: "keepPolicy",
   max_iterations: "maxIterations",
+  max_snippet_chars: "maxSnippetChars",
+  max_snippets: "maxSnippets",
   metric_name: "metricName",
   metric_unit: "metricUnit",
   model_command: "modelCommand",
@@ -620,6 +643,7 @@ const RUNTIME_ARG_ALIASES: Record<string, string> = {
   query_count: "queryCount",
   recipe_id: "recipeId",
   research_slug: "researchSlug",
+  session_jsonl: "sessionJsonl",
   revert_paths: "revertPaths",
   secondary_metrics: "secondaryMetrics",
   skip_init: "skipInit",

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { buildDashboardViewModel } from "../lib/dashboard-view-model.js";
+import { writeContextCapsule } from "../lib/context-capsule.js";
 import { createDashboardCommands } from "../lib/commands/dashboard.js";
 import { createInspectCommands } from "../lib/commands/inspect.js";
 import { createCliCommandHandlers, runCliCommand } from "../lib/cli-handlers.js";
@@ -38,6 +39,7 @@ import {
   revalidateRecipeCatalogProvenance,
 } from "../lib/recipes.js";
 import { serveAutoresearch } from "../lib/live-server.js";
+import { parseSessionForensics } from "../lib/session-forensics.js";
 import {
   parseMetricLines,
   runProcess as runBoundedProcess,
@@ -176,6 +178,7 @@ Usage:
   node scripts/autoresearch.mjs onboarding-packet --cwd <project> [--compact]
   node scripts/autoresearch.mjs recommend-next --cwd <project> [--compact]
   node scripts/autoresearch.mjs codex-goal-brief --cwd <project> [--codex-goal-objective <text>] [--codex-goal-status active|paused|budget_limited|complete]
+  node scripts/autoresearch.mjs session-forensics --cwd <project> --session-jsonl <path> --research-slug <slug> [--dry-run|--apply] [--allow-snippets]
   node scripts/autoresearch.mjs recipes list|show|recommend [recipe-id] [--cwd <project>] [--catalog <path-or-url>]
   node scripts/autoresearch.mjs init --cwd <project> --name <name> --metric-name <name> [--goal <goal>] [--metric-unit <unit>] [--direction lower|higher]
   node scripts/autoresearch.mjs run --cwd <project> [--command <cmd>|--command-file <path>] [--packet-env-file <path>] [--timeout-seconds <n>]
@@ -1745,6 +1748,74 @@ async function recommendNext(args: LooseObject): Promise<LooseObject> {
     compactState: boolOption(args.compact, false) ? compact : undefined,
     resumeAudit: decisionEnvelope,
     decisionEnvelope,
+  };
+}
+
+async function sessionForensics(args: LooseObject): Promise<LooseObject> {
+  const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
+  const apply = boolOption(args.apply, false);
+  const dryRun = boolOption(args.dryRun, !apply);
+  const sessionJsonl = String(args.sessionJsonl || "");
+  const researchSlug = String(args.researchSlug || "");
+  const parsed = await parseSessionForensics({
+    sessionJsonl,
+    allowSnippets: boolOption(args.allowSnippets, false),
+    maxSnippets: positiveIntegerOption(args.maxSnippets, 8, "--max-snippets") ?? 8,
+    maxSnippetChars: positiveIntegerOption(args.maxSnippetChars, 320, "--max-snippet-chars") ?? 320,
+  });
+  if (!parsed.ok) {
+    return {
+      ...parsed,
+      wrote: false,
+    };
+  }
+  const capsule = await writeContextCapsule({
+    cwd: workDir,
+    researchSlug,
+    summary: parsed,
+    apply: apply && !dryRun,
+  });
+  const contextSignal = parsed.productSignals.find(
+    (signal: any) => signal.kind === "context_distillation_required",
+  );
+  const canonicalNextAction = contextSignal
+    ? {
+        kind: "context-distillation",
+        priority: 6,
+        reason: contextSignal.message,
+        command: `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} session-forensics --cwd ${shellQuote(workDir)} --session-jsonl ${shellQuote(sessionJsonl)} --research-slug ${shellQuote(researchSlug)} --apply`,
+        triggeredBy: ["sessionForensics"],
+      }
+    : {
+        kind: "next-packet",
+        priority: 10,
+        reason: "Review imported signals, then continue with the safest next Autoresearch action.",
+        command: "",
+        triggeredBy: ["sessionForensics"],
+      };
+  return {
+    ok: true,
+    workDir,
+    dryRun: capsule.dryRun,
+    wrote: !capsule.dryRun,
+    outputDir: capsule.outputDir,
+    plannedFiles: capsule.files,
+    sourcePath: parsed.sourcePath,
+    timeWindow: parsed.timeWindow,
+    counts: parsed.counts,
+    responseCounts: parsed.responseCounts,
+    toolCounts: parsed.toolCounts,
+    commandClasses: parsed.commandClasses,
+    compactions: parsed.compactions,
+    goal: parsed.goal,
+    userCorrections: parsed.userCorrections,
+    productSignals: parsed.productSignals,
+    workflowWaste: parsed.workflowWaste,
+    blockers: parsed.blockers,
+    snippets: parsed.snippets,
+    evidenceClaims: capsule.evidenceIndex?.claims.length ?? null,
+    canonicalNextAction,
+    nextAction: canonicalNextAction.reason,
   };
 }
 
@@ -4965,6 +5036,8 @@ function compactPublicState(state: LooseObject) {
     commands: continuation.commands || state.commands || {},
     resumeAudit: state.resumeAudit || null,
     decisionEnvelope: state.decisionEnvelope || state.resumeAudit || null,
+    canonicalNextAction:
+      state.decisionEnvelope?.canonicalNextAction || state.resumeAudit?.canonicalNextAction || null,
   };
 }
 
@@ -5831,6 +5904,7 @@ async function main() {
     promptPlan,
     publicState,
     recommendNext,
+    sessionForensics,
     readJsonl,
     recipeCommand,
     resolveWorkDir,

--- a/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
+++ b/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
@@ -24,10 +24,11 @@ AX, the AI experience:
 - When the user gives a broad natural-language goal without a benchmark contract, run `prompt-plan` first. It should infer metric defaults, experiment lanes, safe scope, missing essentials, and the read-only setup path before Codex edits files.
 - If the target repo already has benchmark surfaces in scripts, package/cargo scripts, docs, known benchmark filenames, or `.git/autoresearch` hints, prefer those before generic recipes. Treat score-like metrics as quality-bearing until the session docs prove otherwise.
 - Use the CLI as the deterministic execution surface.
-- Keep loop truth in durable files, not chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.ideas.md`, `autoresearch.research/<slug>/`, dashboard state, and commits.
+- Keep loop truth in durable files, not chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.ideas.md`, `autoresearch.research/<slug>/`, evidence indexes, dashboard state, and commits.
 - Keep every packet decision recoverable through `METRIC name=value`, packet evidence, ASI, continuation data, promotion labels, and the ledger.
 - ASI means the structured memory attached to a run: hypothesis, evidence, rollback reason, next action hint, and optional lane/family/risk metadata.
 - When Codex Goal mode is available and explicitly requested, use `get_goal` to inspect parent thread state, then run `codex-goal-brief --cwd <project>` with any imported Goal fields. Treat the bridge as evidence/advice only: Codex owns thread goals; Autoresearch owns benchmark/session truth.
+- When a prior Codex session JSONL is the best evidence source, run `session-forensics --dry-run` first, then `--apply` only to write a bounded context capsule under `autoresearch.research/<slug>/`. Keep raw snippets disabled unless the operator explicitly needs them; imported claims should reference evidence ids instead of persisting raw transcript bodies.
 
 UX, the user experience:
 
@@ -80,6 +81,7 @@ node scripts/autoresearch.mjs checks-inspect --cwd <project> --command "<checks 
 node scripts/autoresearch.mjs guide --cwd <project>
 node scripts/autoresearch.mjs doctor --cwd <project> --explain
 node scripts/autoresearch.mjs serve --cwd <project>
+node scripts/autoresearch.mjs session-forensics --cwd <project> --session-jsonl <path> --research-slug <slug> --dry-run
 ```
 
 ## Active Loop Contract

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -151,6 +151,91 @@ test("quality-gap counts checked and unchecked research gaps", async () => {
   });
 });
 
+test("session-forensics supports dry-run and safe apply capsule writes", async () => {
+  await withTempDir("session-forensics-cli", async (dir) => {
+    const sessionPath = path.join(dir, "rollout.jsonl");
+    await writeFile(
+      sessionPath,
+      [
+        JSON.stringify({
+          timestamp: "2026-05-25T00:00:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Segments UX is not the best." }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-25T00:00:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "exec_command",
+            arguments: JSON.stringify({ cmd: "git status --short" }),
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-25T00:00:02.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call_output",
+            call_id: "call1",
+            output:
+              "Chunk ID: abc\nProcess exited with code 0\nOriginal token count: 25000\nTotal output lines: 600\nOutput:\ntoken=abcdefghijklmnop",
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const dryRun = await runCli([
+      "session-forensics",
+      "--cwd",
+      dir,
+      "--session-jsonl",
+      sessionPath,
+      "--research-slug",
+      "session-019e",
+      "--dry-run",
+    ]);
+    assert.equal(dryRun.code, 0, dryRun.stderr);
+    const dryPayload = JSON.parse(dryRun.stdout);
+    assert.equal(dryPayload.ok, true);
+    assert.equal(dryPayload.dryRun, true);
+    assert.equal(dryPayload.wrote, false);
+    assert.equal(dryPayload.plannedFiles.length, 4);
+    await assert.rejects(() =>
+      access(path.join(dir, "autoresearch.research", "session-019e", "session-digest.md")),
+    );
+
+    const applied = await runCli([
+      "session-forensics",
+      "--cwd",
+      dir,
+      "--session-jsonl",
+      sessionPath,
+      "--research-slug",
+      "session-019e",
+      "--apply",
+    ]);
+    assert.equal(applied.code, 0, applied.stderr);
+    const applyPayload = JSON.parse(applied.stdout);
+    assert.equal(applyPayload.wrote, true);
+    assert.equal(applyPayload.evidenceClaims > 0, true);
+
+    const researchRoot = path.join(dir, "autoresearch.research", "session-019e");
+    const digest = await readFile(path.join(researchRoot, "session-digest.md"), "utf8");
+    const gaps = await readFile(path.join(researchRoot, "quality-gaps.md"), "utf8");
+    const evidence = JSON.parse(
+      await readFile(path.join(researchRoot, "evidence-index.json"), "utf8"),
+    );
+    assert.match(digest, /Session Forensics Import/);
+    assert.match(gaps, /\[evidence:ev-/);
+    assert.equal(evidence.schemaVersion, 1);
+    assert.equal(JSON.stringify(evidence).includes("abcdefghijklmnop"), false);
+  });
+});
+
 test("run returns explicit keep/discard decision options instead of a fake status", async () => {
   await withTempDir("decision-hint", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "decision hint", "--metric-name", "seconds"]);

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -22,6 +22,23 @@ import {
   redactEvidenceText,
   redactPathDisplay,
 } from "../lib/evidence-redaction.js";
+import {
+  DEFAULT_DECISION_THRESHOLDS,
+  resolveDecisionThresholds,
+} from "../lib/decision-thresholds.js";
+import {
+  compactEvidenceSummaries,
+  evidenceClaim,
+  mergeEvidenceClaims,
+  readEvidenceIndex,
+  validateClaimReferences,
+} from "../lib/evidence-index.js";
+import {
+  assertInsideResearchRoot,
+  resolveSafeResearchPath,
+  validateResearchSlug,
+} from "../lib/research-path-guard.js";
+import { parseSessionForensics } from "../lib/session-forensics.js";
 import { quoteForShell } from "./helpers/process.js";
 
 const withTempDir = async (name, fn) => {
@@ -239,4 +256,144 @@ test("evidence redactor removes stack frames before dashboard or packet storage"
   assert.doesNotMatch(redacted, /abcdefghijklmnop/);
   assert.doesNotMatch(redacted, /Alice|alice/);
   assert.doesNotMatch(redacted, /secret\.ts|index\.mjs|secret\.py/);
+});
+
+test("decision thresholds use conservative defaults with safe overrides", () => {
+  assert.equal(DEFAULT_DECISION_THRESHOLDS.compactions, 3);
+  assert.equal(DEFAULT_DECISION_THRESHOLDS.outputCommandTokenBudget, 20_000);
+  const resolved = resolveDecisionThresholds({
+    decisionThresholds: {
+      compactions: 5,
+      outputCommandTokenBudget: 10_000,
+      repeatedCommandHeadCount: -1,
+    },
+  });
+  assert.equal(resolved.compactions, 5);
+  assert.equal(resolved.outputCommandTokenBudget, 10_000);
+  assert.equal(
+    resolved.repeatedCommandHeadCount,
+    DEFAULT_DECISION_THRESHOLDS.repeatedCommandHeadCount,
+  );
+});
+
+test("research path guard rejects unsafe slugs and out-of-root paths", async () => {
+  await withTempDir("research-path-guard", async (dir) => {
+    assert.equal(validateResearchSlug("session-019e"), "session-019e");
+    for (const slug of ["../x", "x/y", "x\\y", "CON", ".hidden", ""]) {
+      assert.throws(() => validateResearchSlug(slug));
+    }
+
+    const safe = await resolveSafeResearchPath(dir, "session-019e");
+    assert.equal(path.basename(safe.outputDir), "session-019e");
+    await assertInsideResearchRoot(safe.root, path.join(safe.outputDir, "session-digest.md"));
+    await assert.rejects(
+      () => assertInsideResearchRoot(safe.root, path.join(dir, "outside.md")),
+      /escapes/,
+    );
+  });
+});
+
+test("evidence index uses deterministic ids, merges claims, and validates references", async () => {
+  await withTempDir("evidence-index", async (dir) => {
+    const claim = evidenceClaim({
+      claim: "Session import observed repeated polling.",
+      source: "rollout.jsonl",
+      evidenceType: "session",
+      freshness: "current",
+      confidence: "medium",
+      promotionRelevance: "diagnostic",
+    });
+    const index = await mergeEvidenceClaims(dir, "session-019e", [claim]);
+    assert.equal(index.schemaVersion, 1);
+    assert.equal(index.claims.length, 1);
+    assert.equal(index.claims[0].id, claim.id);
+
+    const reread = await readEvidenceIndex(dir, "session-019e");
+    assert.deepEqual(reread, index);
+    assert.deepEqual(validateClaimReferences(`[evidence:${claim.id}]`, index), []);
+    assert.deepEqual(validateClaimReferences("[evidence:ev-aaaaaaaaaaaa]", index), [
+      "ev-aaaaaaaaaaaa",
+    ]);
+    assert.deepEqual(compactEvidenceSummaries(index), [
+      {
+        id: claim.id,
+        claim: claim.claim,
+        evidenceType: "session",
+        confidence: "medium",
+        promotionRelevance: "diagnostic",
+      },
+    ]);
+  });
+});
+
+test("session forensics parses bounded signals without raw body persistence", async () => {
+  await withTempDir("session-forensics", async (dir) => {
+    const sessionPath = path.join(dir, "rollout.jsonl");
+    const noisyOutput = [
+      "Chunk ID: abc",
+      "Wall time: 0.1 seconds",
+      "Process exited with code 1",
+      "Original token count: 25000",
+      "Output:",
+      "api_key=sk-test-1234567890abcdef",
+      "Total output lines: 600",
+    ].join("\n");
+    const entries = [
+      { timestamp: "2026-05-25T00:00:00.000Z", type: "session_meta", payload: { id: "s1" } },
+      {
+        timestamp: "2026-05-25T00:00:01.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Actually the metric details tell me nothing." }],
+        },
+      },
+      {
+        timestamp: "2026-05-25T00:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "exec_command",
+          arguments: JSON.stringify({ cmd: "git status --short" }),
+        },
+      },
+      {
+        timestamp: "2026-05-25T00:00:03.000Z",
+        type: "response_item",
+        payload: { type: "function_call_output", call_id: "call1", output: noisyOutput },
+      },
+      { timestamp: "2026-05-25T00:00:04.000Z", type: "compacted", payload: {} },
+    ];
+    await writeFile(sessionPath, entries.map((entry) => JSON.stringify(entry)).join("\n"));
+
+    const result = await parseSessionForensics({
+      sessionJsonl: sessionPath,
+      allowSnippets: true,
+      maxSnippets: 3,
+      thresholds: { compactions: 1, repeatedCommandHeadCount: 1 },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.compactions, 1);
+    assert.equal(result.toolCounts.exec_command, 1);
+    assert.equal(result.commandClasses["git status --short"], 1);
+    assert.equal(
+      result.productSignals.some((signal) => signal.kind === "dashboard_ux_feedback"),
+      true,
+    );
+    assert.equal(
+      result.productSignals.some((signal) => signal.kind === "context_distillation_required"),
+      true,
+    );
+    assert.equal(
+      result.workflowWaste.some((signal) => signal.kind === "output_budget_exceeded"),
+      true,
+    );
+    assert.equal(
+      result.workflowWaste.some((signal) => signal.kind === "verification_churn"),
+      true,
+    );
+    assert.equal(JSON.stringify(result).includes("sk-test"), false);
+  });
 });

--- a/plugins/codex-autoresearch/tests/full-product.test.ts
+++ b/plugins/codex-autoresearch/tests/full-product.test.ts
@@ -1303,7 +1303,7 @@ test("live server log actions stay disabled and leave last-run packets untouched
 
 async function waitForServerPayload(stdoutFn, stderrFn) {
   const started = Date.now();
-  while (Date.now() - started < 5000) {
+  while (Date.now() - started < 15000) {
     const stdout = stdoutFn();
     if (stdout.trim().endsWith("}")) return JSON.parse(stdout);
     await new Promise((resolve) => setTimeout(resolve, 50));


### PR DESCRIPTION
## Summary
- add shared decision thresholds, research path guards, evidence index helpers, and session JSONL forensics parsing
- add `session-forensics` / `session_forensics` to write bounded context capsules into `autoresearch.research/<slug>/`
- surface canonical `context-distillation` next-action guidance and sync README/docs/skill/changelog
- widen the full-product live-server startup wait to avoid Windows cleanup/startup timing noise in verification

## Verification
- `npm run check`
- `node --test dist/tests/evidence-core.test.mjs`
- `node --test dist/tests/autoresearch-cli.test.mjs`
- `node --test --test-name-pattern "dashboard export and live endpoints redact" dist/tests/full-product.test.mjs`
- `git diff --check`