### PR TITLE
fix: close dev safety gaps for lanes, forensics, and timeouts

### DIFF
--- a/plugins/codex-autoresearch/lib/experiment-economics.ts
+++ b/plugins/codex-autoresearch/lib/experiment-economics.ts
@@ -141,12 +141,14 @@ function innerTimeoutSeconds(lastRun: LooseObject | null): number | null {
 
 function parseTimeoutFromCommand(command: string): number | null {
   const match = command.match(
-    /(?:--(?:test-)?timeout(?:-seconds|Seconds)?|timeout(?:Seconds)?)=?\s*([0-9.]+)/i,
+    /(?:--(?:test[-_]?timeout(?:-seconds|Seconds)?)|--timeout(?:-seconds|Seconds)?|timeout(?:Seconds)?)=?\s*([0-9.]+)/i,
   );
   if (!match) return null;
   const value = Number(match[1]);
   if (!Number.isFinite(value)) return null;
-  return /testtimeout/i.test(match[0]) && value > 1000 ? value / 1000 : value;
+  const flag = match[0].replace(/\s*=?[\s]*[0-9.]+$/, "");
+  const usesMilliseconds = /--test[-_]?timeout(?![-_]?seconds)/i.test(flag) && value > 1000;
+  return usesMilliseconds ? value / 1000 : value;
 }
 
 function median(values: number[]): number | null {

--- a/plugins/codex-autoresearch/lib/session-forensics.ts
+++ b/plugins/codex-autoresearch/lib/session-forensics.ts
@@ -16,6 +16,7 @@ export interface SessionForensicsOptions {
   maxSnippets?: number;
   maxSnippetChars?: number;
   thresholds?: Partial<DecisionThresholdConfig>;
+  createReadStream?: typeof fs.createReadStream;
 }
 
 export interface SessionForensicsError {
@@ -78,8 +79,8 @@ export async function parseSessionForensics(
     decisionThresholds: { ...DEFAULT_DECISION_THRESHOLDS, ...options.thresholds },
   });
   const state = createAccumulator(sessionJsonl, thresholds);
-  const stream = fs.createReadStream(sessionJsonl, { encoding: "utf8" });
-  stream.on("error", () => {});
+  const openStream = options.createReadStream ?? fs.createReadStream;
+  const stream = openStream(sessionJsonl, { encoding: "utf8" });
   const lines = createInterface({ input: stream, crlfDelay: Infinity });
   let lineNumber = 0;
   try {

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -6005,18 +6005,48 @@ function normalizeLaneMode(value: unknown, fallback: string) {
   throw new Error("--mode must be read_only_scout or implementation.");
 }
 
-function commandLooksMutating(command: string) {
-  return (
-    /(^|[\s;&|])(git\s+(add|am|apply|checkout|clean|commit|merge|mv|rebase|reset|restore|rm|switch)|npm\s+(install|i)|pnpm\s+(add|install)|yarn\s+(add|install)|rm\s+|del\s+|erase\s+|remove-item|set-content|out-file|new-item|move-item|copy-item|apply_patch)(\s|$)/i.test(
+type LaneCommandSafety = {
+  mutating: boolean;
+  unsafeForWriteScope: boolean;
+};
+
+const LANE_GIT_MUTATING_SUBCOMMANDS =
+  "add|am|apply|bisect|checkout|cherry-pick|clean|commit|merge|mv|pull|push|rebase|reset|restore|revert|rm|stash|switch|tag|worktree";
+const LANE_GIT_WRITE_SCOPE_UNSAFE =
+  "am|apply|bisect|checkout|cherry-pick|clean|commit|merge|pull|push|rebase|reset|restore|revert|stash|switch|tag|worktree";
+const LANE_PACKAGE_MANAGER_MUTATING =
+  "(?:npm\\s+(?:ci|install|i|update|uninstall|remove|add)|pnpm\\s+(?:add|install|remove|update|uninstall)|yarn\\s+(?:add|install|remove|upgrade|uninstall)|bun\\s+(?:add|install|remove))";
+
+function classifyLaneCommandSafety(command: string): LaneCommandSafety {
+  const gitMutating = new RegExp(
+    `(^|[\\s;&|])git\\b[^\\r\\n;&|]*\\b(${LANE_GIT_MUTATING_SUBCOMMANDS})\\b`,
+    "i",
+  ).test(command);
+  const packageMutating = new RegExp(
+    `(^|[\\s;&|])${LANE_PACKAGE_MANAGER_MUTATING}(\\s|$)`,
+    "i",
+  ).test(command);
+  const fileMutating =
+    /(^|[\s;&|])(rm\s+|del\s+|erase\s+|remove-item|set-content|out-file|new-item|move-item|copy-item|apply_patch)(\s|$)/i.test(
       command,
-    ) || /(^|[^<])>>?[^&]/.test(command)
-  );
+    ) || /(^|[^<])>>?[^&]/.test(command);
+  const mutating = gitMutating || packageMutating || fileMutating;
+  const gitUnsafeForWriteScope = new RegExp(
+    `(^|[\\s;&|])git\\b[^\\r\\n;&|]*\\b(${LANE_GIT_WRITE_SCOPE_UNSAFE})\\b`,
+    "i",
+  ).test(command);
+  return {
+    mutating,
+    unsafeForWriteScope: gitUnsafeForWriteScope || packageMutating,
+  };
+}
+
+function commandLooksMutating(command: string) {
+  return classifyLaneCommandSafety(command).mutating;
 }
 
 function commandLooksUnsafeForWriteScope(command: string) {
-  return /(^|[\s;&|])git\b[^\r\n;&|]*\b(am|apply|checkout|clean|commit|merge|rebase|reset|restore|stash|switch)\b/i.test(
-    command,
-  );
+  return classifyLaneCommandSafety(command).unsafeForWriteScope;
 }
 
 async function gitStatusPorcelain(cwd: string) {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -355,6 +355,33 @@ test("session-forensics supports dry-run and safe apply capsule writes", async (
     assert.match(gaps, /\[evidence:ev-/);
     assert.equal(evidence.schemaVersion, 1);
     assert.equal(JSON.stringify(evidence).includes("abcdefghijklmnop"), false);
+
+    const reapplied = await runCli([
+      "session-forensics",
+      "--cwd",
+      dir,
+      "--session-jsonl",
+      sessionPath,
+      "--research-slug",
+      "session-019e",
+      "--apply",
+    ]);
+    assert.equal(reapplied.code, 0, reapplied.stderr);
+    const evidenceAfter = JSON.parse(
+      await readFile(path.join(researchRoot, "evidence-index.json"), "utf8"),
+    );
+    const claimIds = new Set(
+      (evidenceAfter.claims || []).map((claim: { id?: string }) => claim.id).filter(Boolean),
+    );
+    const gapsAfter = await readFile(path.join(researchRoot, "quality-gaps.md"), "utf8");
+    const referencedIds = [...gapsAfter.matchAll(/\[evidence:(ev-[^\]]+)\]/g)].map(
+      (match) => match[1],
+    );
+    assert.equal(referencedIds.length > 0, true);
+    for (const evidenceId of referencedIds) {
+      assert.equal(claimIds.has(evidenceId), true, evidenceId);
+    }
+    assert.equal((evidenceAfter.claims || []).length >= (evidence.claims || []).length, true);
   });
 });
 
@@ -1081,6 +1108,101 @@ test("lane-runner blocks implementation lanes without explicit isolation", async
   });
 });
 
