### PR TITLE
Add progress economics and partial result recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ This project uses a root-only changelog because the root README is the public do
 - Added durable `goal` state in config/readouts plus `goalAdvice` in the decision envelope so resumed loops keep the objective visible without relying on chat memory.
 - Added `session-forensics` / `session_forensics`, a safe import path for long Codex session JSONL that writes bounded session digests, quality-gap candidates, decision notes, and evidence-index claims into `autoresearch.research/<slug>/`.
 - Added shared decision thresholds, safe research-slug path guards, and canonical `context-distillation` next-action guidance for sessions that exceed compaction, token, tool-call, polling, or output-budget limits.
+- Added packet progress/economics readouts, workflow-friction signals, and experiment-memory exhaustion/shelf detection to the shared decision envelope.
+- Added `partial-results` / `partial_results` so crashed or timed-out packets can expose artifact rows and record selected rows as diagnostic `measure` evidence with evidence-index provenance.
 
 ### Changed
 
+- `state --compact`, `recommend-next --compact`, and dashboard data now share canonical next-action priorities for workflow friction, stale progress, partial-result review, context distillation, quality gaps, plateau pivots, finalization, and next packets.
 - Bumped public package and plugin manifest version surfaces to `1.4.1`.
 
 ## 1.4.0

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Codex Autoresearch helps Codex:
 4. import bounded forensics from long Codex sessions into durable research notes when context loss becomes the bottleneck
 5. return a shared next-step contract with stage, reason, CLI command, safety, and missing essentials
 6. verify the benchmark contract
-7. run a measured packet with command identity, output tails, metrics, artifacts, checks, and a freshness fingerprint
-8. log the result as `keep`, `discard`, `crash`, or `checks_failed`
-9. preserve ASI, packet fingerprints, promotion labels, and metrics in durable files
-10. continue safely or preview finalization into reviewable branches
+7. run a measured packet with command identity, output tails, metrics, artifacts, checks, progress, and a freshness fingerprint
+8. log the result as `keep`, `discard`, `measure`, `crash`, or `checks_failed`
+9. salvage diagnostic partial-result rows from failed packet artifacts before rerunning expensive work
+10. preserve ASI, packet fingerprints, promotion labels, evidence claims, and metrics in durable files
+11. continue safely or preview finalization into reviewable branches
 
 When you use Codex Goal mode, `codex-goal-brief` turns Autoresearch state into a Goal objective draft and completion audit. It does not mutate Codex Goal state. That boundary matters; otherwise everything starts wearing a fake mustache and calling itself done.
 
@@ -127,6 +128,7 @@ The dashboard shows:
 * baseline, latest, best, confidence, and weighted metric formulas
 * Codex brief and session memory
 * next safe action, evidence label, proof gaps, and why the action is safe
+* packet economics, workflow friction, partial-result candidates, and stale-progress warnings
 * ledger entries, ASI, and handoff context
 * best kept change and recent failures
 * strategy lanes, scaffold health, research integrity, runtime drift, and finalization readiness

--- a/plugins/codex-autoresearch/docs/operate.md
+++ b/plugins/codex-autoresearch/docs/operate.md
@@ -74,6 +74,15 @@ node scripts/autoresearch.mjs state --cwd <project> --compact
 
 `next` is the packet-producing command. `run` is a raw benchmark probe; use it for quick diagnostics, but do not expect `log --from-last` to reuse it.
 
