### PR TITLE
Add EvidenceRegistry filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses a root-only changelog because the root README is the public do
 - Added `research-fanout` / `research_fanout`, a generic parallel lane planner that turns current session memory into read-only scout lanes and isolated implementation lanes without creating project-specific metrics.
 - Added `--metrics-file` for `log` so PowerShell and Windows sessions can record structured metric metadata without brittle inline JSON quoting.
 - Added run-level `evidenceStatus` labels and artifact evidence summaries so accepted, rejected, provisional, superseded, and quarantined evidence stay visible without becoming promotion signals by accident.
+- Added a central EvidenceRegistry so accepted/current evidence is separated from rejected, provisional, superseded, and quarantined audit evidence before state and dashboard consumers read it.
 
 ### Changed
 

--- a/plugins/codex-autoresearch/lib/dashboard-view-model.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.ts
@@ -1,5 +1,6 @@
 import { STATUS_VALUES, buildDecisionEnvelope, finiteMetric } from "./session-core.js";
 import { redactEvidenceObject } from "./evidence-redaction.js";
+import { buildEvidenceRegistry } from "./evidence-registry.js";
 import type { DashboardContext } from "../dashboard/src/types.js";
 
 type LooseObject = Record<string, any>;
@@ -948,31 +949,24 @@ function buildEvidenceReadout({
 }
 
 function buildEvidenceLedger(current: RunLike[] = []) {
-  const counts = current.reduce((acc: LooseObject, run) => {
-    const status =
-      String((run as LooseObject).evidenceStatus || "") ||
-      (run.status === "keep" ? "accepted" : run.status === "measure" ? "provisional" : "rejected");
-    acc[status] = (acc[status] || 0) + 1;
-    return acc;
-  }, {});
-  const latest = [...current]
+  const registry = buildEvidenceRegistry({ runs: current });
+  const latest = [...registry.audit]
     .reverse()
-    .map((run) => ({
-      run: run.run,
-      status: run.status,
-      evidenceStatus:
-        (run as LooseObject).evidenceStatus ||
-        (run.status === "keep"
-          ? "accepted"
-          : run.status === "measure"
-            ? "provisional"
-            : "rejected"),
-      description: run.description || "",
+    .map((entry) => ({
+      run: entry.run,
+      status: entry.status,
+      kind: entry.kind,
+      name: entry.name || "",
+      path: entry.path || "",
+      evidenceStatus: entry.evidenceStatus,
+      current: entry.current,
+      description: entry.description || "",
     }))
     .slice(0, 5);
   return {
-    counts,
+    counts: registry.counts,
     latest,
+    acceptedCurrent: registry.acceptedCurrent.length,
     rule: "Accepted evidence can promote; rejected and quarantined evidence stays visible but does not drive promotion.",
   };
 }

--- a/plugins/codex-autoresearch/lib/evidence-registry.ts
+++ b/plugins/codex-autoresearch/lib/evidence-registry.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { redactPathDisplay } from "./evidence-redaction.js";
+
+type LooseObject = Record<string, any>;
+
+export type EvidenceStatus = "provisional" | "accepted" | "rejected" | "superseded";
+export type EvidenceKind = "run" | "artifact";
+
+export interface EvidenceRegistryEntry extends LooseObject {
+  id: string;
+  kind: EvidenceKind;
+  evidenceStatus: EvidenceStatus;
+  accepted: boolean;
+  current: boolean;
+  auditVisible: boolean;
+  run?: number | null;
+  status?: string;
+  name?: string;
+  path?: string;
+  exists?: boolean | null;
+  quarantined?: boolean;
+}
+
+export interface EvidenceRegistry {
+  schemaVersion: 1;
+  entries: EvidenceRegistryEntry[];
+  acceptedCurrent: EvidenceRegistryEntry[];
+  audit: EvidenceRegistryEntry[];
+  currentRuns: LooseObject[];
+  currentArtifacts: EvidenceRegistryEntry[];
+  counts: Record<EvidenceStatus, number>;
+}
+
+export function normalizeEvidenceStatus(
+  value: unknown,
+  fallback: EvidenceStatus = "provisional",
+): EvidenceStatus {
+  const normalized = String(value || "").toLowerCase();
+  if (
+    normalized === "provisional" ||
+    normalized === "accepted" ||
+    normalized === "rejected" ||
+    normalized === "superseded"
+  ) {
+    return normalized;
+  }
+  return fallback;
+}
+
+export function defaultEvidenceStatusForRun(run: LooseObject): EvidenceStatus {
+  const status = String(run?.status || "");
+  if (status === "keep") return "accepted";
+  if (status === "measure") return "provisional";
+  return "rejected";
+}
+
+export function isAcceptedCurrentEvidence(value: LooseObject | null | undefined): boolean {
+  const fallback =
+    value?.kind === "artifact" ? "provisional" : defaultEvidenceStatusForRun(value || {});
+  const evidenceStatus = normalizeEvidenceStatus(value?.evidenceStatus, fallback);
+  return evidenceStatus === "accepted" && value?.quarantined !== true;
+}
+
+export function artifactEvidenceList(
+  artifacts: LooseObject = {},
+  workDir = "",
+  evidenceStatus: EvidenceStatus | string = "provisional",
+): EvidenceRegistryEntry[] {
+  const normalizedStatus = normalizeEvidenceStatus(evidenceStatus, "provisional");
+  return artifactList(artifacts, workDir).map((artifact: LooseObject) =>
+    normalizeEvidenceEntry({
+      kind: "artifact",
+      ...artifact,
+      evidenceStatus: artifact.quarantined ? "rejected" : normalizedStatus,
+      promotable: !artifact.quarantined && normalizedStatus === "accepted",
+      promotionRelevance: artifact.quarantined
+        ? "blocked_external_artifact"
+        : normalizedStatus === "accepted"
+          ? "supporting"
+          : "context",
+    }),
+  );
+}
+
+export function buildEvidenceRegistry({
+  runs = [],
+  artifacts = [],
+  workDir = "",
+}: {
+  runs?: LooseObject[];
+  artifacts?: LooseObject[];
+  workDir?: string;
+} = {}): EvidenceRegistry {
+  const entries: EvidenceRegistryEntry[] = [];
+  for (const run of runs || []) {
+    entries.push(runEvidenceEntry(run));
+    const artifactEvidence = Array.isArray(run?.artifactEvidence)
+      ? run.artifactEvidence
+      : run?.artifacts && Object.keys(run.artifacts).length
+        ? artifactEvidenceList(
+            run.artifacts,
+            workDir,
+            normalizeEvidenceStatus(run.evidenceStatus, defaultEvidenceStatusForRun(run)),
+          )
+        : [];
+    for (const artifact of artifactEvidence) {
+      entries.push(
+        normalizeEvidenceEntry({
+          run: run.run ?? null,
+          status: run.status || "",
+          ...artifact,
+          kind: "artifact",
+        }),
+      );
+    }
+  }
+  for (const artifact of artifacts || []) {
+    entries.push(normalizeEvidenceEntry({ ...artifact, kind: "artifact" }));
+  }
+  const normalized = entries.map(normalizeEvidenceEntry);
+  const acceptedCurrent = normalized.filter((entry) => entry.current);
+  return {
+    schemaVersion: 1,
+    entries: normalized,
+    acceptedCurrent,
+    audit: normalized.filter((entry) => entry.auditVisible),
+    currentRuns: (runs || []).filter((run) => isAcceptedCurrentEvidence(run)),
+    currentArtifacts: acceptedCurrent.filter((entry) => entry.kind === "artifact"),
+    counts: evidenceStatusCounts(normalized),
+  };
+}
+
+export function acceptedCurrentRuns(runs: LooseObject[] = []): LooseObject[] {
+  return runs.filter((run) => isAcceptedCurrentEvidence(run));
+}
+
+function runEvidenceEntry(run: LooseObject): EvidenceRegistryEntry {
+  return normalizeEvidenceEntry({
+    id: `run-${run.run ?? "unknown"}`,
+    kind: "run",
+    run: run.run ?? null,
+    status: run.status || "",
+    metric: run.metric ?? null,
+    evidenceStatus: normalizeEvidenceStatus(run.evidenceStatus, defaultEvidenceStatusForRun(run)),
+    description: run.description || "",
+  });
+}
+
+function normalizeEvidenceEntry(value: LooseObject): EvidenceRegistryEntry {
+  const kind: EvidenceKind = value.kind === "artifact" ? "artifact" : "run";
+  const fallback =
+    kind === "run" ? defaultEvidenceStatusForRun(value) : ("provisional" as EvidenceStatus);
+  const evidenceStatus = normalizeEvidenceStatus(value.evidenceStatus, fallback);
+  const quarantined = value.quarantined === true;
+  const accepted = evidenceStatus === "accepted" && !quarantined;
+  const current = accepted;
+  const id =
+    String(value.id || "").trim() ||
+    (kind === "artifact"
+      ? `artifact-${value.run ?? "manual"}-${value.name || value.path || "unknown"}`
+      : `run-${value.run ?? "unknown"}`);
+  return {
+    ...value,
+    id,
+    kind,
+    evidenceStatus: quarantined ? "rejected" : evidenceStatus,
+    accepted,
+    current,
+    auditVisible: true,
+    quarantined,
+  };
+}
+
+function evidenceStatusCounts(entries: EvidenceRegistryEntry[]): Record<EvidenceStatus, number> {
+  const counts: Record<EvidenceStatus, number> = {
+    provisional: 0,
+    accepted: 0,
+    rejected: 0,
+    superseded: 0,
+  };
+  for (const entry of entries) counts[entry.evidenceStatus] += 1;
+  return counts;
+}
+
+export function artifactList(artifacts: LooseObject = {}, workDir = "") {
+  return Object.entries(artifacts || {}).map(([name, artifactPath]) => {
+    const quarantined = String(artifactPath || "") === "<outside-workdir>";
+    return {
+      id: `artifact-${name}`,
+      name,
+      path: quarantined
+        ? "<outside-workdir>"
+        : redactPathDisplay(String(artifactPath || ""), workDir),
+      exists: quarantined ? false : artifactExists(String(artifactPath || ""), workDir),
+      quarantined,
+      warning: quarantined ? "Artifact path is outside the working directory." : "",
+    };
+  });
+}
+
+function artifactExists(artifactPath: string, workDir: string) {
+  if (!artifactPath) return false;
+  const resolved = path.isAbsolute(artifactPath)
+    ? artifactPath
+    : path.resolve(workDir || process.cwd(), artifactPath);
+  return fs.existsSync(resolved);
+}

--- a/plugins/codex-autoresearch/lib/session-core.ts
+++ b/plugins/codex-autoresearch/lib/session-core.ts
@@ -4,6 +4,12 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { createInterface } from "node:readline";
 
+import {
+  acceptedCurrentRuns,
+  buildEvidenceRegistry,
+  isAcceptedCurrentEvidence,
+} from "./evidence-registry.js";
+
 export const STATUS_VALUES = new Set(["keep", "discard", "crash", "checks_failed", "measure"]);
 export const FAILURE_STATUSES = new Set(["crash", "checks_failed"]);
 export const NON_PROMOTIONAL_STATUSES = new Set(["crash", "checks_failed", "measure"]);
@@ -185,7 +191,7 @@ export function bestMetric(runs: RunRecord[], direction: Direction | string): nu
 
 export function bestKeptMetric(runs: RunRecord[], direction: Direction | string): number | null {
   return bestMetric(
-    runs.filter((run) => run.status === "keep"),
+    runs.filter((run) => run.status === "keep" && isAcceptedCurrentEvidence(run)),
     direction,
   );
 }
@@ -245,7 +251,8 @@ export function isPromotionGradeRun(run: RunRecord | null | undefined): boolean 
 }
 
 function evidenceTrack(runs: RunRecord[], direction: Direction | string) {
-  const kept = runs.filter((run) => run.status === "keep");
+  const acceptedRuns = acceptedCurrentRuns(runs);
+  const kept = acceptedRuns.filter((run) => run.status === "keep");
   const bestRun = bestMetricRun(kept, direction);
   return {
     count: runs.length,
@@ -316,7 +323,10 @@ export function currentState(workDir: string): SessionState {
   const baseline = finiteMetric(current.find(isBaselineEligibleMetricRun)?.metric);
   const best = bestKeptMetric(current, config.bestDirection);
   const confidence = computeConfidence(current, config.bestDirection);
-  const promotionRuns = current.filter((run) => run.status === "keep" && isPromotionGradeRun(run));
+  const evidenceRegistry = buildEvidenceRegistry({ runs: current, workDir });
+  const promotionRuns = evidenceRegistry.currentRuns.filter(
+    (run) => run.status === "keep" && isPromotionGradeRun(run),
+  );
   return {
     config,
     segment,
@@ -327,6 +337,7 @@ export function currentState(workDir: string): SessionState {
     confidence,
     development: evidenceTrack(current, config.bestDirection),
     promotion: evidenceTrack(promotionRuns, config.bestDirection),
+    evidenceRegistry,
   };
 }
 

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -19,6 +19,7 @@ import {
   redactEvidenceText,
   redactPathDisplay,
 } from "../lib/evidence-redaction.js";
+import { artifactEvidenceList, artifactList } from "../lib/evidence-registry.js";
 import { buildExperimentMemory } from "../lib/experiment-memory.js";
 import { mergeEvidenceClaims } from "../lib/evidence-index.js";
 import {
@@ -5433,6 +5434,7 @@ async function publicState(args: LooseObject): Promise<LooseObject> {
     best: state.best,
     development: state.development,
     promotion: state.promotion,
+    evidenceRegistry: state.evidenceRegistry,
     confidence: state.confidence,
     scaffoldHealth,
     researchIntegrity,
@@ -5488,6 +5490,17 @@ function compactPublicState(state: LooseObject) {
     best: state.best,
     developmentBest: state.development?.best ?? null,
     promotionBest: state.promotion?.best ?? null,
+    evidenceRegistry: state.evidenceRegistry
+      ? {
+          counts: state.evidenceRegistry.counts,
+          acceptedCurrent: Array.isArray(state.evidenceRegistry.acceptedCurrent)
+            ? state.evidenceRegistry.acceptedCurrent.length
+            : 0,
+          currentArtifacts: Array.isArray(state.evidenceRegistry.currentArtifacts)
+            ? state.evidenceRegistry.currentArtifacts.slice(0, 5)
+            : [],
+        }
+      : null,
     evidenceLabels: state.researchIntegrity?.evidenceLabels || [],
     scaffoldHealth: state.scaffoldHealth
       ? {
@@ -6365,46 +6378,6 @@ function packetEvidenceForRun(run: LooseObject, history: LooseObject) {
       : null,
     freshnessFingerprint: fingerprint,
   };
-}
-
-function artifactList(artifacts: LooseObject = {}, workDir = "") {
-  return Object.entries(artifacts || {}).map(([name, artifactPath]) => {
-    const quarantined = String(artifactPath || "") === "<outside-workdir>";
-    return {
-      name,
-      path: quarantined
-        ? "<outside-workdir>"
-        : redactPathDisplay(String(artifactPath || ""), workDir),
-      exists: quarantined ? false : artifactExists(String(artifactPath || ""), workDir),
-      quarantined,
-      warning: quarantined ? "Artifact path is outside the working directory." : "",
-    };
-  });
-}
-
-function artifactEvidenceList(
-  artifacts: LooseObject = {},
-  workDir = "",
-  evidenceStatus = "provisional",
-) {
-  return artifactList(artifacts, workDir).map((artifact: LooseObject) => ({
-    ...artifact,
-    evidenceStatus: artifact.quarantined ? "rejected" : evidenceStatus,
-    promotable: !artifact.quarantined && evidenceStatus === "accepted",
-    promotionRelevance: artifact.quarantined
-      ? "blocked_external_artifact"
-      : evidenceStatus === "accepted"
-        ? "supporting"
-        : "context",
-  }));
-}
-
-function artifactExists(artifactPath: string, workDir: string) {
-  if (!artifactPath) return false;
-  const resolved = path.isAbsolute(artifactPath)
-    ? artifactPath
-    : path.resolve(workDir || process.cwd(), artifactPath);
-  return fs.existsSync(resolved);
 }
 
 function promotionStateForLoggedDecision({

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -770,6 +770,63 @@ test("external ARTIFACT paths are quarantined instead of stored as usable paths"
     ]);
     assert.equal(logged.code, 0, logged.stderr);
     assert.equal(JSON.parse(logged.stdout).experiment.artifacts.manifest, "<outside-workdir>");
+    const state = await runCli(["state", "--cwd", dir]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    assert.equal(statePayload.evidenceRegistry.currentArtifacts.length, 0);
+    assert.equal(statePayload.evidenceRegistry.counts.rejected, 1);
+  });
+});
+
+test("accepted logged artifacts become current evidence in state registry", async () => {
+  await withTempDir("accepted-artifact-registry", async (dir) => {
+    await runCli([
+      "init",
+      "--cwd",
+      dir,
+      "--name",
+      "accepted artifact registry",
+      "--metric-name",
+      "score",
+      "--direction",
+      "higher",
+    ]);
+    await mkdir(path.join(dir, "out"), { recursive: true });
+    await writeFile(path.join(dir, "out", "manifest.json"), '{"ok":true}\n', "utf8");
+    await writeFile(
+      path.join(dir, "packet-runner.mjs"),
+      "console.log('METRIC score=7');\nconsole.log('ARTIFACT manifest=out/manifest.json');\n",
+      "utf8",
+    );
+
+    const packet = await runCli([
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} packet-runner.mjs`,
+    ]);
+    assert.equal(packet.code, 0, packet.stderr);
+
+    const logged = await runCli([
+      "log",
+      "--cwd",
+      dir,
+      "--from-last",
+      "--status",
+      "keep",
+      "--description",
+      "Keep accepted artifact evidence",
+    ]);
+    assert.equal(logged.code, 0, logged.stderr);
+
+    const state = await runCli(["state", "--cwd", dir]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    assert.equal(statePayload.evidenceRegistry.currentArtifacts.length, 1);
+    assert.equal(statePayload.evidenceRegistry.currentArtifacts[0].name, "manifest");
+    assert.equal(statePayload.evidenceRegistry.currentArtifacts[0].evidenceStatus, "accepted");
+    assert.equal(statePayload.evidenceRegistry.counts.accepted, 2);
   });
 });
 

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -35,6 +35,7 @@ import {
   readEvidenceIndex,
   validateClaimReferences,
 } from "../lib/evidence-index.js";
+import { artifactEvidenceList, buildEvidenceRegistry } from "../lib/evidence-registry.js";
 import {
   buildPartialResultEvidenceClaim,
   discoverPartialResultCandidates,
@@ -335,6 +336,79 @@ test("evidence index uses deterministic ids, merges claims, and validates refere
         promotionRelevance: "diagnostic",
       },
     ]);
+  });
+});
+
+test("evidence registry keeps rejected and provisional runs out of accepted current evidence", async () => {
+  await withTempDir("evidence-registry-runs", async (dir) => {
+    appendJsonl(dir, { type: "config", name: "registry", metricName: "score" });
+    appendJsonl(dir, {
+      run: 1,
+      metric: 10,
+      status: "keep",
+      evidenceStatus: "rejected",
+      description: "Rejected keep must remain audit only.",
+    });
+    appendJsonl(dir, {
+      run: 2,
+      metric: 8,
+      status: "measure",
+      description: "Provisional diagnostic measurement.",
+    });
+    appendJsonl(dir, {
+      run: 3,
+      metric: 6,
+      status: "keep",
+      evidenceStatus: "accepted",
+      description: "Accepted current result.",
+    });
+
+    const state = currentState(dir);
+    assert.equal(state.best, 6);
+    assert.equal(state.evidenceRegistry.counts.accepted, 1);
+    assert.equal(state.evidenceRegistry.counts.provisional, 1);
+    assert.equal(state.evidenceRegistry.counts.rejected, 1);
+    assert.deepEqual(
+      state.evidenceRegistry.currentRuns.map((run) => run.run),
+      [3],
+    );
+    assert.deepEqual(
+      state.evidenceRegistry.acceptedCurrent.map((entry) => entry.id),
+      ["run-3"],
+    );
+    assert.deepEqual(
+      state.evidenceRegistry.audit.map((entry) => entry.id),
+      ["run-1", "run-2", "run-3"],
+    );
+  });
+});
+
+test("evidence registry rejects quarantined artifacts and accepts current artifact evidence", async () => {
+  await withTempDir("evidence-registry-artifacts", async (dir) => {
+    await mkdir(path.join(dir, "out"), { recursive: true });
+    await writeFile(path.join(dir, "out", "accepted.json"), "{}\n", "utf8");
+
+    const accepted = artifactEvidenceList({ manifest: "out/accepted.json" }, dir, "accepted");
+    const quarantined = artifactEvidenceList({ outside: "<outside-workdir>" }, dir, "accepted");
+    const registry = buildEvidenceRegistry({
+      runs: [
+        {
+          run: 1,
+          status: "keep",
+          evidenceStatus: "accepted",
+          artifactEvidence: [...accepted, ...quarantined],
+        },
+      ],
+    });
+
+    assert.equal(registry.currentArtifacts.length, 1);
+    assert.equal(registry.currentArtifacts[0].name, "manifest");
+    assert.equal(registry.currentArtifacts[0].evidenceStatus, "accepted");
+    assert.equal(registry.currentArtifacts[0].current, true);
+    const outside = registry.audit.find((entry) => entry.name === "outside");
+    assert.equal(outside?.evidenceStatus, "rejected");
+    assert.equal(outside?.current, false);
+    assert.equal(outside?.quarantined, true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a generic EvidenceRegistry with accepted/provisional/rejected/superseded evidence states
- route artifact evidence normalization through the registry and expose registry summaries in state/dashboard
- filter best/promotion-style consumers to accepted/current evidence while keeping rejected/provisional evidence visible for audit
- add regressions for rejected/provisional runs, quarantined artifacts, and accepted current artifacts

## Validation
- node --test --test-name-pattern "evidence registry|external ARTIFACT|accepted logged artifacts|discarded metrics|measure logs metric evidence" dist/tests/evidence-core.test.mjs dist/tests/autoresearch-cli.test.mjs
- npm run check
- git diff --check