+test("lane-runner rejects missing and foreign implementation worktrees", async () => {
+  await withTempDir("lane-runner-worktree-edges", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "lane runner", "--metric-name", "quality_gap"]);
+    await git(dir, ["init"]);
+    await git(dir, ["config", "user.email", "codex@example.test"]);
+    await git(dir, ["config", "user.name", "Codex Test"]);
+    await writeFile(path.join(dir, "README.md"), "base\n", "utf8");
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-m", "initial"]);
+
+    const missing = await runCli([
+      "lane-runner",
+      "--cwd",
+      dir,
+      "--lane-id",
+      "implementation-candidate",
+      "--mode",
+      "implementation",
+      "--worktree",
+      "missing-worktree-path",
+      "--command",
+      "git status --short",
+      "--summary",
+      "Missing worktree.",
+      "--yes",
+    ]);
+    assert.notEqual(missing.code, 0);
+    assert.match(missing.stderr, /existing Git worktree/i);
+
+    const foreignRepo = path.join(dir, "foreign-repo");
+    await mkdir(foreignRepo, { recursive: true });
+    await git(foreignRepo, ["init"]);
+    await git(foreignRepo, ["config", "user.email", "codex@example.test"]);
+    await git(foreignRepo, ["config", "user.name", "Codex Test"]);
+    await writeFile(path.join(foreignRepo, "README.md"), "foreign\n", "utf8");
+    await git(foreignRepo, ["add", "-A"]);
+    await git(foreignRepo, ["commit", "-m", "foreign"]);
+
+    const foreign = await runCli([
+      "lane-runner",
+      "--cwd",
+      dir,
+      "--lane-id",
+      "implementation-candidate",
+      "--mode",
+      "implementation",
+      "--worktree",
+      foreignRepo,
+      "--command",
+      "git status --short",
+      "--summary",
+      "Foreign worktree.",
+      "--yes",
+    ]);
+    assert.notEqual(foreign.code, 0);
+    assert.match(foreign.stderr, /same Git repository/i);
+  });
+});
+
+test("lane-runner allows a sibling implementation worktree", async () => {
+  await withTempDir("lane-runner-worktree-pass", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "lane runner", "--metric-name", "quality_gap"]);
+    await git(dir, ["init"]);
+    await git(dir, ["config", "user.email", "codex@example.test"]);
+    await git(dir, ["config", "user.name", "Codex Test"]);
+    await writeFile(path.join(dir, "README.md"), "base\n", "utf8");
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-m", "initial"]);
+
+    const worktreePath = path.join(dir, "lane-worktree");
+    await git(dir, ["worktree", "add", worktreePath, "-b", "lane-impl"]);
+
+    const result = await runCli([
+      "lane-runner",
+      "--cwd",
+      dir,
+      "--lane-id",
+      "implementation-candidate",
+      "--mode",
+      "implementation",
+      "--worktree",
+      worktreePath,
+      "--command",
+      "git status --short",
+      "--summary",
+      "Sibling worktree command.",
+      "--yes",
+    ]);
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.result.commandResult.code, 0);
+  });
+});
+
 test("lane-runner rejects the main checkout as an implementation worktree", async () => {
   await withTempDir("lane-runner-main-worktree", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "lane runner", "--metric-name", "quality_gap"]);
@@ -1171,6 +1293,49 @@ test("lane-runner blocks write-scope commands that hide changes in commits", asy
     assert.notEqual(result.code, 0);
     assert.match(result.stderr, /cannot run git cleanup|cannot move HEAD/);
   });