+If a packet crashes or times out after writing artifact rows, inspect partial results before spending another expensive rerun:
+
+```bash
+node scripts/autoresearch.mjs partial-results --cwd <project> --from-last
+node scripts/autoresearch.mjs partial-results --cwd <project> --record <candidate-id>
+```
+
+Recorded partial results are diagnostic `measure` evidence only. They link the source packet, artifact row, metric provenance, validation status, and evidence-index claim, but they are never promotion-grade evidence.
+
 If `log --from-last` says there is no loggable packet or the packet is stale, recover with one of the commands it prints:
 
 ```bash

--- a/plugins/codex-autoresearch/lib/cli-handlers.ts
+++ b/plugins/codex-autoresearch/lib/cli-handlers.ts
@@ -272,6 +272,17 @@ export function createCliCommandHandlers(deps: LooseObject): Record<string, CliH
         checksPolicy: args.checksPolicy,
       }),
     }),
+    "partial-results": async (args) => ({
+      result: await deps.partialResultsCommand({
+        cwd: args.cwd,
+        fromLast: args.fromLast,
+        artifact: args.artifact,
+        record: args.record,
+        researchSlug: args.researchSlug,
+        commandHash: args.commandHash,
+        description: args.description,
+      }),
+    }),
     log: async (args) => ({
       result: await deps.logExperiment({
         cwd: args.cwd,

--- a/plugins/codex-autoresearch/lib/dashboard-view-model.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.ts
@@ -61,6 +61,12 @@ export function buildDashboardViewModel(context: DashboardContext) {
     qualityGap,
     scaffoldHealth,
     researchIntegrity,
+    experimentEconomics: state.experimentEconomics || null,
+    salvageCandidates: (state.partialResults as LooseObject)?.candidates || [],
+    workflowFriction: state.workflowFriction || [],
+    experimentMemory,
+    segmentTransition: segmentTransitionFromDashboardInput({ state, guidedSetup, qualityGap }),
+    setupState: setupStateFromDashboardInput({ guidedSetup, setupPlan }),
     warnings,
   });
   const decisionEnvelopeSummary = summarizeDecisionEnvelope({
@@ -191,6 +197,12 @@ export function buildDashboardViewModel(context: DashboardContext) {
     guidedSetup,
     decisionEnvelope,
     decisionEnvelopeSummary,
+    experimentEconomics: state.experimentEconomics || decisionEnvelope?.experimentEconomics || null,
+    partialResults: state.partialResults || {
+      candidates: decisionEnvelope?.salvageCandidates || [],
+      skippedArtifacts: [],
+    },
+    workflowFriction: state.workflowFriction || decisionEnvelope?.workflowFriction || [],
     scaffoldHealth,
     researchIntegrity,
     lastRun: guidedSetup?.lastRun || null,
@@ -307,6 +319,12 @@ function normalizeDecisionEnvelope({
   qualityGap = null,
   scaffoldHealth = null,
   researchIntegrity = null,
+  experimentEconomics = null,
+  salvageCandidates = [],
+  workflowFriction = [],
+  experimentMemory = null,
+  segmentTransition = null,
+  setupState = null,
   warnings = [],
 }: LooseObject) {
   const supplied = firstRecord(
@@ -333,7 +351,48 @@ function normalizeDecisionEnvelope({
     researchIntegrity,
     finalization: finalizePreview,
     qualityGap,
+    experimentEconomics,
+    salvageCandidates,
+    workflowFriction,
+    experimentMemory,
+    segmentTransition,
+    setupState,
   });
+}
+
+function setupStateFromDashboardInput({ guidedSetup, setupPlan }: LooseObject) {
+  const blockers = [...stringList(setupPlan?.missing), ...stringList(setupPlan?.missingEssentials)];
+  if (!guidedSetup?.stage && blockers.length === 0) return null;
+  return {
+    stage: cleanText(guidedSetup?.stage),
+    blockers,
+    nextAction:
+      cleanText(guidedSetup?.nextAction) || cleanText(setupPlan?.nextStep?.nextAction?.reason),
+  };
+}
+
+function segmentTransitionFromDashboardInput({ state, guidedSetup, qualityGap }: LooseObject) {
+  const limit = guidedSetup?.state?.limit || guidedSetup?.limit || state?.limit || {};
+  const limitReached =
+    limit.limitReached === true ||
+    (Number.isFinite(Number(limit.remainingIterations)) && Number(limit.remainingIterations) <= 0);
+  if (limitReached || guidedSetup?.stage === "limit-reached") {
+    return {
+      required: true,
+      nextAction:
+        cleanText(guidedSetup?.nextAction) ||
+        "The active segment reached its limit; extend the limit or start a new segment.",
+      triggeredBy: ["limit"],
+    };
+  }
+  if (qualityGap?.done === true) {
+    return {
+      required: true,
+      nextAction: "The active quality round is closed; refresh gaps or preview finalization.",
+      triggeredBy: ["qualityRound"],
+    };
+  }
+  return null;
 }
 
 function summarizeDecisionEnvelope({
@@ -358,6 +417,12 @@ function summarizeDecisionEnvelope({
     (Number.isFinite(Number(limit.remainingIterations)) && Number(limit.remainingIterations) <= 0);
   const finalization = envelope?.finalizationReadiness || {};
   const qualityRound = envelope?.qualityRound || {};
+  const canonicalSummary = summaryFromCanonicalNextAction(envelope?.canonicalNextAction, {
+    current,
+    measurements,
+    envelope,
+  });
+  if (canonicalSummary && canonicalSummary.kind !== "next-packet") return canonicalSummary;
 
   let summary = {
     kind: "continue",
@@ -467,6 +532,61 @@ function summarizeDecisionEnvelope({
   }
 
   return summary;
+}
+
+function summaryFromCanonicalNextAction(
+  action: unknown,
+  { current, measurements, envelope }: LooseObject,
+) {
+  if (!action || typeof action !== "object") return null;
+  const canonical = action as LooseObject;
+  const kind = cleanText(canonical.kind);
+  if (!kind) return null;
+  return {
+    kind,
+    priority: canonicalPriorityLabel(canonical.priority),
+    title: cleanText(canonical.title) || canonicalTitle(kind),
+    detail:
+      cleanText(canonical.reason) || cleanText(envelope?.nextAction) || "Review before continuing.",
+    command: cleanText(canonical.command),
+    source: "decision-envelope",
+    fresh: envelope?.latestPacketFreshness?.fresh ?? null,
+    segment: envelope?.activeSegment?.segment ?? null,
+    runs: envelope?.activeSegment?.runs ?? current.length,
+    measurementRuns: measurements.length,
+    finalizationReady: envelope?.finalizationReadiness?.ready ?? null,
+    canonical: true,
+  };
+}
+
+function canonicalPriorityLabel(value: unknown): string {
+  const priority = Number(value);
+  if (!Number.isFinite(priority)) return cleanText(value) || "Next";
+  if (priority <= 2) return "Critical";
+  if (priority <= 5) return "Review";
+  if (priority <= 8) return "Pivot";
+  if (priority === 9) return "Review";
+  return "Next";
+}
+
+function canonicalTitle(kind: string): string {
+  const titles: Record<string, string> = {
+    "safety-blocker": "Resolve the safety blocker",
+    "benchmark-mismatch": "Repair the benchmark mismatch",
+    "workflow-friction": "Remove workflow friction",
+    "stale-packet": "Replace the stale packet",
+    setup: "Complete setup",
+    "benchmark-command": "Add a benchmark command",
+    "partial-salvage": "Review partial results",
+    "log-decision": "Log the last packet",
+    "context-distillation": "Refresh context",
+    "segment-transition": "Start a new segment",
+    "quality-gap": "Close accepted quality gaps",
+    "plateau-pivot": "Pivot before repeating the plateau",
+    finalization: "Preview finalization",
+    "next-packet": "Run the next measured hypothesis",
+  };
+  return titles[kind] || "Next action";
 }
 
 const UNKNOWN = "unknown";
@@ -1562,8 +1682,17 @@ function actionFromDecisionEnvelope(
     guidedSetup?.commands?.replaceLast ||
     (setupPlan?.defaultBenchmarkCommandReady ? commandMap.get("next run") : "");
   const commandByKind: Record<string, string> = {
+    "safety-blocker": commandMap.get("doctor") || "",
+    "workflow-friction": commandMap.get("doctor") || "",
+    "benchmark-mismatch": commandMap.get("benchmark lint") || commandMap.get("doctor") || "",
     "stale-packet":
       stalePacketCommand || guidedSetup?.commands?.setup || commandMap.get("setup plan") || "",
+    "partial-salvage": commandMap.get("partial results") || "",
+    "context-distillation": cleanText(summary.command) || "",
+    "quality-gap": commandMap.get("gap candidates") || "",
+    "plateau-pivot": commandMap.get("next run") || "",
+    finalization: commandMap.get("finalize preview") || "",
+    "next-packet": commandMap.get("next run") || "",
     setup: guidedSetup?.commands?.setup || commandMap.get("setup plan") || "",
     "benchmark-command": guidedSetup?.commands?.setup || commandMap.get("setup plan") || "",
     "log-decision":
@@ -1581,7 +1710,16 @@ function actionFromDecisionEnvelope(
     baseline: guidedSetup?.commands?.baseline || commandMap.get("next run") || "",
   };
   const labelByKind: Record<string, string> = {
+    "safety-blocker": "Doctor",
+    "workflow-friction": "Doctor",
+    "benchmark-mismatch": "Lint",
     "stale-packet": stalePacketCommand ? "Next" : "Setup",
+    "partial-salvage": "Partial",
+    "context-distillation": "Context",
+    "quality-gap": "Gaps",
+    "plateau-pivot": "Next",
+    finalization: "Preview",
+    "next-packet": "Next",
     setup: "Setup",
     "benchmark-command": "Setup",
     "log-decision": "Log",
@@ -1591,7 +1729,16 @@ function actionFromDecisionEnvelope(
     baseline: "Next",
   };
   const safeActionByKind: Record<string, string> = {
+    "safety-blocker": "doctor",
+    "workflow-friction": "doctor",
+    "benchmark-mismatch": "benchmark-lint",
     "stale-packet": stalePacketCommand ? "" : "setup-plan",
+    "partial-salvage": "partial-results",
+    "context-distillation": "session-forensics",
+    "quality-gap": "gap-candidates",
+    "plateau-pivot": "next",
+    finalization: "finalize-preview",
+    "next-packet": "next",
     setup: "setup-plan",
     "benchmark-command": "setup-plan",
     "segment-transition": "new-segment",
@@ -1605,20 +1752,43 @@ function actionFromDecisionEnvelope(
     detail: cleanText(summary.detail) || "Review the decision envelope before continuing.",
     utilityCopy: decisionEnvelopeUtility(kind),
     safeAction: safeActionByKind[kind] || "",
-    command: commandByKind[kind] || commandMap.get("next run") || "",
+    command: cleanText(summary.command) || commandByKind[kind] || commandMap.get("next run") || "",
     commandLabel: labelByKind[kind] || "Next",
-    tone:
-      kind === "finalize-preview"
-        ? "good"
-        : ["stale-packet", "setup", "benchmark-command", "log-decision", "plateau"].includes(kind)
-          ? "warn"
-          : "focus",
+    tone: ["finalize-preview", "finalization"].includes(kind)
+      ? "good"
+      : [
+            "safety-blocker",
+            "benchmark-mismatch",
+            "workflow-friction",
+            "stale-packet",
+            "setup",
+            "benchmark-command",
+            "log-decision",
+            "plateau",
+            "plateau-pivot",
+          ].includes(kind)
+        ? "warn"
+        : "focus",
     source: cleanText(summary.source) || "decision-envelope",
   });
 }
 
 function decisionEnvelopeUtility(kind: string): string {
+  if (kind === "safety-blocker") return "Safety blockers come before benchmark work.";
+  if (kind === "workflow-friction")
+    return "Workflow friction should be removed before spending another packet.";
+  if (kind === "benchmark-mismatch")
+    return "Benchmark timeout and command-shape mismatches come before reruns.";
   if (kind === "stale-packet") return "Authoritative packet freshness blocks logging old metrics.";
+  if (kind === "partial-salvage")
+    return "Review completed artifact rows before rerunning an expensive failed packet.";
+  if (kind === "context-distillation")
+    return "Refresh bounded context before context loss repeats the same work.";
+  if (kind === "quality-gap")
+    return "Accepted quality gaps should drive the next implementation step.";
+  if (kind === "plateau-pivot") return "Plateau evidence should redirect the next hypothesis.";
+  if (kind === "finalization") return "Finalization is ready after higher-priority loop checks.";
+  if (kind === "next-packet") return "The next packet should produce metric evidence and ASI.";
   if (kind === "setup") return "Setup blockers come before trustworthy metrics.";
   if (kind === "benchmark-command")
     return "A repeatable benchmark command comes before more segment work.";

--- a/plugins/codex-autoresearch/lib/experiment-economics.ts
+++ b/plugins/codex-autoresearch/lib/experiment-economics.ts
@@ -1,0 +1,163 @@
+import { resolveDecisionThresholds } from "./decision-thresholds.js";
+import { commandClassFor, type RunnerProgressSnapshot } from "./runner-progress.js";
+import { finiteMetric } from "./session-core.js";
+
+type LooseObject = Record<string, any>;
+
+export type RuntimeClass = "short" | "medium" | "long" | "expensive";
+
+export interface ExperimentEconomicsWarning {
+  code: string;
+  message: string;
+  recommendation: string;
+  details?: LooseObject;
+}
+
+export interface ExperimentEconomicsSummary {
+  runtimeClass: RuntimeClass;
+  expectedRuntimeSeconds: number | null;
+  baselineFreshness: "missing" | "current" | "stale" | "unknown";
+  freshRunRequired: boolean;
+  freshRunReason: string;
+  warnings: ExperimentEconomicsWarning[];
+  progress: RunnerProgressSnapshot | null;
+}
+
+export function runtimeClassFor(seconds: unknown, fallbackLong = false): RuntimeClass {
+  const value = Number(seconds);
+  if (!Number.isFinite(value)) return fallbackLong ? "expensive" : "medium";
+  if (value < 60) return "short";
+  if (value < 600) return "medium";
+  if (value < 1800) return "long";
+  return "expensive";
+}
+
+export function analyzeExperimentEconomics({
+  state = {},
+  lastRun = null,
+  progress = null,
+  thresholds: thresholdConfig = {},
+}: LooseObject = {}): ExperimentEconomicsSummary {
+  const thresholds = resolveDecisionThresholds({ decisionThresholds: thresholdConfig });
+  const runs = Array.isArray(state.current) ? state.current : [];
+  const recentRuns = runs.slice(-thresholds.repeatedSmallProbeWindow);
+  const warnings: ExperimentEconomicsWarning[] = [];
+  const lastDuration =
+    finiteMetric(lastRun?.run?.durationSeconds) ??
+    finiteMetric(progress?.elapsedSeconds) ??
+    finiteMetric(lastRun?.packetEvidence?.progressSnapshot?.elapsedSeconds) ??
+    median(
+      recentRuns
+        .map((run: LooseObject) => finiteMetric(run.durationSeconds ?? run.elapsedSeconds))
+        .filter((value: number | null): value is number => value != null),
+    );
+  const runtimeClass = runtimeClassFor(
+    lastDuration,
+    Boolean(progress?.staleProgressReason || lastRun?.packetEvidence?.timedOut),
+  );
+  const outerTimeout = finiteMetric(lastRun?.packetEvidence?.timeoutSeconds);
+  const innerTimeout = innerTimeoutSeconds(lastRun);
+  if (outerTimeout != null && innerTimeout != null && outerTimeout < innerTimeout) {
+    warnings.push({
+      code: "outer_timeout_shorter_than_inner",
+      message: `Packet timeout ${outerTimeout}s is shorter than inner workload timeout ${innerTimeout}s.`,
+      recommendation:
+        "Raise the outer packet timeout or lower the inner benchmark timeout before rerunning.",
+      details: { outerTimeout, innerTimeout },
+    });
+  }
+  const repeated = repeatedSmallProbeWarning(recentRuns, thresholds, runtimeClass);
+  if (repeated) warnings.push(repeated);
+  if (progress?.staleProgressReason) {
+    warnings.push({
+      code: "stale_progress",
+      message: progress.staleProgressReason,
+      recommendation: "Inspect the active artifact or child command before restarting the packet.",
+      details: {
+        commandClass: progress.commandClass,
+        latestArtifactRow: progress.latestArtifactRow,
+      },
+    });
+  }
+  const baselineFreshness = baselineFreshnessFor(state);
+  return {
+    runtimeClass,
+    expectedRuntimeSeconds: lastDuration,
+    baselineFreshness,
+    freshRunRequired: baselineFreshness !== "current" || warnings.length > 0,
+    freshRunReason:
+      baselineFreshness === "current" && warnings.length === 0
+        ? "Current segment has baseline evidence and no economics warning."
+        : warnings[0]?.recommendation || "Run a fresh packet after restoring baseline confidence.",
+    warnings,
+    progress,
+  };
+}
+
+function repeatedSmallProbeWarning(
+  recentRuns: LooseObject[],
+  thresholds: ReturnType<typeof resolveDecisionThresholds>,
+  runtimeClass: RuntimeClass,
+): ExperimentEconomicsWarning | null {
+  if (!["medium", "long", "expensive"].includes(runtimeClass)) return null;
+  const weakRuns = recentRuns.filter(isRejectedOrRegressed);
+  if (weakRuns.length < thresholds.repeatedSmallProbeMinimum) return null;
+  return {
+    code: "repeated_small_probe",
+    message: `${weakRuns.length} of the last ${recentRuns.length} runs were rejected, crashed, checks-failed, or regressed.`,
+    recommendation:
+      "Pivot to a changed precondition or distant-scout lane before spending another packet.",
+    details: {
+      runs: weakRuns.map((run) => run.run).filter(Boolean),
+      runtimeClass,
+    },
+  };
+}
+
+function isRejectedOrRegressed(run: LooseObject): boolean {
+  const status = String(run.status || "");
+  if (["discard", "crash", "checks_failed"].includes(status)) return true;
+  return Boolean(run.asi?.regression || run.regression || run.promotion?.label === "invalidated");
+}
+
+function baselineFreshnessFor(state: LooseObject): ExperimentEconomicsSummary["baselineFreshness"] {
+  if (finiteMetric(state.baseline) == null) return "missing";
+  if (state.config?.benchmarkContractChanged || state.benchmarkConfigDrift?.drifted) return "stale";
+  return "current";
+}
+
+function innerTimeoutSeconds(lastRun: LooseObject | null): number | null {
+  const explicit =
+    finiteMetric(lastRun?.run?.benchmarkContract?.innerTimeoutSeconds) ??
+    finiteMetric(lastRun?.run?.innerTimeoutSeconds) ??
+    finiteMetric(lastRun?.packetEvidence?.commandIdentity?.innerTimeoutSeconds);
+  if (explicit != null) return explicit;
+  const command = String(
+    lastRun?.packetEvidence?.commandIdentity?.command || lastRun?.run?.command || "",
+  );
+  const parsed = parseTimeoutFromCommand(command);
+  return parsed ?? null;
+}
+
+function parseTimeoutFromCommand(command: string): number | null {
+  const match = command.match(
+    /(?:--(?:test-)?timeout(?:-seconds|Seconds)?|timeout(?:Seconds)?)=?\s*([0-9.]+)/i,
+  );
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value)) return null;
+  return /testtimeout/i.test(match[0]) && value > 1000 ? value / 1000 : value;
+}
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+export function economicsCommandClass(lastRun: LooseObject | null): string {
+  return commandClassFor(
+    lastRun?.packetEvidence?.commandIdentity?.command || lastRun?.run?.command || "",
+  );
+}

--- a/plugins/codex-autoresearch/lib/experiment-memory.ts
+++ b/plugins/codex-autoresearch/lib/experiment-memory.ts
@@ -1,4 +1,5 @@
 import { finiteMetric } from "./session-core.js";
+import { resolveDecisionThresholds } from "./decision-thresholds.js";
 
 type LooseObject = Record<string, any>;
 type Direction = "lower" | "higher" | string;
@@ -22,6 +23,8 @@ type FamilySummary = LooseObject & {
   bestRun: LooseObject | null;
   bestKeptRun: LooseObject | null;
   exhausted?: boolean;
+  failedRuns?: number[];
+  requiredPrecondition?: string;
 };
 
 const FAILURE_STATUSES = new Set(["discard", "crash", "checks_failed"]);
@@ -49,6 +52,13 @@ function isRejectedStatus(status: unknown): boolean {
   return FAILURE_STATUSES.has(String(status));
 }
 
+function isRejectedOrRegressedRun(run: LooseObject): boolean {
+  return (
+    isRejectedStatus(run.status) ||
+    Boolean(run.asi?.regression || run.regression || run.promotion?.label === "invalidated")
+  );
+}
+
 function nextActionHintFromAsi(asi: LooseObject): string {
   return asi.next_action_hint || asi.nextAction || asi.next_action || "";
 }
@@ -66,8 +76,23 @@ function compactMemoryRun(run: MemoryRun, asi = getAsi(run)) {
   };
 }
 
+function missingAsiFields(run: MemoryRun, asi = getAsi(run)): string[] {
+  const missing = [];
+  if (!asi.hypothesis) missing.push("hypothesis");
+  if (!asi.evidence) missing.push("evidence");
+  if (
+    !isKeepStatus(run.status) &&
+    !asi.next_action_hint &&
+    !asi.nextAction &&
+    !asi.rollback_reason
+  ) {
+    missing.push("next_action_hint_or_rollback_reason");
+  }
+  return missing;
+}
+
 function isMissingAsiMemory(run: MemoryRun, asi = getAsi(run)): boolean {
-  return !asi.evidence && !asi.rollback_reason && (isKeepStatus(run.status) || !asi.hypothesis);
+  return missingAsiFields(run, asi).length > 0;
 }
 
 export function buildExperimentMemory({
@@ -75,10 +100,12 @@ export function buildExperimentMemory({
   direction = "lower",
   settings = {},
 }: LooseObject = {}) {
+  const thresholds = resolveDecisionThresholds(settings);
   const kept: LooseObject[] = [];
   const rejected: LooseObject[] = [];
   const nextActions: LooseObject[] = [];
   const missingAsiRuns: number[] = [];
+  const missingAsiDetails: LooseObject[] = [];
   const enriched: MemoryRun[] = runs.map((run: LooseObject) => ({
     ...run,
     family: familyForRun(run),
@@ -93,6 +120,12 @@ export function buildExperimentMemory({
     }
     if (isMissingAsiMemory(run, asi)) {
       missingAsiRuns.push(run.run);
+      missingAsiDetails.push({
+        run: run.run,
+        status: run.status,
+        missingFields: missingAsiFields(run, asi),
+        risk: "Sparse ASI increases the chance that future packets repeat rejected work.",
+      });
     }
     if (isKeepStatus(run.status)) {
       kept.push(compact);
@@ -104,13 +137,31 @@ export function buildExperimentMemory({
     }
   }
 
-  const families = summarizeFamilies(enriched, direction);
-  const plateau = detectPlateau({ runs: enriched, families, direction });
+  const families = summarizeFamilies(enriched, direction, thresholds);
+  const metricShelves = detectMetricShelves(enriched, thresholds);
+  const plateau = detectPlateau({ runs: enriched, families, direction, metricShelves });
   const novelty = noveltySummary(enriched);
   const warnings = [];
   if (runs.length && missingAsiRuns.length) {
-    warnings.push(`Runs missing ASI memory fields: ${missingAsiRuns.slice(-5).join(", ")}.`);
+    warnings.push(
+      `Runs missing ASI memory fields: ${missingAsiRuns.slice(-5).join(", ")}; future packets may repeat work.`,
+    );
   }
+  const exhaustedFamilies = families
+    .filter((family) => family.exhausted)
+    .map((family) => ({
+      family: family.label,
+      key: family.key,
+      runs: family.failedRuns || [],
+      reason:
+        family.reason ||
+        `${family.label} has repeated rejected, crashed, checks-failed, or regressed runs without a kept improvement.`,
+      requiredPrecondition:
+        family.requiredPrecondition ||
+        "Change a precondition, input corpus, benchmark contract, or implementation lane before retrying.",
+    }));
+  for (const family of exhaustedFamilies.slice(0, 2)) warnings.push(family.reason);
+  for (const shelf of metricShelves.slice(0, 2)) warnings.push(shelf.reason);
   if (plateau.detected) warnings.push(plateau.reason);
   const latestNextAction = nextActions.at(-1)?.nextActionHint || "";
   const lanePortfolio = buildLanePortfolio({
@@ -137,7 +188,10 @@ export function buildExperimentMemory({
     latestNextAction,
     families,
     plateau,
+    metricShelves,
+    exhaustedFamilies,
     novelty,
+    missingAsiDetails,
     lanePortfolio,
     diversityGuidance,
     summary: {
@@ -146,6 +200,8 @@ export function buildExperimentMemory({
       missingAsi: missingAsiRuns.length,
       families: families.length,
       plateau: plateau.detected,
+      exhaustedFamilies: exhaustedFamilies.length,
+      metricShelves: metricShelves.length,
       suggestedLane: diversityGuidance?.id || "",
     },
   };
@@ -156,6 +212,18 @@ export function detectRepeatedHypothesis({ proposed = "", memory = {} }: LooseOb
   if (!key) return null;
   const candidates = [...(memory.rejected || []), ...(memory.kept || [])];
   const proposedFamily = canonicalFamilyKey(proposed);
+  const exhausted = (memory.exhaustedFamilies || []).find((family: LooseObject) =>
+    familyKeyMatches(proposedFamily, canonicalFamilyKey(family.key || family.family || "")),
+  );
+  if (exhausted) {
+    return {
+      matchedRun: exhausted.runs?.at(-1) ?? null,
+      status: "exhausted",
+      family: exhausted.family,
+      reason: exhausted.reason,
+      requiredPrecondition: exhausted.requiredPrecondition,
+    };
+  }
   for (const item of candidates) {
     const previous = normalizeHypothesis(item.hypothesis || item.description);
     const previousFamily = canonicalFamilyKey(item.family || item.hypothesis || item.description);
@@ -199,8 +267,13 @@ function familyKeyMatches(proposedFamily: string, previousFamily: string): boole
   );
 }
 
-function summarizeFamilies(runs: MemoryRun[], direction: Direction): FamilySummary[] {
+function summarizeFamilies(
+  runs: MemoryRun[],
+  direction: Direction,
+  thresholds: ReturnType<typeof resolveDecisionThresholds>,
+): FamilySummary[] {
   const map = new Map<string, FamilySummary>();
+  const familyRuns = new Map<string, MemoryRun[]>();
   for (const run of runs) {
     const key = run.family.key;
     if (!map.has(key)) {
@@ -216,13 +289,14 @@ function summarizeFamilies(runs: MemoryRun[], direction: Direction): FamilySumma
         statuses: {},
       });
     }
+    familyRuns.set(key, [...(familyRuns.get(key) || []), run]);
     const family = map.get(key)!;
     const status = run.status || "unknown";
     family.runs += 1;
     family.latestRun = compactFamilyRun(run);
     family.statuses[status] = (family.statuses[status] || 0) + 1;
     if (isKeepStatus(status)) family.kept += 1;
-    if (isRejectedStatus(status)) family.rejected += 1;
+    if (isRejectedOrRegressedRun(run)) family.rejected += 1;
     const metric = finiteMetric(run.metric);
     const bestMetric = finiteMetric(family.bestRun?.metric);
     const bestKeptMetric = finiteMetric(family.bestKeptRun?.metric);
@@ -237,10 +311,25 @@ function summarizeFamilies(runs: MemoryRun[], direction: Direction): FamilySumma
       family.bestKeptRun = compactFamilyRun(run);
     }
   }
-  const summarized = [...map.values()].map((family) => ({
-    ...family,
-    exhausted: family.runs >= 3 && family.rejected >= Math.max(2, family.kept + 1),
-  }));
+  const summarized = [...map.values()].map((family) => {
+    const runsForFamily = familyRuns.get(family.key) || [];
+    const lastKeepIndex = findLastIndex(runsForFamily, (run) => isKeepStatus(run.status));
+    const sinceKeep = runsForFamily.slice(lastKeepIndex + 1);
+    const failedRuns = sinceKeep.filter(isRejectedOrRegressedRun).map((run) => run.run);
+    const exhausted = failedRuns.length >= thresholds.rejectedOrRegressedRunsInFamily;
+    return {
+      ...family,
+      rejected: Math.max(family.rejected, failedRuns.length),
+      failedRuns,
+      exhausted,
+      reason: exhausted
+        ? `${family.label} is exhausted: ${failedRuns.length} recent rejected, crashed, checks-failed, or regressed run(s) since the last keep.`
+        : "",
+      requiredPrecondition: exhausted
+        ? "Change a precondition, input corpus, benchmark contract, or implementation lane before retrying this family."
+        : "",
+    };
+  });
   const sorted = summarized.sort(
     (a, b) => b.runs - a.runs || (b.latestRun?.run || 0) - (a.latestRun?.run || 0),
   );
@@ -256,10 +345,12 @@ function detectPlateau({
   runs,
   families,
   direction,
+  metricShelves = [],
 }: {
   runs: MemoryRun[];
   families: FamilySummary[];
   direction: Direction;
+  metricShelves?: LooseObject[];
 }): LooseObject {
   const finiteRuns = runs.filter(hasNumericMetricForPlateau);
   const keptFinite = finiteRuns.filter((run) => isKeepStatus(run.status));
@@ -276,7 +367,7 @@ function detectPlateau({
     best &&
     runs.length >= 5 &&
     runsSinceBest >= 4 &&
-    (repeatedFamilyRuns >= 3 || recentFailures >= 3),
+    (repeatedFamilyRuns >= 3 || recentFailures >= 3 || metricShelves.length > 0),
   );
   return {
     detected,
@@ -286,13 +377,53 @@ function detectPlateau({
     recentFailures,
     repeatedFamilyRuns,
     repeatedFamily: repeatedFamily ? repeatedFamily.label : "",
+    metricShelves,
     reason: detected
-      ? `Plateau risk: ${runsSinceBest} runs since the best keep, with ${repeatedFamilyRuns} recent run(s) in ${repeatedFamily?.label || "one family"}.`
+      ? `Plateau risk: ${runsSinceBest} runs since the best keep, with ${repeatedFamilyRuns} recent run(s) in ${repeatedFamily?.label || "one family"}${metricShelves.length ? ` and shelf ${metricShelves[0].value}` : ""}.`
       : "",
     recommendation: detected
       ? "Force a distant scout or constraint-removal lane before another near-neighbor tweak."
       : "Continue balancing incumbent confirmation with fresh scouts.",
   };
+}
+
+function detectMetricShelves(
+  runs: MemoryRun[],
+  thresholds: ReturnType<typeof resolveDecisionThresholds>,
+): LooseObject[] {
+  const buckets: Array<{ value: number; runs: number[] }> = [];
+  for (const run of runs) {
+    const metric = finiteMetric(run.metric);
+    if (metric == null) continue;
+    const bucket = buckets.find((item) =>
+      sameShelf(item.value, metric, thresholds.shelfRelativeEpsilon),
+    );
+    if (bucket) {
+      bucket.runs.push(run.run);
+    } else {
+      buckets.push({ value: metric, runs: [run.run] });
+    }
+  }
+  return buckets
+    .filter((bucket) => bucket.runs.length >= thresholds.rejectedOrRegressedRunsInFamily)
+    .map((bucket) => ({
+      value: bucket.value,
+      runs: bucket.runs,
+      reason: `${bucket.runs.length} runs are clustered on metric shelf ${bucket.value}; change a precondition before repeating this lane.`,
+    }));
+}
+
+function sameShelf(left: number, right: number, epsilon: number): boolean {
+  if (Number.isInteger(left) && Number.isInteger(right)) return left === right;
+  const scale = Math.max(1, Math.abs(left), Math.abs(right));
+  return Math.abs(left - right) / scale <= epsilon;
+}
+
+function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index])) return index;
+  }
+  return -1;
 }
 
 function hasNumericMetricForPlateau(run: MemoryRun): boolean {

--- a/plugins/codex-autoresearch/lib/partial-results.ts
+++ b/plugins/codex-autoresearch/lib/partial-results.ts
@@ -1,0 +1,459 @@
+import { createHash } from "node:crypto";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { evidenceClaim, type EvidenceClaim } from "./evidence-index.js";
+import { finiteMetric } from "./session-core.js";
+
+type LooseRecord = Record<string, unknown>;
+
+export type PartialResultCandidateStatus = "scored" | "manual_review";
+
+export interface PartialResultSalvagerOptions {
+  workDir: string;
+  primaryMetricName?: string;
+}
+
+export interface DiscoverPartialResultCandidatesOptions extends PartialResultSalvagerOptions {
+  lastRunPacket: unknown;
+}
+
+export interface PartialResultCandidate {
+  id: string;
+  artifactName: string;
+  artifactPath: string;
+  rowIndex: number;
+  status: PartialResultCandidateStatus;
+  reason: string;
+  metricName: string | null;
+  metricValue: number | null;
+  provenance: PartialResultCandidateProvenance;
+}
+
+export interface PartialResultCandidateProvenance {
+  source: "packetEvidence.artifacts";
+  commandHash: string | null;
+  artifactName: string;
+  artifactPath: string;
+  rowIndex: number;
+  schemaVersion: string | number | null;
+  formulaVersion: string | null;
+  diagnosticOnly: true;
+}
+
+export interface PartialResultArtifactNotice {
+  artifactName: string;
+  artifactPath: string;
+  reason: string;
+}
+
+export interface PartialResultDiscovery {
+  candidates: PartialResultCandidate[];
+  skippedArtifacts: PartialResultArtifactNotice[];
+}
+
+interface ArtifactEntry {
+  name: string;
+  path: string;
+  exists: boolean | null;
+  quarantined: boolean;
+}
+
+interface ResolvedArtifact {
+  absolutePath: string;
+  relativePath: string;
+}
+
+type ArtifactResolution = { ok: true; artifact: ResolvedArtifact } | { ok: false; reason: string };
+
+interface ParsedArtifact {
+  rows: unknown[];
+  schemaVersion: string | number | null;
+  formulaVersion: string | null;
+  metricName: string | null;
+}
+
+export class PartialResultSalvager {
+  readonly workDir: string;
+  readonly primaryMetricName: string | null;
+
+  constructor(options: PartialResultSalvagerOptions) {
+    this.workDir = path.resolve(options.workDir || process.cwd());
+    this.primaryMetricName = stringValue(options.primaryMetricName);
+  }
+
+  async discover(lastRunPacket: unknown): Promise<PartialResultDiscovery> {
+    const packetMetricName = packetPrimaryMetricName(lastRunPacket);
+    const commandHash = packetCommandHash(lastRunPacket);
+    const candidates: PartialResultCandidate[] = [];
+    const skippedArtifacts: PartialResultArtifactNotice[] = [];
+
+    for (const artifact of packetArtifactEntries(lastRunPacket)) {
+      const displayedPath = displayArtifactPath(this.workDir, artifact.path);
+      if (artifact.quarantined) {
+        skippedArtifacts.push({
+          artifactName: artifact.name,
+          artifactPath: displayedPath,
+          reason: "artifact_quarantined",
+        });
+        continue;
+      }
+      if (artifact.exists === false) {
+        skippedArtifacts.push({
+          artifactName: artifact.name,
+          artifactPath: displayedPath,
+          reason: "artifact_missing",
+        });
+        continue;
+      }
+
+      const resolved = await resolveArtifactPath(this.workDir, artifact.path);
+      if (!resolved.ok) {
+        skippedArtifacts.push({
+          artifactName: artifact.name,
+          artifactPath: displayedPath,
+          reason: resolved.reason,
+        });
+        continue;
+      }
+
+      const parsed = await readPartialResultArtifact(resolved.artifact.absolutePath);
+      if (!parsed.ok) {
+        skippedArtifacts.push({
+          artifactName: artifact.name,
+          artifactPath: resolved.artifact.relativePath,
+          reason: parsed.reason,
+        });
+        continue;
+      }
+
+      for (const [rowIndex, row] of parsed.artifact.rows.entries()) {
+        if (!isRecord(row)) continue;
+        candidates.push(
+          candidateFromRow({
+            artifact,
+            artifactPath: resolved.artifact.relativePath,
+            artifactMetadata: parsed.artifact,
+            commandHash,
+            packetMetricName,
+            primaryMetricName: this.primaryMetricName,
+            row,
+            rowIndex,
+          }),
+        );
+      }
+    }
+
+    return {
+      candidates: candidates.sort(compareCandidates),
+      skippedArtifacts: skippedArtifacts.sort(compareNotices),
+    };
+  }
+
+  buildEvidenceClaim(candidate: PartialResultCandidate): EvidenceClaim {
+    return buildPartialResultEvidenceClaim(candidate);
+  }
+}
+
+export async function discoverPartialResultCandidates(
+  options: DiscoverPartialResultCandidatesOptions,
+): Promise<PartialResultDiscovery> {
+  return new PartialResultSalvager(options).discover(options.lastRunPacket);
+}
+
+export function buildPartialResultEvidenceClaim(candidate: PartialResultCandidate): EvidenceClaim {
+  const metric =
+    candidate.metricName && candidate.metricValue != null
+      ? `${candidate.metricName}=${candidate.metricValue}`
+      : "metric unavailable";
+  return evidenceClaim({
+    claim: `Partial result row ${candidate.rowIndex} from ${candidate.artifactName} is ${candidate.status}: ${metric}. Diagnostic only; not promotion-grade evidence.`,
+    source: `${candidate.artifactPath}#row-${candidate.rowIndex}`,
+    evidenceType: "benchmark-artifact",
+    freshness: "current",
+    confidence: candidate.status === "scored" ? "medium" : "low",
+    promotionRelevance: "diagnostic",
+    validatedBy: "partial-results",
+  });
+}
+
+async function readPartialResultArtifact(
+  artifactPath: string,
+): Promise<{ ok: true; artifact: ParsedArtifact } | { ok: false; reason: string }> {
+  let body: string;
+  try {
+    body = await fsp.readFile(artifactPath, "utf8");
+  } catch (error: unknown) {
+    return {
+      ok: false,
+      reason: missingFileError(error) ? "artifact_missing" : "artifact_unreadable",
+    };
+  }
+
+  try {
+    return { ok: true, artifact: parsePartialResultArtifact(JSON.parse(body)) };
+  } catch {
+    return { ok: false, reason: "artifact_invalid_json" };
+  }
+}
+
+function parsePartialResultArtifact(value: unknown): ParsedArtifact {
+  if (Array.isArray(value)) {
+    return {
+      rows: value,
+      schemaVersion: null,
+      formulaVersion: null,
+      metricName: null,
+    };
+  }
+  if (!isRecord(value)) {
+    throw new Error("partial result artifact must be an object or array");
+  }
+  const rows = Array.isArray(value.rows) ? value.rows : [];
+  return {
+    rows,
+    schemaVersion: versionValue(value.schemaVersion),
+    formulaVersion: stringValue(value.formulaVersion),
+    metricName: stringValue(value.metricName),
+  };
+}
+
+function candidateFromRow({
+  artifact,
+  artifactPath,
+  artifactMetadata,
+  commandHash,
+  packetMetricName,
+  primaryMetricName,
+  row,
+  rowIndex,
+}: {
+  artifact: ArtifactEntry;
+  artifactPath: string;
+  artifactMetadata: ParsedArtifact;
+  commandHash: string | null;
+  packetMetricName: string | null;
+  primaryMetricName: string | null;
+  row: LooseRecord;
+  rowIndex: number;
+}): PartialResultCandidate {
+  const metricName =
+    primaryMetricName ||
+    artifactMetadata.metricName ||
+    stringValue(row.metricName) ||
+    packetMetricName;
+  const metricValue = metricName ? metricValueForRow(row, metricName) : null;
+  const reasons: string[] = [];
+  if (metricName == null || metricValue == null) reasons.push("finite primary metric missing");
+  if (!commandHash) reasons.push("command hash missing");
+  if (artifactMetadata.schemaVersion == null) reasons.push("artifact schema version missing");
+  if (!artifactMetadata.formulaVersion) reasons.push("artifact formula version missing");
+
+  const status: PartialResultCandidateStatus = reasons.length === 0 ? "scored" : "manual_review";
+  const provenance: PartialResultCandidateProvenance = {
+    source: "packetEvidence.artifacts",
+    commandHash,
+    artifactName: artifact.name,
+    artifactPath,
+    rowIndex,
+    schemaVersion: artifactMetadata.schemaVersion,
+    formulaVersion: artifactMetadata.formulaVersion,
+    diagnosticOnly: true,
+  };
+
+  return {
+    id: partialResultCandidateId({
+      artifactName: artifact.name,
+      artifactPath,
+      rowIndex,
+      metricName,
+      metricValue,
+      commandHash,
+      schemaVersion: artifactMetadata.schemaVersion,
+      formulaVersion: artifactMetadata.formulaVersion,
+    }),
+    artifactName: artifact.name,
+    artifactPath,
+    rowIndex,
+    status,
+    reason:
+      status === "scored"
+        ? "Finite primary metric, command hash, and artifact version provenance are present."
+        : reasons.join("; "),
+    metricName,
+    metricValue,
+    provenance,
+  };
+}
+
+function metricValueForRow(row: LooseRecord, metricName: string): number | null {
+  if (Object.hasOwn(row, metricName)) return finiteMetric(row[metricName]);
+  const metrics = isRecord(row.metrics) ? row.metrics : null;
+  if (metrics && Object.hasOwn(metrics, metricName)) return finiteMetric(metrics[metricName]);
+  if (stringValue(row.metricName) === metricName) {
+    return finiteMetric(row.metricValue ?? row.metric);
+  }
+  return null;
+}
+
+function packetArtifactEntries(lastRunPacket: unknown): ArtifactEntry[] {
+  const packet = isRecord(lastRunPacket) ? lastRunPacket : {};
+  const packetEvidence = isRecord(packet.packetEvidence) ? packet.packetEvidence : {};
+  const artifacts = packetEvidence.artifacts;
+  const entries: ArtifactEntry[] = [];
+
+  if (Array.isArray(artifacts)) {
+    for (const [index, item] of artifacts.entries()) {
+      const artifact = isRecord(item) ? item : {};
+      const artifactPath = stringValue(artifact.path) || "";
+      entries.push({
+        name: stringValue(artifact.name) || fallbackArtifactName(artifactPath, index),
+        path: artifactPath,
+        exists: typeof artifact.exists === "boolean" ? artifact.exists : null,
+        quarantined: artifact.quarantined === true,
+      });
+    }
+  } else if (isRecord(artifacts)) {
+    for (const [name, artifactPath] of Object.entries(artifacts)) {
+      entries.push({
+        name,
+        path: stringValue(artifactPath) || "",
+        exists: null,
+        quarantined: false,
+      });
+    }
+  }
+
+  return entries.sort(
+    (left, right) => left.name.localeCompare(right.name) || left.path.localeCompare(right.path),
+  );
+}
+
+function packetPrimaryMetricName(lastRunPacket: unknown): string | null {
+  const packet = isRecord(lastRunPacket) ? lastRunPacket : {};
+  const packetEvidence = isRecord(packet.packetEvidence) ? packet.packetEvidence : {};
+  const run = isRecord(packet.run) ? packet.run : {};
+  const config = isRecord(packet.config) ? packet.config : {};
+  return (
+    stringValue(packetEvidence.metricName) ||
+    stringValue(packetEvidence.primaryMetricName) ||
+    stringValue(run.metricName) ||
+    stringValue(config.metricName) ||
+    stringValue(packet.metricName)
+  );
+}
+
+function packetCommandHash(lastRunPacket: unknown): string | null {
+  const packet = isRecord(lastRunPacket) ? lastRunPacket : {};
+  const packetEvidence = isRecord(packet.packetEvidence) ? packet.packetEvidence : {};
+  const packetCommandIdentity = isRecord(packetEvidence.commandIdentity)
+    ? packetEvidence.commandIdentity
+    : {};
+  const run = isRecord(packet.run) ? packet.run : {};
+  const runCommandIdentity = isRecord(run.commandIdentity) ? run.commandIdentity : {};
+  return (
+    stringValue(packetCommandIdentity.commandHash) ||
+    stringValue(run.commandHash) ||
+    stringValue(runCommandIdentity.commandHash) ||
+    stringValue(packet.commandHash)
+  );
+}
+
+async function resolveArtifactPath(
+  workDir: string,
+  artifactPath: string,
+): Promise<ArtifactResolution> {
+  if (!artifactPath || artifactPath === "<outside-workdir>") {
+    return { ok: false, reason: "artifact_path_outside_workdir" };
+  }
+  const workDirAbsolute = path.resolve(workDir || process.cwd());
+  const lexicalPath = path.isAbsolute(artifactPath)
+    ? path.resolve(artifactPath)
+    : path.resolve(workDirAbsolute, artifactPath);
+  const lexicalRelative = relativeInside(workDirAbsolute, lexicalPath);
+  if (!lexicalRelative) return { ok: false, reason: "artifact_path_outside_workdir" };
+
+  try {
+    const [realWorkDir, realArtifactPath] = await Promise.all([
+      fsp.realpath(workDirAbsolute),
+      fsp.realpath(lexicalPath),
+    ]);
+    const realRelative = relativeInside(realWorkDir, realArtifactPath);
+    if (!realRelative) return { ok: false, reason: "artifact_path_outside_workdir" };
+  } catch (error: unknown) {
+    if (missingFileError(error)) return { ok: false, reason: "artifact_missing" };
+    return { ok: false, reason: "artifact_unreadable" };
+  }
+
+  return { ok: true, artifact: { absolutePath: lexicalPath, relativePath: lexicalRelative } };
+}
+
+function relativeInside(workDir: string, candidatePath: string): string | null {
+  const relative = path.relative(workDir, candidatePath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+  return relative.replace(/\\/g, "/");
+}
+
+function displayArtifactPath(workDir: string, artifactPath: string): string {
+  if (!artifactPath || artifactPath === "<outside-workdir>") return "<outside-workdir>";
+  const workDirAbsolute = path.resolve(workDir || process.cwd());
+  const resolved = path.isAbsolute(artifactPath)
+    ? path.resolve(artifactPath)
+    : path.resolve(workDirAbsolute, artifactPath);
+  return relativeInside(workDirAbsolute, resolved) || "<outside-workdir>";
+}
+
+function partialResultCandidateId(input: {
+  artifactName: string;
+  artifactPath: string;
+  rowIndex: number;
+  metricName: string | null;
+  metricValue: number | null;
+  commandHash: string | null;
+  schemaVersion: string | number | null;
+  formulaVersion: string | null;
+}): string {
+  return `partial-${createHash("sha256").update(JSON.stringify(input)).digest("hex").slice(0, 12)}`;
+}
+
+function compareCandidates(left: PartialResultCandidate, right: PartialResultCandidate): number {
+  return (
+    left.artifactPath.localeCompare(right.artifactPath) ||
+    left.artifactName.localeCompare(right.artifactName) ||
+    left.rowIndex - right.rowIndex ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function compareNotices(
+  left: PartialResultArtifactNotice,
+  right: PartialResultArtifactNotice,
+): number {
+  return (
+    left.artifactPath.localeCompare(right.artifactPath) ||
+    left.artifactName.localeCompare(right.artifactName) ||
+    left.reason.localeCompare(right.reason)
+  );
+}
+
+function fallbackArtifactName(artifactPath: string, index: number): string {
+  return path.basename(artifactPath || "") || `artifact-${index}`;
+}
+
+function versionValue(value: unknown): string | number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return stringValue(value);
+}
+
+function stringValue(value: unknown): string | null {
+  const text = typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
+  return text || null;
+}
+
+function missingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function isRecord(value: unknown): value is LooseRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/plugins/codex-autoresearch/lib/runner-progress.ts
+++ b/plugins/codex-autoresearch/lib/runner-progress.ts
@@ -1,0 +1,203 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+type LooseObject = Record<string, any>;
+
+export interface RunnerProgressSnapshot {
+  packetId: string;
+  commandClass: string;
+  startedAt: string;
+  lastOutputAt: string | null;
+  timeoutSeconds: number | null;
+  timeoutPhase: "none" | "benchmark" | "checks" | "unknown";
+  exitState: "running" | "completed" | "failed" | "timed_out" | "crashed";
+  artifactRoot: string;
+  latestArtifactRow: string;
+  elapsedSeconds: number;
+  staleProgressReason: string;
+  finalArtifactSummary: string;
+}
+
+export function commandClassFor(command: unknown): string {
+  const parts = String(command || "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (parts.length === 0) return "unknown";
+  const head = parts[0].replace(/^["']|["']$/g, "");
+  const base = path.basename(head).toLowerCase();
+  if (["npm", "pnpm", "yarn", "bun"].includes(base)) return parts.slice(0, 3).join(" ");
+  if (["node", "python", "python3", "pwsh", "powershell", "bash", "sh"].includes(base)) {
+    return parts.slice(0, 2).join(" ");
+  }
+  return parts.slice(0, 2).join(" ");
+}
+
+export function createProgressSnapshot({
+  packetId = "",
+  command = "",
+  commandClass = "",
+  startedAt = new Date().toISOString(),
+  timeoutSeconds = null,
+  artifactRoot = "",
+}: LooseObject = {}): RunnerProgressSnapshot {
+  return {
+    packetId: packetId || progressId(command, startedAt),
+    commandClass: commandClass || commandClassFor(command),
+    startedAt: isoTime(startedAt),
+    lastOutputAt: null,
+    timeoutSeconds: finiteNumber(timeoutSeconds),
+    timeoutPhase: "none",
+    exitState: "running",
+    artifactRoot: String(artifactRoot || ""),
+    latestArtifactRow: "",
+    elapsedSeconds: 0,
+    staleProgressReason: "",
+    finalArtifactSummary: "",
+  };
+}
+
+export function updateProgressSnapshot(
+  snapshot: RunnerProgressSnapshot,
+  { output = "", artifactRow = "", observedAt = new Date().toISOString() }: LooseObject = {},
+): RunnerProgressSnapshot {
+  const lastOutputAt = output || artifactRow ? isoTime(observedAt) : snapshot.lastOutputAt;
+  return {
+    ...snapshot,
+    lastOutputAt,
+    latestArtifactRow: artifactRow || snapshot.latestArtifactRow,
+    elapsedSeconds: elapsedSeconds(snapshot.startedAt, observedAt),
+  };
+}
+
+export function finishProgressSnapshot(
+  snapshot: RunnerProgressSnapshot,
+  {
+    exitCode = null,
+    timedOut = false,
+    crashed = false,
+    timeoutPhase = "",
+    completedAt = new Date().toISOString(),
+    artifacts = [],
+  }: LooseObject = {},
+): RunnerProgressSnapshot {
+  const artifactCount = Array.isArray(artifacts)
+    ? artifacts.filter((artifact) => artifact && artifact.quarantined !== true).length
+    : 0;
+  const exitState = timedOut
+    ? "timed_out"
+    : crashed
+      ? "crashed"
+      : exitCode === 0
+        ? "completed"
+        : "failed";
+  return {
+    ...snapshot,
+    timeoutPhase: timedOut ? normalizeTimeoutPhase(timeoutPhase) : "none",
+    exitState,
+    elapsedSeconds: elapsedSeconds(snapshot.startedAt, completedAt),
+    finalArtifactSummary:
+      artifactCount > 0
+        ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} linked`
+        : "No linked artifacts",
+  };
+}
+
+export function staleProgressReason(
+  snapshot: RunnerProgressSnapshot,
+  { now = new Date().toISOString(), staleAfterSeconds = 300 }: LooseObject = {},
+): string {
+  const last = snapshot.lastOutputAt || snapshot.startedAt;
+  const quietSeconds = elapsedSeconds(last, now);
+  if (snapshot.exitState !== "running") return "";
+  if (quietSeconds < Number(staleAfterSeconds || 0)) return "";
+  return `No packet output or artifact progress for ${Math.round(quietSeconds)}s.`;
+}
+
+export function progressSnapshotFromRun({
+  packetId = "",
+  run = {},
+  artifacts = [],
+}: LooseObject = {}): RunnerProgressSnapshot {
+  const existing = isProgressSnapshot(run.progressSnapshot)
+    ? {
+        ...run.progressSnapshot,
+        packetId: packetId || run.progressSnapshot.packetId,
+      }
+    : null;
+  const durationSeconds =
+    finiteNumber(run.durationSeconds) ?? finiteNumber(run.progress?.elapsedSeconds) ?? 0;
+  const finishedAt = run.finishedAt || new Date().toISOString();
+  const startedAt =
+    run.startedAt || new Date(Date.parse(finishedAt) - durationSeconds * 1000).toISOString();
+  const snapshot =
+    existing ||
+    createProgressSnapshot({
+      packetId,
+      command: run.command,
+      startedAt,
+      timeoutSeconds: run.timeoutSeconds,
+      artifactRoot: run.workDir || "",
+    });
+  const withOutput = updateProgressSnapshot(snapshot, {
+    output: run.tailOutput || run.progress?.latestOutputTail || "",
+    artifactRow: latestArtifactRow(artifacts),
+    observedAt: run.lastOutputAt || finishedAt,
+  });
+  return finishProgressSnapshot(withOutput, {
+    exitCode: run.exitCode,
+    timedOut: run.timedOut,
+    crashed: run.exitCode == null && !run.timedOut,
+    timeoutPhase: run.timeoutPhase || (run.timedOut ? "benchmark" : "none"),
+    completedAt: finishedAt,
+    artifacts,
+  });
+}
+
+function isProgressSnapshot(value: unknown): value is RunnerProgressSnapshot {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as LooseObject).startedAt === "string" &&
+    typeof (value as LooseObject).commandClass === "string",
+  );
+}
+
+function progressId(command: unknown, startedAt: unknown): string {
+  return `progress-${createHash("sha256")
+    .update(`${String(command || "")}\n${String(startedAt || "")}`, "utf8")
+    .digest("hex")
+    .slice(0, 12)}`;
+}
+
+function latestArtifactRow(artifacts: LooseObject[]): string {
+  const artifact = [...(artifacts || [])].reverse().find((item) => item?.path && !item.quarantined);
+  if (!artifact) return "";
+  return `${artifact.name || "artifact"}=${artifact.path}`;
+}
+
+function isoTime(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function elapsedSeconds(from: unknown, to: unknown): number {
+  const start = Date.parse(String(from || ""));
+  const end = Date.parse(String(to || ""));
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return 0;
+  return Math.max(0, Number(((end - start) / 1000).toFixed(3)));
+}
+
+function finiteNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeTimeoutPhase(value: unknown): RunnerProgressSnapshot["timeoutPhase"] {
+  const text = String(value || "").toLowerCase();
+  if (text.includes("benchmark")) return "benchmark";
+  if (text.includes("check")) return "checks";
+  return "unknown";
+}

--- a/plugins/codex-autoresearch/lib/runner.ts
+++ b/plugins/codex-autoresearch/lib/runner.ts
@@ -31,6 +31,7 @@ export interface ShellRunOptions {
   maxFullOutputBytes?: number;
   maxMetricOutputBytes?: number;
   maxOutputBytes?: number;
+  onProgress?: (event: { observedAt: string; output: string }) => void;
   retainMetricNames?: string[];
 }
 
@@ -38,14 +39,17 @@ export interface ShellRunResult {
   command: string;
   durationSeconds: number;
   exitCode: number | null;
+  finishedAt: string;
   fullOutput: string;
   fullOutputTruncated: boolean;
+  lastOutputAt: string | null;
   metricOutput: string;
   metricOutputTruncated: boolean;
   output: string;
   outputTruncated: boolean;
   parsedMetrics: Record<string, number>;
   retainedMetricOutput: string;
+  startedAt: string;
   timedOut: boolean;
 }
 
@@ -57,8 +61,11 @@ export interface ProcessRunResult {
   durationMs: number;
   durationSeconds: number;
   exitCode: number | null;
+  finishedAt: string;
+  lastOutputAt: string | null;
   outputTruncated: boolean;
   parsedMetrics: Record<string, number>;
+  startedAt: string;
   stderr: string;
   stderrTruncated: boolean;
   stdout: string;
@@ -176,6 +183,7 @@ export async function runShell(
   options: ShellRunOptions = {},
 ): Promise<ShellRunResult> {
   const startedAt = Date.now();
+  const startedAtIso = new Date(startedAt).toISOString();
   return await new Promise<ShellRunResult>((resolve) => {
     const child = spawn(command, {
       cwd,
@@ -197,6 +205,7 @@ export async function runShell(
     let outputTruncated = false;
     let fullOutputTruncated = false;
     let metricOutputTruncated = false;
+    let lastOutputAt: string | null = null;
     let timedOut = false;
     const metricCollector = createMetricCollector();
     const maxOutputBytes = positiveByteLimit(options.maxOutputBytes, OUTPUT_CAPTURE_BYTES);
@@ -234,6 +243,8 @@ export async function runShell(
       }
     };
     const appendOutput = (text: string) => {
+      lastOutputAt = new Date().toISOString();
+      options.onProgress?.({ observedAt: lastOutputAt, output: text });
       metricCollector.append(text);
       appendMetricLines(text);
       const boundedFullOutput = appendBoundedOutput(fullOutput, text, maxFullOutputBytes);
@@ -266,6 +277,9 @@ export async function runShell(
         exitCode: null,
         timedOut,
         durationSeconds: (Date.now() - startedAt) / 1000,
+        startedAt: startedAtIso,
+        finishedAt: new Date().toISOString(),
+        lastOutputAt,
         output: errorText,
         fullOutput: `${fullOutput}${fullOutput ? "\n" : ""}${errorText}`,
         metricOutput,
@@ -285,6 +299,9 @@ export async function runShell(
         exitCode: code,
         timedOut,
         durationSeconds: (Date.now() - startedAt) / 1000,
+        startedAt: startedAtIso,
+        finishedAt: new Date().toISOString(),
+        lastOutputAt,
         output,
         fullOutput,
         metricOutput,
@@ -308,6 +325,7 @@ export async function runProcess(
   }: ProcessRunOptions = {},
 ): Promise<ProcessRunResult> {
   const startedAt = Date.now();
+  const startedAtIso = new Date(startedAt).toISOString();
   const argv = Array.isArray(args) ? args.map(String) : [];
   const commandDisplay = [command, ...argv].map(shellDisplayPart).join(" ");
   return await new Promise<ProcessRunResult>((resolve) => {
@@ -321,9 +339,11 @@ export async function runProcess(
     let stderr = "";
     let stdoutTruncated = false;
     let stderrTruncated = false;
+    let lastOutputAt: string | null = null;
     let timedOut = false;
     const metricCollector = createMetricCollector();
     const appendOutput = (target: "stdout" | "stderr", text: string) => {
+      lastOutputAt = new Date().toISOString();
       metricCollector.append(text);
       let value = target === "stdout" ? stdout : stderr;
       let truncated = target === "stdout" ? stdoutTruncated : stderrTruncated;
@@ -363,6 +383,8 @@ export async function runProcess(
           stderrTruncated,
           timedOut,
           startedAt,
+          startedAtIso,
+          lastOutputAt,
           parsedMetrics: metricCollector.finish(),
         }),
       );
@@ -379,6 +401,8 @@ export async function runProcess(
           stderrTruncated,
           timedOut,
           startedAt,
+          startedAtIso,
+          lastOutputAt,
           parsedMetrics: metricCollector.finish(),
         }),
       );
@@ -407,12 +431,16 @@ function processResult({
   stderrTruncated,
   timedOut,
   startedAt,
+  startedAtIso,
+  lastOutputAt,
   parsedMetrics = Object.create(null),
 }: {
   commandDisplay: string;
   exitCode: number | null;
+  lastOutputAt?: string | null;
   parsedMetrics?: Record<string, number>;
   startedAt: number;
+  startedAtIso?: string;
   stderr: string;
   stderrTruncated: boolean;
   stdout: string;
@@ -430,6 +458,9 @@ function processResult({
     combinedOutput: `${stdout || ""}${stderr ? `${stdout ? "\n" : ""}${stderr}` : ""}`,
     timedOut,
     durationSeconds,
+    startedAt: startedAtIso || new Date(startedAt).toISOString(),
+    finishedAt: new Date().toISOString(),
+    lastOutputAt: lastOutputAt || null,
     durationMs: Math.round(durationSeconds * 1000),
     outputTruncated: Boolean(stdoutTruncated || stderrTruncated),
     stdoutTruncated,

--- a/plugins/codex-autoresearch/lib/session-core.ts
+++ b/plugins/codex-autoresearch/lib/session-core.ts
@@ -378,6 +378,12 @@ export function buildDecisionEnvelope({
   finalization = null,
   qualityGap = null,
   contextDistillation = null,
+  experimentEconomics = null,
+  salvageCandidates = [],
+  workflowFriction = [],
+  experimentMemory = null,
+  segmentTransition = null,
+  setupState = null,
 }: LooseObject): LooseObject {
   const current: RunRecord[] = Array.isArray(state?.current) ? state.current : [];
   const all: RunRecord[] = Array.isArray(state?.results) ? state.results : current;
@@ -391,6 +397,13 @@ export function buildDecisionEnvelope({
     direction,
   );
   const codes = warningCodes(warningDetails);
+  const limit = state?.limit || {};
+  const limitReached =
+    limit.limitReached === true ||
+    (Number.isFinite(Number(limit.remainingIterations)) && Number(limit.remainingIterations) <= 0);
+  const qualityRound = qualityRoundState(qualityGap);
+  const segmentTransitionRequired =
+    segmentTransition?.required === true || limitReached || qualityRound.done === true;
   const scaffoldBlockers = Array.isArray(scaffoldHealth?.checks)
     ? scaffoldHealth.checks
         .filter((check: any) => check?.severity === "blocker")
@@ -433,7 +446,7 @@ export function buildDecisionEnvelope({
           )
         : [],
     },
-    qualityRound: qualityRoundState(qualityGap),
+    qualityRound,
     scaffoldHealth: scaffoldHealth
       ? {
           ok: scaffoldHealth.ok,
@@ -464,6 +477,38 @@ export function buildDecisionEnvelope({
           warnings: finalization.warnings || [],
         }
       : { available: false, ready: null, nextAction: "", warnings: [] },
+    experimentEconomics,
+    salvageCandidates: Array.isArray(salvageCandidates) ? salvageCandidates : [],
+    workflowFriction: Array.isArray(workflowFriction) ? workflowFriction : [],
+    experimentMemory: experimentMemory
+      ? {
+          plateau: experimentMemory.plateau || null,
+          exhaustedFamilies: experimentMemory.exhaustedFamilies || [],
+          metricShelves: experimentMemory.metricShelves || [],
+          missingAsiDetails: experimentMemory.missingAsiDetails || [],
+        }
+      : null,
+    setupState: setupState
+      ? {
+          stage: setupState.stage || "",
+          blockers: Array.isArray(setupState.blockers) ? setupState.blockers : [],
+          nextAction: setupState.nextAction || "",
+        }
+      : null,
+    segmentTransition: segmentTransitionRequired
+      ? {
+          required: true,
+          nextAction:
+            segmentTransition?.nextAction ||
+            segmentTransition?.reason ||
+            (qualityRound.done === true
+              ? "The active quality round is closed; refresh gaps or preview finalization."
+              : "The active segment reached its limit; extend the limit or start a new segment."),
+          triggeredBy:
+            segmentTransition?.triggeredBy ||
+            (qualityRound.done === true ? ["qualityRound"] : ["limit"]),
+        }
+      : null,
     nextAction: nextAction || "Run doctor, then next.",
   };
   return {
@@ -496,11 +541,116 @@ function canonicalNextActionForEnvelope(envelope: LooseObject): LooseObject {
       triggeredBy: ["dirtySourceDrift"],
     };
   }
+  const timeoutMismatch = firstEconomicsWarning(
+    envelope.experimentEconomics,
+    "outer_timeout_shorter_than_inner",
+  );
+  if (timeoutMismatch) {
+    return {
+      kind: "benchmark-mismatch",
+      priority: 2,
+      reason: timeoutMismatch.recommendation || timeoutMismatch.message,
+      command: "",
+      triggeredBy: ["experimentEconomics", timeoutMismatch.code],
+    };
+  }
+  const workflowBlocker = firstWorkflowFriction(envelope.workflowFriction, "blocker");
+  if (workflowBlocker) {
+    return {
+      kind: "workflow-friction",
+      priority: 2,
+      reason: workflowBlocker.suggestedAction?.reason || workflowBlocker.reason,
+      command: workflowBlocker.suggestedAction?.command || "",
+      triggeredBy: workflowBlocker.suggestedAction?.triggeredBy || [workflowBlocker.kind],
+    };
+  }
+  const workflowWarning = firstWorkflowFriction(envelope.workflowFriction, "warning");
+  if (workflowWarning) {
+    return {
+      kind: "workflow-friction",
+      priority: 3,
+      reason: workflowWarning.suggestedAction?.reason || workflowWarning.reason,
+      command: workflowWarning.suggestedAction?.command || "",
+      triggeredBy: workflowWarning.suggestedAction?.triggeredBy || [workflowWarning.kind],
+    };
+  }
+  const repeatedSmallProbe = firstEconomicsWarning(
+    envelope.experimentEconomics,
+    "repeated_small_probe",
+  );
+  if (repeatedSmallProbe) {
+    return {
+      kind: "workflow-friction",
+      priority: 3,
+      reason: repeatedSmallProbe.recommendation || repeatedSmallProbe.message,
+      command: "",
+      triggeredBy: ["experimentEconomics", repeatedSmallProbe.code],
+    };
+  }
   if (envelope.latestPacketFreshness?.fresh === false) {
     return {
       kind: "stale-packet",
       priority: 4,
       reason: envelope.latestPacketFreshness.reason || "Last-run packet is stale.",
+      command: "",
+      triggeredBy: ["latestPacketFreshness"],
+    };
+  }
+  if (
+    envelope.experimentEconomics?.warnings?.some(
+      (warning: any) => warning.code === "stale_progress",
+    )
+  ) {
+    return {
+      kind: "stale-packet",
+      priority: 4,
+      reason:
+        envelope.experimentEconomics.warnings.find(
+          (warning: any) => warning.code === "stale_progress",
+        )?.recommendation || "Inspect stale packet progress before continuing.",
+      command: "",
+      triggeredBy: ["experimentEconomics", "progress"],
+    };
+  }
+  const setupBlockers = Array.isArray(envelope.setupState?.blockers)
+    ? envelope.setupState.blockers
+    : [];
+  if (setupBlockers.length || envelope.setupState?.stage === "needs-setup") {
+    return {
+      kind: "setup",
+      priority: 4,
+      reason:
+        setupBlockers[0] ||
+        envelope.setupState?.nextAction ||
+        "Complete setup blockers before trusting another packet.",
+      command: "",
+      triggeredBy: ["setup"],
+    };
+  }
+  if (envelope.setupState?.stage === "needs-benchmark-command") {
+    return {
+      kind: "benchmark-command",
+      priority: 4,
+      reason: envelope.setupState?.nextAction || "Add a repeatable benchmark command.",
+      command: "",
+      triggeredBy: ["setup", "benchmarkCommand"],
+    };
+  }
+  const salvage = firstDiagnosticSalvage(envelope.salvageCandidates);
+  if (salvage) {
+    return {
+      kind: "partial-salvage",
+      priority: 5,
+      reason: `Review partial result ${salvage.id} before rerunning an expensive packet.`,
+      command: "",
+      triggeredBy: ["partialResults"],
+    };
+  }
+  if (envelope.latestPacketFreshness?.fresh === true) {
+    return {
+      kind: "log-decision",
+      priority: 5,
+      reason: "Record the fresh last-run packet before starting another packet.",
       command: "",
       triggeredBy: ["latestPacketFreshness"],
     };
@@ -516,6 +666,22 @@ function canonicalNextActionForEnvelope(envelope: LooseObject): LooseObject {
       triggeredBy: envelope.contextDistillation.triggeredBy || ["contextDistillation"],
     };
   }
+  if (envelope.segmentTransition?.required === true) {
+    return {
+      kind: "segment-transition",
+      priority: 7,
+      title: Array.isArray(envelope.segmentTransition.triggeredBy)
+        ? envelope.segmentTransition.triggeredBy.includes("qualityRound")
+          ? "Review completion state"
+          : "Start a new segment"
+        : "Start a new segment",
+      reason:
+        envelope.segmentTransition.nextAction ||
+        "Resolve the active segment transition before continuing.",
+      command: "",
+      triggeredBy: envelope.segmentTransition.triggeredBy || ["segmentTransition"],
+    };
+  }
   if (envelope.qualityRound?.active && envelope.qualityRound.done === false) {
     return {
       kind: "quality-gap",
@@ -523,6 +689,21 @@ function canonicalNextActionForEnvelope(envelope: LooseObject): LooseObject {
       reason: `${envelope.qualityRound.open ?? "Open"} accepted quality gaps remain.`,
       command: "",
       triggeredBy: ["qualityRound"],
+    };
+  }
+  const exhausted = envelope.experimentMemory?.exhaustedFamilies?.[0];
+  const shelf = envelope.experimentMemory?.metricShelves?.[0];
+  if (envelope.experimentMemory?.plateau?.detected || exhausted || shelf) {
+    return {
+      kind: "plateau-pivot",
+      priority: 8,
+      reason:
+        exhausted?.requiredPrecondition ||
+        shelf?.reason ||
+        envelope.experimentMemory?.plateau?.recommendation ||
+        "Pivot before repeating the same experiment family.",
+      command: "",
+      triggeredBy: exhausted ? ["experimentMemory", "exhaustedFamily"] : ["experimentMemory"],
     };
   }
   if (envelope.finalizationReadiness?.ready === true) {
@@ -541,6 +722,26 @@ function canonicalNextActionForEnvelope(envelope: LooseObject): LooseObject {
     command: "",
     triggeredBy: ["continuation"],
   };
+}
+
+function firstEconomicsWarning(economics: any, code: string): any | null {
+  return Array.isArray(economics?.warnings)
+    ? economics.warnings.find((warning: any) => warning?.code === code) || null
+    : null;
+}
+
+function firstWorkflowFriction(signals: any[], severity: string): any | null {
+  return Array.isArray(signals)
+    ? signals.find((signal) => signal?.severity === severity) || null
+    : null;
+}
+
+function firstDiagnosticSalvage(candidates: any[]): any | null {
+  return Array.isArray(candidates)
+    ? candidates.find((candidate) =>
+        ["scored", "manual_review", "diagnostic"].includes(String(candidate?.status || "")),
+      ) || null
+    : null;
 }
 
 function buildGoalAdvice({

--- a/plugins/codex-autoresearch/lib/tool-contracts.ts
+++ b/plugins/codex-autoresearch/lib/tool-contracts.ts
@@ -168,6 +168,22 @@ const CONTRACTS = {
       "continuation",
     ]),
   },
+  partial_results: {
+    purpose: "Inspect or record diagnostic rows from a crashed or timed-out packet artifact.",
+    whenToUse:
+      "Use before rerunning an expensive failed packet when last-run artifacts may contain completed rows.",
+    contrast: "Use log_experiment for ordinary keep/discard/crash decisions.",
+    safety:
+      "Read-only unless record is supplied; recording appends measure-only diagnostic evidence and clears the last-run packet.",
+    outputSchema: basicOutputSchema([
+      "ok",
+      "workDir",
+      "candidates",
+      "skippedArtifacts",
+      "experiment",
+      "evidenceClaim",
+    ]),
+  },
   log_experiment: {
     purpose: "Record a keep/discard/measure/crash/checks_failed decision.",
     whenToUse: "Use after next_experiment, preferably with from_last.",

--- a/plugins/codex-autoresearch/lib/tool-registry.ts
+++ b/plugins/codex-autoresearch/lib/tool-registry.ts
@@ -34,6 +34,7 @@ const TOOL_REGISTRY = [
   { name: "init_experiment", cliCommand: "init", actionPolicy: "state_mutation" },
   { name: "run_experiment", cliCommand: "run", actionPolicy: "process_start" },
   { name: "next_experiment", cliCommand: "next", actionPolicy: "process_start" },
+  { name: "partial_results", cliCommand: "partial-results", actionPolicy: "artifact_write" },
   { name: "log_experiment", cliCommand: "log", actionPolicy: "git_mutation" },
   { name: "read_state", cliCommand: "state", actionPolicy: "read" },
   { name: "measure_quality_gap", cliCommand: "quality-gap", actionPolicy: "read" },
@@ -78,6 +79,7 @@ export function actionPolicyForTool(name: string, args: LooseObject = {}): Actio
   if (name === "session_forensics" && (args.apply || args.apply === "true")) {
     return "artifact_write";
   }
+  if (name === "partial_results" && args.record) return "artifact_write";
   if (name === "guided_setup" && (args.start_dashboard || args.startDashboard)) {
     return "process_start";
   }

--- a/plugins/codex-autoresearch/lib/tool-schemas.ts
+++ b/plugins/codex-autoresearch/lib/tool-schemas.ts
@@ -315,6 +315,24 @@ export const toolSchemas = applyToolContracts([
     },
   },
   {
+    name: "partial_results",
+    description:
+      "Inspect or record diagnostic-only partial-result rows from a crashed or timed-out last-run artifact.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        working_dir: { type: "string" },
+        from_last: { type: "boolean" },
+        artifact: { type: "string" },
+        record: { type: "string" },
+        research_slug: { type: "string" },
+        command_hash: { type: "string" },
+        description: { type: "string" },
+      },
+      required: ["working_dir"],
+    },
+  },
+  {
     name: "log_experiment",
     description:
       "Append an experiment result, keep/commit or discard/revert changes, then return whether the active loop should immediately continue.",
@@ -586,6 +604,7 @@ const CLI_COMMAND_TO_TOOL: Record<string, string> = {
   init: "init_experiment",
   run: "run_experiment",
   next: "next_experiment",
+  "partial-results": "partial_results",
   log: "log_experiment",
   state: "read_state",
   doctor: "doctor_session",

--- a/plugins/codex-autoresearch/lib/workflow-friction.ts
+++ b/plugins/codex-autoresearch/lib/workflow-friction.ts
@@ -1,0 +1,282 @@
+import { resolveDecisionThresholds, type DecisionThresholdConfig } from "./decision-thresholds.js";
+
+type LooseObject = Record<string, any>;
+
+export type WorkflowFrictionKind =
+  | "output_budget_exceeded"
+  | "verification_churn"
+  | "dirty_tree_recovery"
+  | "unknown_recipe"
+  | "quality_gap_wording";
+
+export interface WorkflowFrictionSignal {
+  kind: WorkflowFrictionKind;
+  severity: "info" | "warning" | "blocker";
+  reason: string;
+  commandHead?: string;
+  count?: number;
+  reportedSize?: { tokens?: number; lines?: number };
+  affectedFiles?: string[];
+  suggestedAction: {
+    kind: "workflow-friction";
+    priority: number;
+    reason: string;
+    command?: string;
+    triggeredBy?: string[];
+  };
+}
+
+export function analyzeWorkflowFriction({
+  state = {},
+  forensics = null,
+  lastRun = null,
+  thresholds: thresholdConfig = {},
+  warningDetails = [],
+  recipes = [],
+}: LooseObject = {}): WorkflowFrictionSignal[] {
+  const thresholds = resolveThresholds(thresholdConfig);
+  const signals: WorkflowFrictionSignal[] = [];
+  signals.push(...outputBudgetSignals({ forensics, lastRun, thresholds }));
+  signals.push(...verificationChurnSignals({ state, thresholds }));
+  signals.push(...dirtyTreeSignals({ state, warningDetails }));
+  const unknown = unknownRecipeSignal({ state, recipes });
+  if (unknown) signals.push(unknown);
+  const qualityGap = qualityGapWordingSignal({ state });
+  if (qualityGap) signals.push(qualityGap);
+  return dedupeSignals(signals);
+}
+
+function outputBudgetSignals({
+  forensics,
+  lastRun,
+  thresholds,
+}: {
+  forensics: LooseObject | null;
+  lastRun: LooseObject | null;
+  thresholds: DecisionThresholdConfig;
+}): WorkflowFrictionSignal[] {
+  const signals: WorkflowFrictionSignal[] = [];
+  for (const signal of forensics?.workflowWaste || forensics?.signals || []) {
+    if (signal?.kind !== "output_budget_exceeded") continue;
+    const detail = signal.details || signal.size || {};
+    signals.push(
+      workflowSignal({
+        kind: "output_budget_exceeded",
+        severity: "warning",
+        reason: signal.message || "A command exceeded the output budget.",
+        reportedSize: {
+          tokens: finitePositive(detail.tokenCount),
+          lines: finitePositive(detail.lines),
+        },
+        commandHead: detail.commandHead || detail.commandClass || "unknown",
+        actionReason:
+          "Use a bounded summary command or write large output to an artifact before continuing.",
+      }),
+    );
+  }
+  const stdoutTailLines = String(lastRun?.packetEvidence?.stdoutTail || "")
+    .split(/\r?\n/)
+    .filter(Boolean).length;
+  if (
+    lastRun?.run?.outputTruncated ||
+    lastRun?.run?.metricsTruncated ||
+    stdoutTailLines >= thresholds.outputCommandLineBudget
+  ) {
+    signals.push(
+      workflowSignal({
+        kind: "output_budget_exceeded",
+        severity: "warning",
+        reason:
+          "The last packet output was truncated; inspect the saved packet or artifact summary instead of rerunning a noisy command.",
+        reportedSize: {
+          lines: stdoutTailLines,
+        },
+        commandHead: commandHead(lastRun?.packetEvidence?.commandIdentity?.command || ""),
+        actionReason: "Switch to a bounded command or artifact summary before another packet.",
+      }),
+    );
+  }
+  return signals;
+}
+
+function verificationChurnSignals({
+  state,
+  thresholds,
+}: {
+  state: LooseObject;
+  thresholds: DecisionThresholdConfig;
+}): WorkflowFrictionSignal[] {
+  const runs = Array.isArray(state.current) ? state.current : [];
+  const commandCounts = countCommandHeads(
+    runs.map((run) => run?.benchmarkContract?.command || run?.command || run?.description || ""),
+  );
+  const checksCounts = countCommandHeads(
+    runs.map((run) => run?.benchmarkContract?.checksCommand || ""),
+  );
+  const signals: WorkflowFrictionSignal[] = [];
+  for (const [head, count] of commandCounts) {
+    if (count >= thresholds.repeatedCommandHeadCount) {
+      signals.push(
+        workflowSignal({
+          kind: "verification_churn",
+          severity: "warning",
+          reason: `Command head '${head}' ran ${count} times in this segment.`,
+          commandHead: head,
+          count,
+          actionReason:
+            "Checkpoint the evidence, batch verification, or pivot lanes before repeating it.",
+        }),
+      );
+    }
+  }
+  for (const [head, count] of checksCounts) {
+    if (count >= thresholds.repeatedCheckHeadCount) {
+      signals.push(
+        workflowSignal({
+          kind: "verification_churn",
+          severity: "warning",
+          reason: `Check command '${head}' ran ${count} times without a clear source checkpoint.`,
+          commandHead: head,
+          count,
+          actionReason:
+            "Checkpoint source changes or run a narrower targeted check before another broad check.",
+        }),
+      );
+    }
+  }
+  return signals;
+}
+
+function dirtyTreeSignals({
+  state,
+  warningDetails,
+}: {
+  state: LooseObject;
+  warningDetails: LooseObject[];
+}): WorkflowFrictionSignal[] {
+  const warnings = Array.isArray(warningDetails)
+    ? warningDetails.filter((warning) =>
+        ["git_dirty", "missing_commit_paths"].includes(String(warning?.code || "")),
+      )
+    : [];
+  if (warnings.length === 0) return [];
+  const commitPaths = Array.isArray(state.config?.commitPaths) ? state.config.commitPaths : [];
+  const revertPaths = Array.isArray(state.config?.revertPaths) ? state.config.revertPaths : [];
+  const affectedFiles = [...new Set([...commitPaths, ...revertPaths])];
+  return [
+    workflowSignal({
+      kind: "dirty_tree_recovery",
+      severity: "blocker",
+      reason: warnings[0]?.message || "Dirty source state blocks safe logging or cleanup.",
+      affectedFiles,
+      actionReason: affectedFiles.length
+        ? `Use scoped commit/revert paths (${affectedFiles.slice(0, 4).join(", ")}) before continuing.`
+        : "Group the dirty files and set commitPaths or revertPaths before continuing.",
+    }),
+  ];
+}
+
+function unknownRecipeSignal({
+  state,
+  recipes,
+}: {
+  state: LooseObject;
+  recipes: LooseObject[];
+}): WorkflowFrictionSignal | null {
+  const recipe = String(state.config?.recipeId || state.config?.recipe || "");
+  if (!recipe) return null;
+  const known = new Set((recipes || []).map((item) => String(item.id || item.recipeId || "")));
+  if (known.size === 0 || known.has(recipe)) return null;
+  const closest = [...known].filter(Boolean).slice(0, 3).join(", ");
+  return workflowSignal({
+    kind: "unknown_recipe",
+    severity: "warning",
+    reason: `Configured recipe '${recipe}' is not in the available recipe catalog.`,
+    actionReason: closest
+      ? `Use one of the nearest known recipes (${closest}) or pass the trusted catalog again.`
+      : "List recipes or provide custom recipe catalog metadata before setup.",
+  });
+}
+
+function qualityGapWordingSignal({ state }: { state: LooseObject }): WorkflowFrictionSignal | null {
+  if (state.config?.metricName !== "quality_gap") return null;
+  const open = Number(state.qualityGap?.open);
+  if (!Number.isFinite(open) || open <= 0) return null;
+  return workflowSignal({
+    kind: "quality_gap_wording",
+    severity: "info",
+    reason: `${open} accepted quality-gap checklist item${open === 1 ? "" : "s"} remain open.`,
+    actionReason:
+      "Describe quality_gap as accepted checklist count, not as a perfect score or universal quality benchmark.",
+  });
+}
+
+function workflowSignal({
+  kind,
+  severity,
+  reason,
+  actionReason,
+  commandHead,
+  count,
+  reportedSize,
+  affectedFiles,
+}: Omit<WorkflowFrictionSignal, "suggestedAction"> & {
+  actionReason: string;
+}): WorkflowFrictionSignal {
+  return {
+    kind,
+    severity,
+    reason,
+    ...(commandHead ? { commandHead } : {}),
+    ...(count != null ? { count } : {}),
+    ...(reportedSize ? { reportedSize } : {}),
+    ...(affectedFiles?.length ? { affectedFiles } : {}),
+    suggestedAction: {
+      kind: "workflow-friction",
+      priority: severity === "blocker" ? 2 : 3,
+      reason: actionReason,
+      triggeredBy: [kind],
+    },
+  };
+}
+
+function countCommandHeads(commands: unknown[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const command of commands) {
+    const head = commandHead(command);
+    if (!head) continue;
+    counts.set(head, (counts.get(head) || 0) + 1);
+  }
+  return counts;
+}
+
+function commandHead(command: unknown): string {
+  const parts = String(command || "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  return parts.slice(0, 3).join(" ");
+}
+
+function finitePositive(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function resolveThresholds(value: unknown): DecisionThresholdConfig {
+  return resolveDecisionThresholds(
+    value && typeof value === "object" ? { decisionThresholds: value as LooseObject } : {},
+  );
+}
+
+function dedupeSignals(signals: WorkflowFrictionSignal[]): WorkflowFrictionSignal[] {
+  const seen = new Set<string>();
+  const result: WorkflowFrictionSignal[] = [];
+  for (const signal of signals) {
+    const key = `${signal.kind}:${signal.reason}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(signal);
+  }
+  return result;
+}

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -12,6 +12,7 @@ import { createDashboardCommands } from "../lib/commands/dashboard.js";
 import { createInspectCommands } from "../lib/commands/inspect.js";
 import { createCliCommandHandlers, runCliCommand } from "../lib/cli-handlers.js";
 import { buildDriftReport } from "../lib/drift-doctor.js";
+import { analyzeExperimentEconomics } from "../lib/experiment-economics.js";
 import {
   redactCommandDisplay,
   redactEvidenceObject,
@@ -19,10 +20,15 @@ import {
   redactPathDisplay,
 } from "../lib/evidence-redaction.js";
 import { buildExperimentMemory } from "../lib/experiment-memory.js";
+import { mergeEvidenceClaims } from "../lib/evidence-index.js";
 import {
   finalizeCurrentTree as buildFinalizeCurrentTree,
   finalizePreview as buildFinalizePreview,
 } from "../lib/finalize-preview.js";
+import {
+  buildPartialResultEvidenceClaim,
+  discoverPartialResultCandidates,
+} from "../lib/partial-results.js";
 import { integrationsCommand } from "../lib/integrations.js";
 import {
   gapCandidates as buildGapCandidates,
@@ -47,6 +53,12 @@ import {
   tailText,
 } from "../lib/runner.js";
 import {
+  createProgressSnapshot,
+  progressSnapshotFromRun,
+  staleProgressReason,
+  updateProgressSnapshot,
+} from "../lib/runner-progress.js";
+import {
   STATUS_VALUES,
   FAILURE_STATUSES,
   appendJsonl,
@@ -64,6 +76,7 @@ import {
   buildScaffoldHealth,
   commandDiagnostics,
 } from "../lib/truth-signals.js";
+import { analyzeWorkflowFriction } from "../lib/workflow-friction.js";
 import { resolvePackageRoot, resolveRepoRoot } from "../lib/runtime-paths.js";
 import { PLUGIN_VERSION } from "../lib/plugin-version.js";
 
@@ -183,6 +196,7 @@ Usage:
   node scripts/autoresearch.mjs init --cwd <project> --name <name> --metric-name <name> [--goal <goal>] [--metric-unit <unit>] [--direction lower|higher]
   node scripts/autoresearch.mjs run --cwd <project> [--command <cmd>|--command-file <path>] [--packet-env-file <path>] [--timeout-seconds <n>]
   node scripts/autoresearch.mjs next --cwd <project> [--compact] [--command <cmd>|--command-file <path>] [--packet-env-file <path>] [--timeout-seconds <n>]
+  node scripts/autoresearch.mjs partial-results --cwd <project> [--from-last|--artifact <path>] [--record <candidate-id>] [--research-slug <slug>]
   node scripts/autoresearch.mjs config --cwd <project> [--autonomy-mode guarded|owner-autonomous|manual] [--checks-policy always|on-improvement|manual] [--extend <n>]
   node scripts/autoresearch.mjs research-setup --cwd <project> --slug <slug> --goal <goal> [--checks-command <cmd>] [--max-iterations <n>]
   node scripts/autoresearch.mjs quality-gap --cwd <project> [--research-slug <slug>] [--list] [--json]
@@ -1707,8 +1721,23 @@ async function recommendNext(args: LooseObject): Promise<LooseObject> {
     pluginVersion: PLUGIN_VERSION,
   });
   const compact: LooseObject = await publicState({ cwd: workDir, compact: true });
-  const action = (viewModel.nextBestAction || {}) as LooseObject;
-  const nextAction = action.detail || viewModel.readout?.nextAction || compact.nextAction;
+  const canonicalNextAction =
+    compact.canonicalNextAction ||
+    compact.decisionEnvelope?.canonicalNextAction ||
+    compact.resumeAudit?.canonicalNextAction ||
+    null;
+  const action = canonicalNextAction
+    ? canonicalActionForRecommendNext(
+        canonicalNextAction,
+        viewModel.nextBestAction,
+        compact.commands,
+      )
+    : ((viewModel.nextBestAction || {}) as LooseObject);
+  const nextAction =
+    canonicalNextAction?.reason ||
+    action.detail ||
+    viewModel.readout?.nextAction ||
+    compact.nextAction;
   const baseEnvelope = compact.decisionEnvelope || compact.resumeAudit || null;
   const decisionEnvelope = baseEnvelope
     ? {
@@ -1722,6 +1751,13 @@ async function recommendNext(args: LooseObject): Promise<LooseObject> {
             }
           : baseEnvelope.finalizationReadiness,
         nextAction,
+        canonicalNextAction: action.kind
+          ? {
+              ...baseEnvelope.canonicalNextAction,
+              ...canonicalNextAction,
+              command: action.command || canonicalNextAction?.command || "",
+            }
+          : baseEnvelope.canonicalNextAction,
       }
     : null;
   return {
@@ -1749,6 +1785,44 @@ async function recommendNext(args: LooseObject): Promise<LooseObject> {
     resumeAudit: decisionEnvelope,
     decisionEnvelope,
   };
+}
+
+function canonicalActionForRecommendNext(
+  canonical: LooseObject,
+  existing: unknown,
+  commands: unknown,
+): LooseObject {
+  const base = existing && typeof existing === "object" ? (existing as LooseObject) : {};
+  const command = canonical.command || commandForCanonicalKind(canonical.kind, commands);
+  return {
+    ...base,
+    kind: canonical.kind || base.kind || "next-packet",
+    priority: String(canonical.priority ?? base.priority ?? "Next"),
+    title: canonicalTitle(canonical.kind, base.title),
+    detail: canonical.reason || base.detail || "",
+    utilityCopy: base.utilityCopy || "Decision envelope is the authoritative next-action source.",
+    safeAction: base.safeAction || String(canonical.kind || ""),
+    command,
+    primaryCommand: command ? { label: "Run", command } : base.primaryCommand || null,
+    source: "decision-envelope",
+  };
+}
+
+function canonicalTitle(kind: unknown, fallback: unknown): string {
+  const text = String(kind || "");
+  const titles: Record<string, string> = {
+    "safety-blocker": "Resolve the safety blocker",
+    "benchmark-mismatch": "Repair the benchmark mismatch",
+    "workflow-friction": "Remove workflow friction",
+    "stale-packet": "Replace the stale packet",
+    "partial-salvage": "Review partial results",
+    "context-distillation": "Refresh context",
+    "quality-gap": "Close accepted quality gaps",
+    "plateau-pivot": "Pivot before repeating the plateau",
+    finalization: "Preview finalization",
+    "next-packet": "Run the next measured packet",
+  };
+  return titles[text] || String(fallback || "Next action");
 }
 
 async function sessionForensics(args: LooseObject): Promise<LooseObject> {
@@ -3782,6 +3856,20 @@ function dashboardSettings(config: any, extra: LooseObject = {}) {
   };
 }
 
+function decisionSetupState(guided: any, plan: any) {
+  const blockers = [...listOption(plan?.missing), ...listOption(plan?.missingEssentials)];
+  if (!guided?.stage && blockers.length === 0) return null;
+  return {
+    stage: guided?.stage || "",
+    blockers,
+    nextAction:
+      guided?.nextStep?.nextAction?.reason ||
+      guided?.nextAction ||
+      plan?.nextStep?.nextAction?.reason ||
+      "",
+  };
+}
+
 async function dashboardViewModel(workDir: string, config: any, context: LooseObject = {}) {
   const qualityGap = await currentQualityGapSummary(workDir);
   const state = currentState(workDir);
@@ -3810,50 +3898,87 @@ async function dashboardViewModel(workDir: string, config: any, context: LooseOb
     ? suppressEnvironmentWarningsFromPreview(finalizePreview)
     : finalizePreview;
   const lastRun = await readLastRunPacket(workDir).catch((): null => null);
+  const activeProgress = await readActiveProgressSnapshot(workDir, config);
   const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
   const continuation = loopContinuation(workDir, state, config, "dashboard");
-  const decisionEnvelope = buildDecisionEnvelope({
-    state,
-    nextAction: continuation.nextAction,
-    lastRunFreshness,
-    warningDetails: warnings,
-    scaffoldHealth,
-    researchIntegrity,
-    qualityGap,
-    finalization: effectiveFinalizePreview,
+  const setupPlanResult = await setupPlan({ cwd: workDir }).catch((error: any) => ({
+    ok: false,
+    warnings: [error.message],
+  }));
+  const guidedSetupResult = await guidedSetup({ cwd: workDir }).catch((error: any) => ({
+    ok: false,
+    warnings: [error.message],
+  }));
+  const memory = buildExperimentMemory({
+    runs: state.current,
+    direction: state.config.bestDirection,
+    settings,
   });
+  const stateWithQualityGap = { ...state, qualityGap };
+  const recipeSummaries = listBuiltInRecipes().map((recipe: any) => ({
+    id: recipe.id,
+    title: recipe.title,
+    tags: recipe.tags || [],
+  }));
+  const partialResults = await discoverLastRunPartialResults(workDir, state, lastRun);
+  const workflowFriction = analyzeWorkflowFriction({
+    state: stateWithQualityGap,
+    lastRun,
+    warningDetails: warnings,
+    recipes: recipeSummaries,
+  });
+  const experimentEconomics = analyzeExperimentEconomics({
+    state: stateWithQualityGap,
+    lastRun,
+    progress: activeProgress || lastRun?.packetEvidence?.progressSnapshot || null,
+  });
+  const commands = dashboardCommands(workDir, qualityGap);
+  const guidedCommands = (guidedSetupResult as LooseObject).commands || {};
+  const canonicalCommandHints = {
+    ...commandLookupObject(commands),
+    replaceLast: guidedCommands.replaceLast || "",
+    logLast: guidedCommands.logLast || "",
+    setup: guidedCommands.setup || "",
+  };
+  const decisionEnvelope = withCanonicalActionCommand(
+    buildDecisionEnvelope({
+      state: { ...state, limit: iterationLimitInfo(state, config) },
+      nextAction: continuation.nextAction,
+      lastRunFreshness,
+      warningDetails: warnings,
+      scaffoldHealth,
+      researchIntegrity,
+      qualityGap,
+      finalization: effectiveFinalizePreview,
+      experimentEconomics,
+      salvageCandidates: partialResults.candidates,
+      workflowFriction,
+      experimentMemory: memory,
+      setupState: decisionSetupState(guidedSetupResult, setupPlanResult),
+    }),
+    canonicalCommandHints,
+  );
   const enrichedState = {
     ...state,
     scaffoldHealth,
     researchIntegrity,
     warningDetails: warnings,
+    experimentEconomics,
+    partialResults,
+    workflowFriction,
     resumeAudit: decisionEnvelope,
     decisionEnvelope,
   };
   return buildDashboardViewModel({
     state: enrichedState as any,
     settings,
-    commands: dashboardCommands(workDir, qualityGap),
-    setupPlan: await setupPlan({ cwd: workDir }).catch((error: any) => ({
-      ok: false,
-      warnings: [error.message],
-    })),
-    guidedSetup: await guidedSetup({ cwd: workDir }).catch((error: any) => ({
-      ok: false,
-      warnings: [error.message],
-    })),
+    commands,
+    setupPlan: setupPlanResult,
+    guidedSetup: guidedSetupResult,
     qualityGap,
     finalizePreview: effectiveFinalizePreview,
-    recipes: listBuiltInRecipes().map((recipe: any) => ({
-      id: recipe.id,
-      title: recipe.title,
-      tags: recipe.tags || [],
-    })),
-    experimentMemory: buildExperimentMemory({
-      runs: state.current,
-      direction: state.config.bestDirection,
-      settings,
-    }),
+    recipes: recipeSummaries,
+    experimentMemory: memory,
     drift,
     warnings,
   });
@@ -4029,8 +4154,31 @@ async function runExperiment(args: LooseObject) {
     args.timeout_seconds ?? args.timeoutSeconds,
     DEFAULT_TIMEOUT_SECONDS,
   );
+  let progressSnapshot = createProgressSnapshot({
+    packetId: `packet-${state.results.length + 1}-active`,
+    command,
+    startedAt: new Date().toISOString(),
+    timeoutSeconds,
+    artifactRoot: ".",
+  });
+  await writeActiveProgressSnapshot(workDir, progressSnapshot);
+  const updateProgress = ({ observedAt, output }: { observedAt: string; output: string }) => {
+    progressSnapshot = updateProgressSnapshot(progressSnapshot, { output, observedAt });
+    progressSnapshot = {
+      ...progressSnapshot,
+      staleProgressReason: staleProgressReason(progressSnapshot, {
+        now: observedAt,
+        staleAfterSeconds: numberOption(
+          config.staleProgressSeconds ?? config.progressStaleSeconds,
+          300,
+        ),
+      }),
+    };
+    void writeActiveProgressSnapshot(workDir, progressSnapshot);
+  };
   const benchmark = await runShell(command, workDir, timeoutSeconds, {
     env: commandInput.env,
+    onProgress: updateProgress,
     retainMetricNames: [state.config.metricName],
   });
   const benchmarkPassed = benchmark.exitCode === 0 && !benchmark.timedOut;
@@ -4074,7 +4222,7 @@ async function runExperiment(args: LooseObject) {
         args.checks_timeout_seconds ?? args.checksTimeoutSeconds,
         DEFAULT_CHECKS_TIMEOUT_SECONDS,
       ),
-      { env: commandInput.env },
+      { env: commandInput.env, onProgress: updateProgress },
     );
   }
   const checksPassed = checks ? checks.exitCode === 0 && !checks.timedOut : null;
@@ -4118,8 +4266,13 @@ async function runExperiment(args: LooseObject) {
       separatorCommand: commandInput.separatorCommand,
       result: benchmark,
     }),
+    startedAt: benchmark.startedAt,
+    finishedAt: benchmark.finishedAt,
+    lastOutputAt: benchmark.lastOutputAt,
+    progressSnapshot,
     exitCode: benchmark.exitCode,
-    timedOut: benchmark.timedOut,
+    timedOut: benchmark.timedOut || Boolean(checks?.timedOut),
+    timeoutPhase: benchmark.timedOut ? "benchmark" : checks?.timedOut ? "checks" : "none",
     durationSeconds: benchmark.durationSeconds,
     parsedMetrics,
     artifacts,
@@ -4629,6 +4782,13 @@ async function resolveLastRunPath(workDir: string) {
   return path.join(workDir, "autoresearch.last-run.json");
 }
 
+async function resolveProgressPath(workDir: string) {
+  if (await insideGitRepo(workDir)) {
+    return await gitPrivatePath(workDir, "autoresearch/progress.json");
+  }
+  return path.join(workDir, "autoresearch.progress.json");
+}
+
 async function writeLastRunPacket(workDir: string, packet: any, filePath: string | null = null) {
   const target = filePath || (await resolveLastRunPath(workDir));
   await fsp.mkdir(path.dirname(target), { recursive: true });
@@ -4638,6 +4798,39 @@ async function writeLastRunPacket(workDir: string, packet: any, filePath: string
     "utf8",
   );
   return target;
+}
+
+async function writeActiveProgressSnapshot(workDir: string, snapshot: LooseObject) {
+  const target = await resolveProgressPath(workDir);
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  await fsp.writeFile(target, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  return target;
+}
+
+async function readActiveProgressSnapshot(workDir: string, config: LooseObject = {}) {
+  const target = await resolveProgressPath(workDir);
+  if (!fs.existsSync(target)) return null;
+  try {
+    const snapshot = JSON.parse(fs.readFileSync(target, "utf8"));
+    if (!snapshot || typeof snapshot !== "object" || snapshot.exitState !== "running") {
+      return snapshot || null;
+    }
+    return {
+      ...snapshot,
+      staleProgressReason: staleProgressReason(snapshot, {
+        staleAfterSeconds: numberOption(
+          config.staleProgressSeconds ?? config.progressStaleSeconds,
+          300,
+        ),
+      }),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function deleteActiveProgressSnapshot(workDir: string) {
+  await fsp.rm(await resolveProgressPath(workDir), { force: true }).catch(() => {});
 }
 
 function redactLastRunPacketForStorage(packet: LooseObject): LooseObject {
@@ -4888,6 +5081,211 @@ async function deleteLastRunPacket(workDir: string) {
   }
 }
 
+async function discoverLastRunPartialResults(
+  workDir: string,
+  state: LooseObject,
+  lastRun: LooseObject | null,
+) {
+  if (!lastRun || !partialResultEligiblePacket(lastRun)) {
+    return { candidates: [], skippedArtifacts: [] };
+  }
+  return await discoverPartialResultCandidates({
+    workDir,
+    primaryMetricName: state.config?.metricName || "metric",
+    lastRunPacket: lastRun,
+  }).catch((error: any) => ({
+    candidates: [],
+    skippedArtifacts: [
+      {
+        artifactName: "last-run",
+        artifactPath: lastRun?.lastRunPath || "",
+        reason: error.message || String(error),
+      },
+    ],
+  }));
+}
+
+function partialResultEligiblePacket(packet: LooseObject | null): boolean {
+  if (!packet) return false;
+  const run = packet.run || {};
+  const packetEvidence = packet.packetEvidence || {};
+  if (packet.ok === false || run.timedOut === true || packetEvidence.timedOut === true) return true;
+  const exitCode = finiteMetric(run.exitCode ?? packetEvidence.exitStatus);
+  return exitCode != null && exitCode !== 0;
+}
+
+async function partialResultsCommand(args: LooseObject) {
+  const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
+  const state = currentState(workDir);
+  const artifact = args.artifact ? String(args.artifact) : "";
+  const recordId = args.record ? String(args.record).trim() : "";
+  const fromLast = boolOption(args.from_last ?? args.fromLast, !artifact || Boolean(recordId));
+  const lastRun = fromLast || recordId ? await readLastRunPacket(workDir) : null;
+  if (lastRun) await assertFreshLastRunPacket(workDir, lastRun);
+  const lastRunPacket =
+    lastRun ||
+    partialResultPacketFromArtifact({
+      artifact,
+      commandHash: args.command_hash ?? args.commandHash,
+      state,
+      workDir,
+    });
+  const discovery = await discoverPartialResultCandidates({
+    workDir,
+    primaryMetricName: state.config?.metricName || "metric",
+    lastRunPacket,
+  });
+  if (!recordId) {
+    return {
+      ok: true,
+      workDir,
+      source: lastRun ? "last-run" : "artifact",
+      candidates: discovery.candidates,
+      skippedArtifacts: discovery.skippedArtifacts,
+      nextAction: discovery.candidates.length
+        ? "Review a candidate, then record it as diagnostic measure evidence with --record <candidate-id>."
+        : "No partial-result candidates were found.",
+    };
+  }
+  if (!lastRun) {
+    throw new Error(
+      "--record requires a fresh last-run packet so salvaged evidence links to its source packet.",
+    );
+  }
+  const candidate = discovery.candidates.find((item: any) => item.id === recordId);
+  if (!candidate) throw new Error(`partial result candidate not found: ${recordId}`);
+  return await recordPartialResultCandidate({ workDir, state, lastRun, candidate, args });
+}
+
+function partialResultPacketFromArtifact({
+  artifact,
+  commandHash,
+  state,
+  workDir,
+}: LooseObject): LooseObject {
+  if (!artifact) throw new Error("--artifact is required unless --from-last is used.");
+  const artifactPath = path.isAbsolute(artifact) ? path.resolve(artifact) : artifact;
+  return {
+    ok: false,
+    workDir,
+    history: {
+      segment: state.segment,
+      config: lastRunConfigSnapshot(state.config),
+      nextRun: state.results.length + 1,
+    },
+    packetEvidence: {
+      packetId: `artifact-${createHash("sha256").update(String(artifactPath)).digest("hex").slice(0, 12)}`,
+      metricName: state.config?.metricName || "metric",
+      commandIdentity: {
+        commandHash: commandHash ? String(commandHash) : "",
+      },
+      artifacts: [
+        {
+          name: path.basename(String(artifactPath)) || "partial-result",
+          path: String(artifactPath),
+          exists: true,
+          quarantined: false,
+        },
+      ],
+    },
+  };
+}
+
+async function recordPartialResultCandidate({
+  workDir,
+  state,
+  lastRun,
+  candidate,
+  args,
+}: LooseObject) {
+  const metricName = candidate.metricName || state.config?.metricName || "metric";
+  const metric = finiteMetric(candidate.metricValue);
+  if (metric == null) {
+    throw new Error(
+      `partial result candidate ${candidate.id} has no finite metric and must stay manual-review only.`,
+    );
+  }
+  const sourcePacketId = lastRun?.packetEvidence?.packetId || "";
+  const researchSlug = researchSlugFromArgs({
+    slug: args.research_slug ?? args.researchSlug ?? "partial-results",
+  });
+  const evidenceClaim = buildPartialResultEvidenceClaim(candidate);
+  const evidenceIndex = await mergeEvidenceClaims(workDir, researchSlug, [evidenceClaim]);
+  const experiment: LooseObject = {
+    run: state.results.length + 1,
+    commit: "",
+    metric,
+    metrics: {
+      [metricName]: metric,
+    },
+    metricEligible: false,
+    status: "measure",
+    description:
+      args.description ||
+      `Diagnostic partial result from ${candidate.artifactName} row ${candidate.rowIndex}.`,
+    timestamp: Date.now(),
+    segment: state.segment,
+    confidence: null,
+    promotion: {
+      label: "measurement",
+      reasons: ["Recorded from a partial-result salvage candidate; diagnostic measure only."],
+    },
+    asi: {
+      hypothesis: "Recover diagnostic evidence from a partial benchmark artifact.",
+      evidence: `${metricName}=${metric} from ${candidate.artifactPath} row ${candidate.rowIndex}.`,
+      rollback_reason:
+        "Source packet crashed or timed out, so this evidence cannot be treated as promotion-grade.",
+      next_action_hint:
+        "Use this diagnostic row to choose the next packet; rerun fresh before promotion.",
+      partial_result: {
+        candidateId: candidate.id,
+        status: candidate.status,
+        reason: candidate.reason,
+        sourcePacketId,
+        artifactName: candidate.artifactName,
+        artifactPath: candidate.artifactPath,
+        rowIndex: candidate.rowIndex,
+        provenance: candidate.provenance,
+        evidenceClaimId: evidenceClaim.id,
+        researchSlug,
+      },
+      promotionGrade: false,
+    },
+    artifacts: {
+      [candidate.artifactName]: candidate.artifactPath,
+    },
+    partialResult: {
+      candidateId: candidate.id,
+      sourcePacketId,
+      evidenceClaimId: evidenceClaim.id,
+      researchSlug,
+      validationStatus: candidate.status,
+    },
+  };
+  experiment.confidence = computeConfidence(
+    [...state.current, experiment],
+    state.config?.bestDirection || "lower",
+  );
+  appendJsonl(workDir, experiment);
+  await deleteLastRunPacket(workDir);
+  const stateAfter = currentState(workDir);
+  return {
+    ok: true,
+    workDir,
+    experiment,
+    evidenceClaim,
+    evidenceIndex: {
+      slug: researchSlug,
+      claims: evidenceIndex.claims.length,
+    },
+    lastRunCleared: true,
+    baseline: stateAfter.baseline,
+    best: stateAfter.best,
+    confidence: stateAfter.confidence,
+    continuation: loopContinuation(workDir, stateAfter, readConfig(workDir), "logged"),
+  };
+}
+
 async function publicState(args: LooseObject): Promise<LooseObject> {
   const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
   const state = currentState(workDir);
@@ -4895,6 +5293,7 @@ async function publicState(args: LooseObject): Promise<LooseObject> {
   const researchIntegrity = buildResearchIntegrity({ state, config });
   const warningDetails = await operatorWarningsForWorkDir(workDir);
   const lastRun = await readLastRunPacket(workDir).catch((): null => null);
+  const activeProgress = await readActiveProgressSnapshot(workDir, config);
   const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
   const qualityGap = await currentQualityGapSummary(workDir);
   const finalization = await buildFinalizePreview({ cwd: workDir }).catch((error: any) => ({
@@ -4908,6 +5307,24 @@ async function publicState(args: LooseObject): Promise<LooseObject> {
     direction: state.config.bestDirection,
     settings: dashboardSettings(config),
   });
+  const stateWithQualityGap = { ...state, qualityGap };
+  const recipeSummaries = listBuiltInRecipes().map((recipe: any) => ({
+    id: recipe.id,
+    title: recipe.title,
+    tags: recipe.tags || [],
+  }));
+  const partialResults = await discoverLastRunPartialResults(workDir, state, lastRun);
+  const workflowFriction = analyzeWorkflowFriction({
+    state: stateWithQualityGap,
+    lastRun,
+    warningDetails,
+    recipes: recipeSummaries,
+  });
+  const experimentEconomics = analyzeExperimentEconomics({
+    state: stateWithQualityGap,
+    lastRun,
+    progress: activeProgress || lastRun?.packetEvidence?.progressSnapshot || null,
+  });
   const statusCounts = Object.fromEntries(
     [...STATUS_VALUES].map((status: string) => [
       status,
@@ -4915,16 +5332,23 @@ async function publicState(args: LooseObject): Promise<LooseObject> {
     ]),
   );
   const continuation = loopContinuation(workDir, state, config, "state");
-  const decisionEnvelope = buildDecisionEnvelope({
-    state,
-    nextAction: continuation.nextAction,
-    lastRunFreshness,
-    warningDetails,
-    scaffoldHealth,
-    researchIntegrity,
-    qualityGap,
-    finalization,
-  });
+  const decisionEnvelope = withCanonicalActionCommand(
+    buildDecisionEnvelope({
+      state: { ...state, limit: iterationLimitInfo(state, config) },
+      nextAction: continuation.nextAction,
+      lastRunFreshness,
+      warningDetails,
+      scaffoldHealth,
+      researchIntegrity,
+      qualityGap,
+      finalization,
+      experimentEconomics,
+      salvageCandidates: partialResults.candidates,
+      workflowFriction,
+      experimentMemory: memory,
+    }),
+    continuation.commands,
+  );
   const fullState = {
     ok: true,
     workDir,
@@ -4957,6 +5381,9 @@ async function publicState(args: LooseObject): Promise<LooseObject> {
     warnings: warningDetails.map((warning: any) => warning.message),
     warningDetails,
     memory,
+    experimentEconomics,
+    partialResults,
+    workflowFriction,
     continuation,
     resumeAudit: decisionEnvelope,
     decisionEnvelope,
@@ -4967,6 +5394,8 @@ async function publicState(args: LooseObject): Promise<LooseObject> {
 function compactPublicState(state: LooseObject) {
   const limit = state.limit || {};
   const continuation = state.continuation || {};
+  const canonicalNextAction =
+    state.decisionEnvelope?.canonicalNextAction || state.resumeAudit?.canonicalNextAction || null;
   const blockers = [
     ...(Array.isArray(state.warningDetails)
       ? state.warningDetails.map((warning: any) => warning.message || warning.code)
@@ -5009,7 +5438,7 @@ function compactPublicState(state: LooseObject) {
       : null,
     limitReached: Boolean(limit.limitReached),
     remainingIterations: limit.remainingIterations ?? null,
-    nextAction: continuation.nextAction || "Run doctor, then next.",
+    nextAction: canonicalNextAction?.reason || continuation.nextAction || "Run doctor, then next.",
     shouldContinue: continuation.shouldContinue === true,
     forbidFinalAnswer: continuation.forbidFinalAnswer === true,
     activeBudget: continuation.activeBudget === true,
@@ -5032,12 +5461,41 @@ function compactPublicState(state: LooseObject) {
       plateau: state.memory?.plateau?.detected === true,
       suggestedLane: state.memory?.summary?.suggestedLane || "",
       latestNextAction: state.memory?.latestNextAction || "",
+      exhaustedFamilies: Array.isArray(state.memory?.exhaustedFamilies)
+        ? state.memory.exhaustedFamilies.slice(0, 3)
+        : [],
+      metricShelves: Array.isArray(state.memory?.metricShelves)
+        ? state.memory.metricShelves.slice(0, 3)
+        : [],
     },
+    experimentEconomics: state.experimentEconomics
+      ? {
+          runtimeClass: state.experimentEconomics.runtimeClass,
+          expectedRuntimeSeconds: state.experimentEconomics.expectedRuntimeSeconds ?? null,
+          baselineFreshness: state.experimentEconomics.baselineFreshness,
+          freshRunRequired: state.experimentEconomics.freshRunRequired === true,
+          freshRunReason: state.experimentEconomics.freshRunReason || "",
+          warnings: Array.isArray(state.experimentEconomics.warnings)
+            ? state.experimentEconomics.warnings.slice(0, 3)
+            : [],
+          progress: state.experimentEconomics.progress || null,
+        }
+      : null,
+    partialResults: {
+      candidates: Array.isArray(state.partialResults?.candidates)
+        ? state.partialResults.candidates.slice(0, 5)
+        : [],
+      skippedArtifacts: Array.isArray(state.partialResults?.skippedArtifacts)
+        ? state.partialResults.skippedArtifacts.slice(0, 5)
+        : [],
+    },
+    workflowFriction: Array.isArray(state.workflowFriction)
+      ? state.workflowFriction.slice(0, 5)
+      : [],
     commands: continuation.commands || state.commands || {},
     resumeAudit: state.resumeAudit || null,
     decisionEnvelope: state.decisionEnvelope || state.resumeAudit || null,
-    canonicalNextAction:
-      state.decisionEnvelope?.canonicalNextAction || state.resumeAudit?.canonicalNextAction || null,
+    canonicalNextAction,
   };
 }
 
@@ -5068,6 +5526,10 @@ function dashboardCommands(workDir: string, qualityGap: any = null) {
     {
       label: "Discard last",
       command: `node ${script} log --cwd ${cwd} --from-last --status discard --description "Describe the discarded change"`,
+    },
+    {
+      label: "Partial results",
+      command: `node ${script} partial-results --cwd ${cwd} --from-last`,
     },
     {
       label: "Gap candidates",
@@ -5221,6 +5683,8 @@ function continuationCommands(workDir: string) {
     nextFull: `node ${script} next --cwd ${cwd}`,
     keepLast: `node ${script} log --cwd ${cwd} --from-last --status keep --description "Describe the kept change"`,
     discardLast: `node ${script} log --cwd ${cwd} --from-last --status discard --description "Describe the discarded change"`,
+    partialResults: `node ${script} partial-results --cwd ${cwd} --from-last`,
+    gapCandidates: `node ${script} gap-candidates --cwd ${cwd} --research-slug ${shellQuote(currentQualityGapSlug(workDir) || "research")}`,
     liveDashboard: `node ${script} serve --cwd ${cwd}`,
     exportDashboard: `node ${script} export --cwd ${cwd}`,
     extendLimit: `node ${script} config --cwd ${cwd} --extend 10`,
@@ -5234,6 +5698,59 @@ function continuationCommands(workDir: string) {
     promoteGateDryRun: `node ${script} promote-gate --cwd ${cwd} --reason "describe promoted measurement" --dry-run`,
     finalizeCurrentTree: `node ${script} finalize-current-tree --cwd ${cwd} --exclude-session-artifacts`,
   };
+}
+
+function withCanonicalActionCommand(envelope: LooseObject, commands: unknown): LooseObject {
+  const action = envelope?.canonicalNextAction;
+  if (!action) return envelope;
+  const command = action.command || commandForCanonicalKind(action.kind, commands);
+  return {
+    ...envelope,
+    canonicalNextAction: {
+      ...action,
+      command,
+    },
+  };
+}
+
+function commandForCanonicalKind(kind: unknown, commands: unknown): string {
+  const lookup = commandLookupObject(commands);
+  switch (String(kind || "")) {
+    case "safety-blocker":
+    case "workflow-friction":
+      return lookup.doctorExplain || lookup.doctor || lookup.state || "";
+    case "benchmark-mismatch":
+      return lookup.benchmarkLint || lookup.doctorExplain || lookup.doctor || "";
+    case "stale-packet":
+      return lookup.replaceLast || lookup.next || lookup.nextRun || "";
+    case "partial-salvage":
+      return lookup.partialResults || "";
+    case "context-distillation":
+      return "";
+    case "quality-gap":
+      return lookup.gapCandidates || "";
+    case "plateau-pivot":
+    case "next-packet":
+      return lookup.next || lookup.nextRun || "";
+    case "finalization":
+      return lookup.finalizePreview || lookup.finalizeCurrentTree || "";
+    default:
+      return lookup.next || lookup.nextRun || "";
+  }
+}
+
+function commandLookupObject(commands: unknown): LooseObject {
+  if (Array.isArray(commands)) {
+    const result: LooseObject = {};
+    for (const item of commands) {
+      const label = String(item?.label || "")
+        .replace(/\s+([a-z])/g, (_match, char) => String(char).toUpperCase())
+        .replace(/^[A-Z]/, (char) => char.toLowerCase());
+      if (label) result[label] = item.command || "";
+    }
+    return result;
+  }
+  return commands && typeof commands === "object" ? (commands as LooseObject) : {};
 }
 
 function currentQualityGapSlug(workDir: string) {
@@ -5584,8 +6101,10 @@ function packetEvidenceForRun(run: LooseObject, history: LooseObject) {
   const fingerprint = createHash("sha256")
     .update(JSON.stringify(packetSource), "utf8")
     .digest("hex");
+  const artifacts = artifactList(run.artifacts, run.workDir);
+  const packetId = `packet-${history.nextRun || "next"}-${fingerprint.slice(0, 12)}`;
   return {
-    packetId: `packet-${history.nextRun || "next"}-${fingerprint.slice(0, 12)}`,
+    packetId,
     cwd: redactPathDisplay(run.workDir, run.workDir),
     commandIdentity: {
       command: redactCommandDisplay(run.command || "", { workDir: run.workDir }),
@@ -5605,8 +6124,9 @@ function packetEvidenceForRun(run: LooseObject, history: LooseObject) {
     stderrTail: "",
     metrics: run.parsedMetrics || {},
     primaryMetric: run.parsedPrimary ?? null,
-    artifacts: artifactList(run.artifacts, run.workDir),
+    artifacts,
     artifactWarnings: run.artifactWarnings || [],
+    progressSnapshot: progressSnapshotFromRun({ packetId, run, artifacts }),
     checks: run.checks
       ? {
           command: redactCommandDisplay(run.checks.command || "", { workDir: run.workDir }),
@@ -5788,6 +6308,7 @@ async function nextExperiment(args: any) {
     }),
   };
   await writeLastRunPacket(run.workDir, packet, lastRunFile);
+  await deleteActiveProgressSnapshot(run.workDir);
   return boolOption(args.compact, false) ? compactNextExperimentPacket(packet) : packet;
 }
 
@@ -5898,6 +6419,7 @@ async function main() {
     nextExperiment,
     onboardingPacket,
     parseJsonOption,
+    partialResultsCommand,
     pluginRoot: PLUGIN_ROOT,
     pluginVersion: PLUGIN_VERSION,
     promoteGate,

--- a/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
+++ b/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
@@ -26,6 +26,7 @@ AX, the AI experience:
 - Use the CLI as the deterministic execution surface.
 - Keep loop truth in durable files, not chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.ideas.md`, `autoresearch.research/<slug>/`, evidence indexes, dashboard state, and commits.
 - Keep every packet decision recoverable through `METRIC name=value`, packet evidence, ASI, continuation data, promotion labels, and the ledger.
+- Before rerunning an expensive crashed or timed-out packet, inspect `partial-results --from-last`; record a selected row only as diagnostic `measure` evidence with `partial-results --record <candidate-id>`.
 - ASI means the structured memory attached to a run: hypothesis, evidence, rollback reason, next action hint, and optional lane/family/risk metadata.
 - When Codex Goal mode is available and explicitly requested, use `get_goal` to inspect parent thread state, then run `codex-goal-brief --cwd <project>` with any imported Goal fields. Treat the bridge as evidence/advice only: Codex owns thread goals; Autoresearch owns benchmark/session truth.
 - When a prior Codex session JSONL is the best evidence source, run `session-forensics --dry-run` first, then `--apply` only to write a bounded context capsule under `autoresearch.research/<slug>/`. Keep raw snippets disabled unless the operator explicitly needs them; imported claims should reference evidence ids instead of persisting raw transcript bodies.
@@ -81,6 +82,7 @@ node scripts/autoresearch.mjs checks-inspect --cwd <project> --command "<checks 
 node scripts/autoresearch.mjs guide --cwd <project>
 node scripts/autoresearch.mjs doctor --cwd <project> --explain
 node scripts/autoresearch.mjs serve --cwd <project>
+node scripts/autoresearch.mjs partial-results --cwd <project> --from-last
 node scripts/autoresearch.mjs session-forensics --cwd <project> --session-jsonl <path> --research-slug <slug> --dry-run
 ```
 
@@ -91,6 +93,7 @@ After `next`, log the packet. After `log`, read the returned continuation object
 - Use `log --from-last` instead of retyping parsed metrics.
 - Only `next` writes a reusable last-run packet. `run` remains a raw benchmark probe for quick checks and is not loggable with `--from-last`.
 - If `log --from-last` reports no loggable packet or a stale packet, recover with `next --cwd <project>` or record a manual measurement with `log --cwd <project> --metric <value> --status measure --description "<what was measured>"`.
+- If the last packet crashed or timed out after writing artifacts, run `partial-results --cwd <project> --from-last` before rerunning. Only `partial-results --record <candidate-id>` may turn a selected row into diagnostic `measure` evidence; it must not become promotion-grade evidence.
 - Read the last-run `packetEvidence` before logging: packet id, command identity, timeout, exit status, output tails, metrics, artifacts, checks, and freshness fingerprint.
 - Include ASI every time: `hypothesis`, `evidence`, `rollback_reason` for rejected paths, `next_action_hint`, and when useful `lane`, `family`, `risk`, and `expected_delta`. Prefer `--asi-file <path>` on PowerShell or any shell where inline JSON quoting is fragile.
 - `keep`, ordinary `discard`, and `measure` require a finite primary metric.
@@ -117,7 +120,7 @@ node scripts/autoresearch.mjs state --cwd <project> --compact
 
 - Missing, null, crashed, and ineligible metrics are unknown. Do not report them as `0`, `0%`, baseline, best, latest plotted evidence, or a win.
 - Last-run packets become stale after ledger, config, command, working directory, Git, or relevant file changes. Rerun `next` before logging.
-- The resume audit is the single next-decision surface. It compares the active segment, historical best, promotion-grade best, packet freshness, benchmark/config drift, dirty source drift, quality round, and finalization readiness before naming `nextAction`.
+- The resume audit is the single next-decision surface. It compares the active segment, historical best, promotion-grade best, packet freshness, progress/economics, partial-result candidates, workflow friction, benchmark/config drift, dirty source drift, quality round, experiment memory, and finalization readiness before naming `nextAction`.
 - If the benchmark/check/config contract changes after logged runs, start a new segment or explicitly invalidate old evidence before running another packet or finalizing.
 - Read dev/local best and promotion-grade best separately. A run needs explicit promotion metadata before it counts as promotion evidence.
 - Read `scaffoldHealth` before first packets and before keep logging. Self-recursive wrappers, missing benchmark workloads, stale `commitPaths`/`revertPaths`, and Git index locks are setup blockers, not experiment evidence.

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
@@ -50,6 +51,127 @@ test("run reports missing primary metric as a failed experiment", async () => {
     assert.match(payload.metricError, /seconds/);
     assert.equal(payload.logHint.status, "crash");
     assert.deepEqual(payload.logHint.allowedStatuses, ["crash"]);
+  });
+});
+
+test("partial-results records diagnostic measure evidence from a failed packet artifact", async () => {
+  await withTempDir("partial-results-record", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "partial salvage", "--metric-name", "seconds"]);
+    const script = path.join(dir, "partial-packet.mjs");
+    await writeFile(
+      script,
+      [
+        "import { mkdirSync, writeFileSync } from 'node:fs';",
+        "mkdirSync('out', { recursive: true });",
+        "writeFileSync('out/rows.json', JSON.stringify({ schemaVersion: 1, metricName: 'seconds', formulaVersion: 'v1', rows: [{ seconds: 4.2, rawBody: 'must not persist' }] }));",
+        "console.log('ARTIFACT rows=out/rows.json');",
+        "process.exit(1);",
+      ].join("\n"),
+    );
+
+    const packet = await runCli([
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} ${quoteForShell(script)}`,
+    ]);
+    assert.equal(packet.code, 0, packet.stderr);
+    const packetPayload = JSON.parse(packet.stdout);
+
+    const list = await runCli(["partial-results", "--cwd", dir, "--from-last"]);
+    assert.equal(list.code, 0, list.stderr);
+    const listPayload = JSON.parse(list.stdout);
+    assert.equal(listPayload.candidates.length, 1);
+    assert.equal(listPayload.candidates[0].status, "scored");
+    assert.equal(listPayload.candidates[0].metricValue, 4.2);
+    assert.equal(JSON.stringify(listPayload).includes("must not persist"), false);
+
+    const state = await runCli(["state", "--cwd", dir, "--compact"]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    assert.equal(statePayload.canonicalNextAction.kind, "partial-salvage");
+    assert.equal(statePayload.nextAction, statePayload.canonicalNextAction.reason);
+
+    const recommend = await runCli(["recommend-next", "--cwd", dir, "--compact"]);
+    assert.equal(recommend.code, 0, recommend.stderr);
+    const recommendPayload = JSON.parse(recommend.stdout);
+    assert.equal(recommendPayload.action.kind, "partial-salvage");
+    assert.equal(recommendPayload.nextAction, statePayload.canonicalNextAction.reason);
+    assert.equal(
+      recommendPayload.decisionEnvelope.canonicalNextAction.kind,
+      statePayload.canonicalNextAction.kind,
+    );
+
+    const record = await runCli([
+      "partial-results",
+      "--cwd",
+      dir,
+      "--record",
+      listPayload.candidates[0].id,
+    ]);
+    assert.equal(record.code, 0, record.stderr);
+    const recordPayload = JSON.parse(record.stdout);
+    assert.equal(recordPayload.experiment.status, "measure");
+    assert.equal(recordPayload.experiment.metricEligible, false);
+    assert.equal(recordPayload.experiment.partialResult.validationStatus, "scored");
+    assert.equal(recordPayload.evidenceClaim.promotionRelevance, "diagnostic");
+
+    const ledger = await readFile(path.join(dir, "autoresearch.jsonl"), "utf8");
+    assert.match(ledger, /"status":"measure"/);
+    assert.match(ledger, /"partialResult"/);
+    await assert.rejects(access(packetPayload.lastRunPath));
+    const evidenceIndex = await readFile(
+      path.join(dir, "autoresearch.research", "partial-results", "evidence-index.json"),
+      "utf8",
+    );
+    assert.match(evidenceIndex, /benchmark-artifact/);
+  });
+});
+
+test("state surfaces active runner progress while next is still executing", async () => {
+  await withTempDir("active-progress", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "active progress", "--metric-name", "seconds"]);
+    const script = path.join(dir, "slow-packet.mjs");
+    await writeFile(
+      script,
+      ["setTimeout(() => {", "  console.log('METRIC seconds=1');", "}, 1500);"].join("\n"),
+    );
+
+    const child = spawn(process.execPath, [
+      cli,
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} ${quoteForShell(script)}`,
+    ]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    let progress = null;
+    const started = Date.now();
+    while (Date.now() - started < 5000) {
+      const state = await runCli(["state", "--cwd", dir, "--compact"]);
+      assert.equal(state.code, 0, state.stderr);
+      const payload = JSON.parse(state.stdout);
+      progress = payload.experimentEconomics?.progress || null;
+      if (progress?.exitState === "running") break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    assert.equal(progress?.exitState, "running");
+    assert.match(progress?.packetId || "", /active/);
+
+    const exitCode = await new Promise((resolve) => child.on("close", resolve));
+    assert.equal(exitCode, 0, stderr);
+    const packetPayload = JSON.parse(stdout);
+    assert.equal(packetPayload.packetEvidence.progressSnapshot.exitState, "completed");
   });
 });
 

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -1293,7 +1293,7 @@ test("dashboard decision envelope priority ladder is stable across competing sig
     },
     {
       name: "plateau outranks finalization readiness",
-      expected: "plateau",
+      expected: "plateau-pivot",
       context: {
         experimentMemory: {
           plateau: { detected: true, recommendation: "Scout a distant lane." },
@@ -1303,7 +1303,7 @@ test("dashboard decision envelope priority ladder is stable across competing sig
     },
     {
       name: "finalization readiness wins after active blockers",
-      expected: "finalize-preview",
+      expected: "finalization",
       context: {
         finalizePreview: { ready: true, nextAction: "Preview finalization." },
       },
@@ -1362,7 +1362,7 @@ test("dashboard action rail treats finalization readiness as the next decision a
     ],
   });
 
-  assert.equal(viewModel.nextBestAction.kind, "finalize-preview");
+  assert.equal(viewModel.nextBestAction.kind, "finalization");
   assert.match(viewModel.nextBestAction.detail, /Preview finalization/);
 });
 

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
   appendJsonl,
+  buildDecisionEnvelope,
   buildLastRunFreshnessSnapshot,
   currentState,
   finiteMetric,
@@ -26,6 +27,7 @@ import {
   DEFAULT_DECISION_THRESHOLDS,
   resolveDecisionThresholds,
 } from "../lib/decision-thresholds.js";
+import { analyzeExperimentEconomics } from "../lib/experiment-economics.js";
 import {
   compactEvidenceSummaries,
   evidenceClaim,
@@ -34,11 +36,21 @@ import {
   validateClaimReferences,
 } from "../lib/evidence-index.js";
 import {
+  buildPartialResultEvidenceClaim,
+  discoverPartialResultCandidates,
+} from "../lib/partial-results.js";
+import {
+  createProgressSnapshot,
+  progressSnapshotFromRun,
+  staleProgressReason,
+} from "../lib/runner-progress.js";
+import {
   assertInsideResearchRoot,
   resolveSafeResearchPath,
   validateResearchSlug,
 } from "../lib/research-path-guard.js";
 import { parseSessionForensics } from "../lib/session-forensics.js";
+import { analyzeWorkflowFriction } from "../lib/workflow-friction.js";
 import { quoteForShell } from "./helpers/process.js";
 
 const withTempDir = async (name, fn) => {
@@ -324,6 +336,308 @@ test("evidence index uses deterministic ids, merges claims, and validates refere
       },
     ]);
   });
+});
+
+test("partial result salvager scores complete artifact rows as diagnostic candidates", async () => {
+  await withTempDir("partial-result-scored", async (dir) => {
+    await mkdir(path.join(dir, "out"), { recursive: true });
+    await writeFile(
+      path.join(dir, "out", "results.json"),
+      JSON.stringify(
+        {
+          rows: [{ label: "candidate-a", seconds: 1.25, rawBody: "do-not-copy-this-body" }],
+          schemaVersion: 1,
+          metricName: "seconds",
+          formulaVersion: "v1",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const discovery = await discoverPartialResultCandidates({
+      workDir: dir,
+      lastRunPacket: {
+        packetEvidence: {
+          commandIdentity: { commandHash: "hash-123" },
+          artifacts: [
+            {
+              name: "results",
+              path: "out/results.json",
+              exists: true,
+              quarantined: false,
+            },
+          ],
+        },
+      },
+    });
+
+    assert.equal(discovery.skippedArtifacts.length, 0);
+    assert.equal(discovery.candidates.length, 1);
+    assert.match(discovery.candidates[0].id, /^partial-[a-f0-9]{12}$/);
+    assert.equal(discovery.candidates[0].artifactName, "results");
+    assert.equal(discovery.candidates[0].artifactPath, "out/results.json");
+    assert.equal(discovery.candidates[0].rowIndex, 0);
+    assert.equal(discovery.candidates[0].status, "scored");
+    assert.equal(discovery.candidates[0].metricName, "seconds");
+    assert.equal(discovery.candidates[0].metricValue, 1.25);
+    assert.equal(discovery.candidates[0].provenance.diagnosticOnly, true);
+    assert.equal(JSON.stringify(discovery.candidates[0]).includes("do-not-copy-this-body"), false);
+
+    const claim = buildPartialResultEvidenceClaim(discovery.candidates[0]);
+    assert.equal(claim.evidenceType, "benchmark-artifact");
+    assert.equal(claim.promotionRelevance, "diagnostic");
+    assert.match(claim.source, /^out\/results\.json#row-0$/);
+  });
+});
+
+test("partial result salvager sends incomplete rows to manual review", async () => {
+  await withTempDir("partial-result-manual", async (dir) => {
+    await mkdir(path.join(dir, "out"), { recursive: true });
+    await writeFile(path.join(dir, "out", "array-results.json"), '[{"seconds":2.5}]\n', "utf8");
+    await writeFile(
+      path.join(dir, "out", "missing-metric.json"),
+      JSON.stringify({
+        rows: [{ label: "candidate-b" }],
+        schemaVersion: 1,
+        metricName: "seconds",
+        formulaVersion: "v1",
+      }),
+      "utf8",
+    );
+
+    const discovery = await discoverPartialResultCandidates({
+      workDir: dir,
+      primaryMetricName: "seconds",
+      lastRunPacket: {
+        packetEvidence: {
+          commandIdentity: { commandHash: "hash-123" },
+          artifacts: [
+            {
+              name: "array-results",
+              path: "out/array-results.json",
+              exists: true,
+              quarantined: false,
+            },
+            {
+              name: "missing-metric",
+              path: "out/missing-metric.json",
+              exists: true,
+              quarantined: false,
+            },
+          ],
+        },
+      },
+    });
+
+    assert.equal(discovery.candidates.length, 2);
+    const byName = new Map(
+      discovery.candidates.map((candidate) => [candidate.artifactName, candidate]),
+    );
+    const missingVersions = byName.get("array-results");
+    const missingMetric = byName.get("missing-metric");
+
+    assert.equal(missingVersions?.status, "manual_review");
+    assert.equal(missingVersions?.metricValue, 2.5);
+    assert.match(missingVersions?.reason || "", /schema version missing/);
+    assert.match(missingVersions?.reason || "", /formula version missing/);
+
+    assert.equal(missingMetric?.status, "manual_review");
+    assert.equal(missingMetric?.metricValue, null);
+    assert.match(missingMetric?.reason || "", /finite primary metric missing/);
+  });
+});
+
+test("partial result salvager rejects path escapes and does not persist raw artifact bodies", async () => {
+  await withTempDir("partial-result-path-escape", async (dir) => {
+    const outsidePath = path.join(path.dirname(dir), `${path.basename(dir)}-outside-results.json`);
+    await writeFile(
+      outsidePath,
+      JSON.stringify({
+        rows: [{ seconds: 9, rawBody: "outside-raw-body-must-not-leak" }],
+        schemaVersion: 1,
+        metricName: "seconds",
+        formulaVersion: "v1",
+      }),
+      "utf8",
+    );
+    try {
+      const discovery = await discoverPartialResultCandidates({
+        workDir: dir,
+        lastRunPacket: {
+          packetEvidence: {
+            commandIdentity: { commandHash: "hash-123" },
+            artifacts: [
+              {
+                name: "outside-results",
+                path: outsidePath,
+                exists: true,
+                quarantined: false,
+              },
+            ],
+          },
+        },
+      });
+
+      assert.equal(discovery.candidates.length, 0);
+      assert.equal(discovery.skippedArtifacts.length, 1);
+      assert.equal(discovery.skippedArtifacts[0].artifactName, "outside-results");
+      assert.equal(discovery.skippedArtifacts[0].artifactPath, "<outside-workdir>");
+      assert.equal(discovery.skippedArtifacts[0].reason, "artifact_path_outside_workdir");
+      assert.equal(JSON.stringify(discovery).includes("outside-raw-body-must-not-leak"), false);
+    } finally {
+      await rm(outsidePath, { force: true });
+    }
+  });
+});
+
+test("runner progress and experiment economics expose timeout and stale-progress costs", () => {
+  const progress = progressSnapshotFromRun({
+    packetId: "packet-1",
+    run: {
+      command: "npm test -- --runInBand",
+      workDir: "project",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      lastOutputAt: "2026-05-25T10:05:00.000Z",
+      finishedAt: "2026-05-25T10:10:00.000Z",
+      timeoutSeconds: 30,
+      timedOut: true,
+      exitCode: null,
+    },
+    artifacts: [{ name: "rows", path: "out/rows.json" }],
+  });
+
+  assert.equal(progress.packetId, "packet-1");
+  assert.equal(progress.commandClass, "npm test --");
+  assert.equal(progress.timeoutPhase, "benchmark");
+  assert.equal(progress.exitState, "timed_out");
+  assert.equal(progress.latestArtifactRow, "rows=out/rows.json");
+
+  const running = createProgressSnapshot({
+    packetId: "packet-2",
+    command: "node bench.mjs --timeout 120",
+    startedAt: "2026-05-25T10:00:00.000Z",
+    timeoutSeconds: 60,
+  });
+  assert.match(
+    staleProgressReason(running, {
+      now: "2026-05-25T10:10:00.000Z",
+      staleAfterSeconds: 300,
+    }),
+    /No packet output/,
+  );
+
+  const economics = analyzeExperimentEconomics({
+    state: {
+      baseline: 10,
+      config: { bestDirection: "lower" },
+      current: [
+        { run: 1, status: "discard", durationSeconds: 900 },
+        { run: 2, status: "crash", durationSeconds: 950 },
+        { run: 3, status: "checks_failed", durationSeconds: 925 },
+        { run: 4, status: "discard", durationSeconds: 940 },
+      ],
+    },
+    lastRun: {
+      run: { durationSeconds: 900 },
+      packetEvidence: {
+        timeoutSeconds: 60,
+        commandIdentity: { command: "node bench.mjs --timeout-seconds 120" },
+      },
+    },
+    progress: {
+      ...running,
+      staleProgressReason: "No packet output or artifact progress for 600s.",
+    },
+  });
+
+  const warningCodes = economics.warnings.map((warning) => warning.code);
+  assert.equal(economics.runtimeClass, "long");
+  assert.equal(warningCodes.includes("outer_timeout_shorter_than_inner"), true);
+  assert.equal(warningCodes.includes("repeated_small_probe"), true);
+  assert.equal(warningCodes.includes("stale_progress"), true);
+  assert.equal(economics.freshRunRequired, true);
+
+  assert.equal(
+    buildDecisionEnvelope({
+      state: { current: [] },
+      experimentEconomics: economics,
+    }).canonicalNextAction.kind,
+    "benchmark-mismatch",
+  );
+
+  const smallProbeEconomics = analyzeExperimentEconomics({
+    state: {
+      baseline: 10,
+      config: { bestDirection: "lower" },
+      current: [
+        { run: 1, status: "discard", durationSeconds: 900 },
+        { run: 2, status: "crash", durationSeconds: 950 },
+        { run: 3, status: "checks_failed", durationSeconds: 925 },
+        { run: 4, status: "discard", durationSeconds: 940 },
+      ],
+    },
+    lastRun: { run: { durationSeconds: 900 }, packetEvidence: { timeoutSeconds: 1200 } },
+  });
+  assert.equal(
+    buildDecisionEnvelope({
+      state: { current: [] },
+      experimentEconomics: smallProbeEconomics,
+    }).canonicalNextAction.kind,
+    "workflow-friction",
+  );
+});
+
+test("workflow friction uses forensics, churn, dirty tree, recipes, and quality_gap wording", () => {
+  const signals = analyzeWorkflowFriction({
+    state: {
+      config: {
+        metricName: "quality_gap",
+        recipeId: "missing-recipe",
+        commitPaths: ["src/a.ts"],
+      },
+      qualityGap: { open: 2 },
+      current: [
+        { run: 1, command: "npm test -- --runInBand" },
+        { run: 2, command: "npm test -- --runInBand" },
+        { run: 3, command: "npm test -- --runInBand" },
+      ],
+    },
+    forensics: {
+      workflowWaste: [
+        {
+          kind: "output_budget_exceeded",
+          message: "Large command output.",
+          size: { tokens: 25000, lines: 900 },
+        },
+      ],
+    },
+    warningDetails: [{ code: "git_dirty", message: "Git worktree is dirty." }],
+    recipes: [{ id: "known-recipe" }],
+    thresholds: { repeatedCommandHeadCount: 3 },
+  });
+  const byKind = new Map(signals.map((signal) => [signal.kind, signal]));
+
+  assert.equal(byKind.get("output_budget_exceeded")?.severity, "warning");
+  assert.equal(byKind.get("verification_churn")?.count, 3);
+  assert.equal(byKind.get("dirty_tree_recovery")?.severity, "blocker");
+  assert.deepEqual(byKind.get("dirty_tree_recovery")?.affectedFiles, ["src/a.ts"]);
+  assert.match(byKind.get("unknown_recipe")?.reason || "", /missing-recipe/);
+  assert.match(byKind.get("quality_gap_wording")?.reason || "", /accepted quality-gap/);
+
+  const quietSignals = analyzeWorkflowFriction({
+    lastRun: {
+      packetEvidence: {
+        stdoutTail: "x".repeat(700),
+        commandIdentity: { command: "node bench.mjs" },
+      },
+    },
+  });
+  assert.equal(
+    quietSignals.some((signal) => signal.kind === "output_budget_exceeded"),
+    false,
+  );
 });
 
 test("session forensics parses bounded signals without raw body persistence", async () => {

--- a/plugins/codex-autoresearch/tests/experiment-memory.test.ts
+++ b/plugins/codex-autoresearch/tests/experiment-memory.test.ts
@@ -51,6 +51,50 @@ test("repeated hypothesis detection catches near-family repeats", () => {
   assert.match(repeat.reason, /already logged/);
 });
 
+test("experiment memory exposes exhausted families, shelves, and sparse ASI risk", () => {
+  const memory = buildExperimentMemory({
+    direction: "lower",
+    runs: [
+      kept(1, 10, "stable baseline", {
+        family: "cache-size",
+        hypothesis: "baseline cache size",
+        evidence: "seconds=10",
+      }),
+      rejected(2, 11, "cache size r1", { family: "cache-size" }),
+      rejected(3, 11.0001, "cache size r2", { family: "cache-size" }),
+      {
+        run: 4,
+        metric: 11.0002,
+        description: "cache size r3",
+        status: "crash",
+        asi: { family: "cache-size" },
+      },
+    ],
+    settings: {
+      decisionThresholds: {
+        rejectedOrRegressedRunsInFamily: 3,
+        shelfRelativeEpsilon: 0.001,
+      },
+    },
+  });
+
+  assert.equal(memory.exhaustedFamilies.length, 1);
+  assert.equal(memory.exhaustedFamilies[0].family, "cache-size");
+  assert.deepEqual(memory.exhaustedFamilies[0].runs, [2, 3, 4]);
+  assert.equal(memory.metricShelves.length > 0, true);
+  assert.equal(
+    memory.missingAsiDetails.some((item) => item.run === 2),
+    true,
+  );
+
+  const repeat = detectRepeatedHypothesis({
+    proposed: "cache-size retry with same precondition",
+    memory,
+  });
+  assert.equal(repeat.status, "exhausted");
+  assert.match(repeat.requiredPrecondition, /Change a precondition/);
+});
+
 test("incumbent guidance prefers kept families over latest rejected families", () => {
   const memory = buildExperimentMemory({
     direction: "lower",
@@ -78,6 +122,8 @@ test("incumbent guidance omits placeholder lanes when there are no kept families
     runs: [
       rejected(1, 12, "Bad family regresses", {
         family: "bad",
+        hypothesis: "bad family",
+        evidence: "seconds=12",
         rollback_reason: "regressed",
         next_action_hint: "avoid bad path",
       }),


### PR DESCRIPTION
## Summary
- add active runner progress snapshots plus experiment-economics warnings for timeout mismatch, stale progress, and repeated probe waste
- add partial-results candidate discovery and diagnostic measure recording with evidence-index linkage
- route workflow friction, experiment memory, salvage, setup, stale packet, and finalization through one canonical next-action surface for compact state, recommend-next, and dashboard
- update CLI/tool contracts, docs, skill guidance, changelog, and regression coverage

## Verification
- npm run check
- npm test
- git diff --check

## Notes
- This is PR 2 in the split dev plan. Dashboard segment/chart UX is intentionally left for the next PR.