+});
+
+test("lane-runner blocks write-scope mutators before execution", async () => {
+  const blockedCommands = [
+    ["git stash push -m blocked", /cannot run git cleanup|look mutating/i],
+    ["git cherry-pick HEAD", /cannot run git cleanup|look mutating/i],
+    ["git revert --no-edit HEAD", /cannot run git cleanup|look mutating/i],
+    ["npm ci", /cannot run git cleanup|dependency|look mutating/i],
+  ];
+  for (const [command, pattern] of blockedCommands) {
+    await withTempDir("lane-runner-write-scope-mutator", async (dir) => {
+      await runCli(["init", "--cwd", dir, "--name", "lane runner", "--metric-name", "quality_gap"]);
+      await mkdir(path.join(dir, "src"), { recursive: true });
+      await writeFile(path.join(dir, "src", "owned.txt"), "before\n", "utf8");
+      await git(dir, ["init"]);
+      await git(dir, ["config", "user.email", "codex@example.test"]);
+      await git(dir, ["config", "user.name", "Codex Test"]);
+      await git(dir, ["add", "-A"]);
+      await git(dir, ["commit", "-m", "initial"]);
+      const marker = path.join(dir, "lane-ran.marker");
+      const guardedCommand = `${command} && node -e "require('fs').writeFileSync('lane-ran.marker','ran')"`;
+
+      const result = await runCli([
+        "lane-runner",
+        "--cwd",
+        dir,
+        "--lane-id",
+        "implementation-candidate",
+        "--mode",
+        "implementation",
+        "--write-scope",
+        "src",
+        "--command",
+        guardedCommand,
+        "--summary",
+        "Unsafe mutator.",
+        "--yes",
+      ]);
+      assert.notEqual(result.code, 0, command);
+      assert.match(result.stderr, pattern, command);
+      await assert.rejects(() => access(marker));
+    });
+  }
 });
 
 test("lane-runner blocks write-scope cleanup commands in the main checkout", async () => {
@@ -4291,6 +4456,99 @@ test("CLI and tool argument normalization share runtime contracts", async () => 
     }),
   );
   assert.equal(normalizeToolArguments("clear_session", { yes: true }).confirm, true);
+
+  const laneRunnerArgs = validateToolArguments("lane_runner", {
+    workingDir: "C:/repo",
+    laneId: "read-only-scout",
+    mode: "read_only_scout",
+    command: "git status --short",
+    yes: true,
+  });
+  assert.deepEqual(normalizeRuntimeToolArguments("lane_runner", laneRunnerArgs), {
+    cwd: "C:/repo",
+    laneId: "read-only-scout",
+    mode: "read_only_scout",
+    command: "git status --short",
+    yes: true,
+  });
+
+  const forensicsArgs = validateToolArguments("session_forensics", {
+    workingDir: "C:/repo",
+    sessionJsonl: "rollout.jsonl",
+    researchSlug: "study",
+    apply: true,
+  });
+  assert.deepEqual(normalizeRuntimeToolArguments("session_forensics", forensicsArgs), {
+    cwd: "C:/repo",
+    sessionJsonl: "rollout.jsonl",
+    researchSlug: "study",
+    apply: true,
+  });
+
+  const partialResultsArgs = validateToolArguments("partial_results", {
+    workingDir: "C:/repo",
+    fromLast: true,
+    record: "rows=out/rows.json",
+    description: "Salvage rows",
+  });
+  assert.deepEqual(normalizeRuntimeToolArguments("partial_results", partialResultsArgs), {
+    cwd: "C:/repo",
+    fromLast: true,
+    record: "rows=out/rows.json",
+    description: "Salvage rows",
+  });
+
+  const goalBridgeArgs = validateToolArguments("codex_goal_bridge", {
+    workingDir: "C:/repo",
+    codexGoalObjective: "Close the loop",
+    codexGoalStatus: "active",
+  });
+  assert.deepEqual(normalizeRuntimeToolArguments("codex_goal_bridge", goalBridgeArgs), {
+    cwd: "C:/repo",
+    codexGoalObjective: "Close the loop",
+    codexGoalStatus: "active",
+  });
+});
+
+test("log rejects conflicting metrics inputs and invalid evidence status", async () => {
+  await withTempDir("log-contract-edges", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "log contract", "--metric-name", "seconds"]);
+    const command = `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=1')"`;
+    const packet = await runCli(["next", "--cwd", dir, "--command", command]);
+    assert.equal(packet.code, 0, packet.stderr);
+
+    const metricsConflict = await runCli([
+      "log",
+      "--cwd",
+      dir,
+      "--from-last",
+      "--status",
+      "keep",
+      "--description",
+      "conflict",
+      "--metrics",
+      '{"seconds":1}',
+      "--metrics-file",
+      "metrics.json",
+    ]);
+    assert.notEqual(metricsConflict.code, 0);
+    assert.match(metricsConflict.stderr, /either --metrics or --metrics-file/i);
+
+    const invalidEvidence = await runCli([
+      "log",
+      "--cwd",
+      dir,
+      "--from-last",
+      "--status",
+      "keep",
+      "--description",
+      "bad evidence",
+      "--evidence-status",
+      "mystery",
+    ]);
+    assert.notEqual(invalidEvidence.code, 0);
+    assert.match(invalidEvidence.stderr, /evidence-status/i);
+  });
 });
 
 test("plugin manifest does not declare an MCP server", async () => {

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -785,3 +785,61 @@ test("session forensics parses bounded signals without raw body persistence", as
     assert.equal(JSON.stringify(result).includes("sk-test"), false);
   });
 });
+
+test("parseSessionForensics returns unreadable_file when the read stream fails", async () => {
+  await withTempDir("session-forensics-stream-error", async (dir) => {
+    const sessionPath = path.join(dir, "rollout.jsonl");
+    await writeFile(sessionPath, '{"type":"session_meta"}\n', "utf8");
+    const { PassThrough } = await import("node:stream");
+    const result = await parseSessionForensics({
+      sessionJsonl: sessionPath,
+      createReadStream: () => {
+        const stream = new PassThrough();
+        queueMicrotask(() => stream.destroy(new Error("stream broke")));
+        return stream as ReturnType<typeof import("node:fs").createReadStream>;
+      },
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "unreadable_file");
+    assert.match(result.message, /stream broke/i);
+    assert.equal(result.path, sessionPath);
+  });
+});
+
+test("analyzeExperimentEconomics converts dashed test-timeout millisecond values", () => {
+  for (const command of [
+    "node bench.mjs --test-timeout 5000",
+    "node bench.mjs --test-timeout=5000",
+  ]) {
+    const economics = analyzeExperimentEconomics({
+      state: { baseline: 10, config: { bestDirection: "lower" }, current: [] },
+      lastRun: {
+        run: { durationSeconds: 30 },
+        packetEvidence: {
+          timeoutSeconds: 3,
+          commandIdentity: { command },
+        },
+      },
+    });
+    const warning = economics.warnings.find(
+      (entry) => entry.code === "outer_timeout_shorter_than_inner",
+    );
+    assert.equal(warning?.details?.innerTimeout, 5, command);
+  }
+
+  const secondsEconomics = analyzeExperimentEconomics({
+    state: { baseline: 10, config: { bestDirection: "lower" }, current: [] },
+    lastRun: {
+      run: { durationSeconds: 30 },
+      packetEvidence: {
+        timeoutSeconds: 3,
+        commandIdentity: { command: "node bench.mjs --test-timeout-seconds 5" },
+      },
+    },
+  });
+  const secondsWarning = secondsEconomics.warnings.find(
+    (entry) => entry.code === "outer_timeout_shorter_than_inner",
+  );
+  assert.equal(secondsWarning?.details?.innerTimeout, 5);
+});


### PR DESCRIPTION
## Summary

Closes high-confidence review gaps on `dev` before broader merge work.

## Problems

1. **Lane safety** — Write-scope and read-only prechecks missed several mutating commands (`git stash`, `cherry-pick`, `revert`, `npm ci`, etc.), allowing execution before post-run integrity checks could fail.
2. **Session forensics** — Read-stream errors were swallowed, so partial parses could return successful summaries.
3. **Timeout parsing** — Dashed `--test-timeout` values were not consistently treated as milliseconds when greater than 1000.

## Approach

- Shared `classifyLaneCommandSafety()` in `scripts/autoresearch.ts` for read-only and write-scope prechecks; block before `runShell()` in main-checkout write-scope mode; keep separate `--worktree` as the escape hatch.
- Fail-closed forensics reads: propagate stream/readline failures as `unreadable_file`; optional injectable `createReadStream` for tests.
- Normalize timeout flag detection in `experiment-economics.ts` for `test-timeout` / `test_timeout` variants.

## Tests

- Lane mutator pre-execution blocks (`lane-ran.marker` never created)
- Worktree isolation: missing path, foreign repo, valid sibling
- Forensics stream failure returns `unreadable_file`
- Economics: `--test-timeout 5000`, `--test-timeout=5000`, `--test-timeout-seconds 5`
- Log contract: `--metrics` + `--metrics-file` conflict, invalid `--evidence-status`
- Tool normalization for `lane_runner`, `session_forensics`, `partial_results`, `codex_goal_bridge`
- Repeated `session-forensics --apply` evidence reference integrity

## Verification

- `npm run check` (plugins/codex-autoresearch) — pass
- `npm test` — 107/107 pass
- `git diff --check` — clean

## Review focus

- Lane regex guard completeness vs false positives
- Forensics fail-closed semantics on partial reads
- Timeout ms vs seconds disambiguation edge cases