### PR TITLE
[codex] Harden evidence finalization semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses a root-only changelog because the root README is the public do
 - Added run-level `evidenceStatus` labels and artifact evidence summaries so accepted, rejected, provisional, superseded, and quarantined evidence stay visible without becoming promotion signals by accident.
 - Added watchdog, process-hygiene, and finalization-pressure dashboard readouts so long quiet windows, stale snapshots, runtime provenance, and accumulating kept work become visible before the loop sleepwalks into more packets.
 - Added a central EvidenceRegistry so accepted/current evidence is separated from rejected, provisional, superseded, and quarantined audit evidence before state and dashboard consumers read it.
+- Hardened finalization and best-run readouts so only accepted/current keeps drive promotion surfaces and review branches; rejected, provisional, superseded, and quarantined evidence remains audit-only.
 
 ### Changed
 
@@ -26,7 +27,9 @@ This project uses a root-only changelog because the root README is the public do
 - `state`, `recommend-next`, and the dashboard now share the same watchdog-aware decision envelope inputs, so quiet-window pressure is visible on CLI surfaces as well as the dashboard.
 - `research-fanout` plans are segment-scoped: a new segment ignores prior fanout plans and falls back to memory/default lanes until a fresh plan is recorded for that segment.
 - Completed `lane-runner` results now enrich parallel lane status and count as watchdog progress signals.
+- Empty `lane-runner --yes` records are planning breadcrumbs, not completed accepted evidence, and do not reset watchdog progress.
 - Read-only scout lanes fail closed when running commands outside a Git worktree unless `--allow-non-git-command` is explicitly passed.
+- `research_fanout` tool metadata now avoids unconditional read-only claims because `--yes` appends a fanout plan to the ledger.
 - Autoresearch-owned dirty files such as `autoresearch.jsonl`, notes, dashboards, and research scratchpads no longer count as dirty source drift; unrelated source dirtiness still blocks trust.
 
 ### Release

--- a/plugins/codex-autoresearch/lib/dashboard-view-model.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.ts
@@ -768,7 +768,7 @@ export function buildWatchdogSummary({
     : [];
   const progressEvents = [
     ...metricMovementEvents(currentRuns, state?.config?.bestDirection || "lower"),
-    ...currentRuns.map((run: LooseObject) => ({
+    ...currentRuns.filter(watchdogDecisionRun).map((run: LooseObject) => ({
       kind: "decision",
       at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
       label: `Logged run #${run.run ?? "?"} as ${run.status || "decision"}.`,
@@ -858,6 +858,12 @@ function metricMovementEvents(current: LooseObject[], direction: Direction) {
 function laneCompleted(lane: LooseObject) {
   const status = String(lane.status || lane.state || lane.evidenceStatus || "").toLowerCase();
   return ["complete", "completed", "done", "kept", "accepted", "finished"].includes(status);
+}
+
+function watchdogDecisionRun(run: LooseObject) {
+  if (run?.type === "lane_result") return false;
+  const status = String(run?.status || "").toLowerCase();
+  return ["keep", "discard", "crash", "checks_failed", "measure"].includes(status);
 }
 
 function timestampMs(value: unknown): number | null {

--- a/plugins/codex-autoresearch/lib/finalize-preview.ts
+++ b/plugins/codex-autoresearch/lib/finalize-preview.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { isAcceptedCurrentEvidence } from "./evidence-registry.js";
 import { resolvePackageRoot } from "./runtime-paths.js";
 
 const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
@@ -587,7 +588,9 @@ async function readKeptRuns(cwd: string): Promise<KeptRun[]> {
       .map((line) => line.trim())
       .filter(Boolean)
       .map((line) => JSON.parse(line))
-      .filter((entry: LooseObject) => entry.status === "keep") as KeptRun[];
+      .filter(
+        (entry: LooseObject) => entry.status === "keep" && isAcceptedCurrentEvidence(entry),
+      ) as KeptRun[];
   } catch {
     return [];
   }

--- a/plugins/codex-autoresearch/lib/session-core.ts
+++ b/plugins/codex-autoresearch/lib/session-core.ts
@@ -401,11 +401,13 @@ export function buildDecisionEnvelope({
   const all: RunRecord[] = Array.isArray(state?.results) ? state.results : current;
   const direction = state?.config?.bestDirection || "lower";
   const historicalBest = bestMetricRun(
-    all.filter((run) => run.status === "keep"),
+    all.filter((run) => run.status === "keep" && isAcceptedCurrentEvidence(run)),
     direction,
   );
   const promotionBest = bestMetricRun(
-    current.filter((run) => run.status === "keep" && isPromotionGradeRun(run)),
+    current.filter(
+      (run) => run.status === "keep" && isAcceptedCurrentEvidence(run) && isPromotionGradeRun(run),
+    ),
     direction,
   );
   const codes = warningCodes(warningDetails);

--- a/plugins/codex-autoresearch/lib/tool-contracts.ts
+++ b/plugins/codex-autoresearch/lib/tool-contracts.ts
@@ -137,7 +137,8 @@ const CONTRACTS = {
     whenToUse: "Use when the loop is spending too long serially exploring one hypothesis path.",
     contrast:
       "Use next_experiment to run a measured packet after a lane has produced a concrete hypothesis.",
-    safety: "Read-only by default; --yes appends only a fanout plan to the Autoresearch ledger.",
+    safety:
+      "Dry-run/default is read-only; yes=true appends only a fanout plan to the Autoresearch ledger.",
     outputSchema: basicOutputSchema(["ok", "workDir", "dryRun", "fanoutPlan", "parallelLanes"]),
   },
   lane_runner: {
@@ -366,7 +367,6 @@ const READ_ONLY_TOOLS = new Set([
   "recommend_next",
   "codex_goal_bridge",
   "list_recipes",
-  "research_fanout",
   "read_state",
   "measure_quality_gap",
   "finalize_preview",

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -5844,11 +5844,13 @@ function enrichParallelLanesWithLaneResults(lanes: LooseObject[], laneResults: L
     if (!entry?.result) return lane;
     const resultStatus = String(entry.result.status || "").toLowerCase();
     const completed = resultStatus === "completed";
+    const accepted = completed && laneResultHasAcceptedEvidence(entry.result);
     return {
       ...lane,
       status: completed ? "completed" : entry.result.status || lane.status,
-      evidenceStatus: completed ? "accepted" : lane.evidenceStatus,
-      completedAt: entry.timestamp ? new Date(entry.timestamp).toISOString() : lane.completedAt,
+      evidenceStatus: accepted ? "accepted" : entry.result.evidenceStatus || lane.evidenceStatus,
+      completedAt:
+        accepted && entry.timestamp ? new Date(entry.timestamp).toISOString() : lane.completedAt,
       lastLaneResult: {
         status: entry.result.status,
         summary: entry.result.summary || "",
@@ -5856,6 +5858,10 @@ function enrichParallelLanesWithLaneResults(lanes: LooseObject[], laneResults: L
       },
     };
   });
+}
+
+function laneResultHasAcceptedEvidence(result: LooseObject) {
+  return result?.evidenceAccepted === true;
 }
 
 function buildParallelOrchestrationContext({
@@ -6343,6 +6349,10 @@ async function laneRunner(args: LooseObject) {
     }
   }
 
+  const explicitSummary = String(args.summary || "").trim();
+  const explicitRecommendation = String(
+    args.recommendation || args.next_action || args.nextAction || "",
+  ).trim();
   const resultStatus =
     args.result_status ||
     args.resultStatus ||
@@ -6350,12 +6360,21 @@ async function laneRunner(args: LooseObject) {
       ? commandResult.code === 0 && !commandResult.timedOut
         ? "completed"
         : "failed"
-      : "completed");
+      : explicitSummary || explicitRecommendation
+        ? "completed"
+        : "planned");
+  const commandSucceeded =
+    commandResult && Number(commandResult.code) === 0 && commandResult.timedOut !== true;
+  const evidenceAccepted = Boolean(
+    String(resultStatus).toLowerCase() === "completed" &&
+    (commandSucceeded || explicitSummary || explicitRecommendation),
+  );
   const result = {
     status: resultStatus,
-    summary: args.summary || (commandResult ? "Lane command completed." : "Lane result recorded."),
-    recommendation:
-      args.recommendation || args.next_action || args.nextAction || lane.nextActionHint,
+    summary:
+      explicitSummary || (commandResult ? "Lane command completed." : "Lane result recorded."),
+    recommendation: explicitRecommendation || lane.nextActionHint,
+    evidenceAccepted,
     command: command || "",
     timeBudgetSeconds,
     isolation: {

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -4,6 +4,8 @@ import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
 
+import { isAcceptedCurrentEvidence } from "../lib/evidence-registry.js";
+
 type LooseObject = Record<string, any>;
 type LocalProcessResult = { code: number | null; stderr: string; stdout: string };
 type FinalizePhaseError = Error & { cause?: unknown; finalizePhase?: string };
@@ -471,7 +473,9 @@ function runEvidenceForCommit(entries: RunEntry[], hash: string): RunEntry | nul
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const run = entries[index];
     const commit = String(run.commit || "");
-    if (commitMatchesHash(commit, hash)) return run.status === "keep" ? run : null;
+    if (commitMatchesHash(commit, hash)) {
+      return run.status === "keep" && isAcceptedCurrentEvidence(run) ? run : null;
+    }
   }
   return null;
 }
@@ -539,7 +543,8 @@ function parseCommitStatus(entries: RunEntry[], hash: string): RunEntry | null {
 
 function describeCommitStatus(entry: RunEntry | null): string {
   if (!entry) return "unlogged";
-  if (entry.status === "keep") return "kept";
+  if (entry.status === "keep" && isAcceptedCurrentEvidence(entry)) return "kept";
+  if (entry.status === "keep" && entry.evidenceStatus) return String(entry.evidenceStatus);
   return String(entry.status || "unlogged");
 }
 
@@ -865,7 +870,9 @@ async function draftGroupsPlan(args: CliArgs, cwd: string): Promise<FinalizePlan
   const goal = safeSlug(args.goal || sourceBranch.replace(/^.*\//, "") || "autoresearch");
   const history = await commitHistory(base, cwd);
   const entries = await readAutoresearchJsonl(cwd);
-  const keptRuns = entries.filter((entry) => entry.status === "keep");
+  const keptRuns = entries.filter(
+    (entry) => entry.status === "keep" && isAcceptedCurrentEvidence(entry),
+  );
   const groups: PlanGroup[] = [];
   const excludedCommits: ExcludedCommit[] = [];
   const selectedCommits = new Set<string>();

--- a/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
+++ b/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
@@ -187,7 +187,7 @@ Use a deep-research loop for broad, qualitative, product-study, UX, architecture
 Use finalization when noisy loop history has useful kept commits.
 
 1. Run `finalize-preview --cwd <project>` before branch creation.
-2. Keep only `status: "keep"` evidence.
+2. Keep only accepted/current `status: "keep"` evidence; rejected, provisional, superseded, and quarantined evidence stays audit-visible but must not drive review branches.
 3. Treat previews and plans as read-only.
 4. Review dirty tree, stale plan, overlap, semantic safety, unkept base..HEAD commits, excluded commits, and excluded-file warnings. A ready preview must cover the final non-session tree.
 5. Treat finalization pressure as a stop-and-review signal when kept runs, preview warnings, missing commit metadata, or watchdog pressure accumulate.

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -1078,11 +1078,102 @@ test("lane-runner allows read-only lanes without worktree isolation", async () =
     assert.equal(payload.ok, true);
     assert.equal(payload.dryRun, false);
     assert.equal(payload.lane.mode, "read_only_scout");
+    assert.equal(payload.result.status, "completed");
+    assert.equal(payload.result.evidenceAccepted, true);
     assert.equal(payload.result.isolation.worktree, "");
     assert.deepEqual(payload.result.isolation.writeScope, []);
 
     const ledger = await readFile(path.join(dir, "autoresearch.jsonl"), "utf8");
     assert.match(ledger, /"type":"lane_result"/);
+
+    const state = await runCli(["state", "--cwd", dir, "--compact"]);
+    assert.equal(state.code, 0, state.stderr);
+    const statePayload = JSON.parse(state.stdout);
+    const lane = statePayload.parallelLanes.find((item) => item.id === "read-only-scout");
+    assert.equal(lane.status, "completed");
+    assert.equal(lane.evidenceStatus, "accepted");
+  });
+});
+
+test("empty lane-runner records are planned breadcrumbs, not watchdog progress", async () => {
+  await withTempDir("lane-runner-empty-planned", async (dir) => {
+    await runCli([
+      "init",
+      "--cwd",
+      dir,
+      "--name",
+      "lane watchdog",
+      "--metric-name",
+      "quality_gap",
+      "--max-iterations",
+      "100",
+    ]);
+    const oldTimestamp = Date.now() - 10 * 60 * 60 * 1000;
+    await writeFile(
+      path.join(dir, "autoresearch.jsonl"),
+      [
+        JSON.stringify({
+          type: "config",
+          name: "lane watchdog",
+          metricName: "quality_gap",
+          bestDirection: "lower",
+        }),
+        JSON.stringify({
+          run: 1,
+          metric: 4,
+          status: "measure",
+          description: "Old baseline.",
+          timestamp: oldTimestamp,
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await runCli(["research-fanout", "--cwd", dir, "--lanes", "4", "--yes"]);
+
+    const emptyResult = await runCli([
+      "lane-runner",
+      "--cwd",
+      dir,
+      "--lane-id",
+      "read-only-scout",
+      "--yes",
+    ]);
+    assert.equal(emptyResult.code, 0, emptyResult.stderr);
+    const emptyPayload = JSON.parse(emptyResult.stdout);
+    assert.equal(emptyPayload.result.status, "planned");
+    assert.equal(emptyPayload.result.evidenceAccepted, false);
+
+    const staleState = await runCli(["state", "--cwd", dir, "--compact"]);
+    assert.equal(staleState.code, 0, staleState.stderr);
+    const stalePayload = JSON.parse(staleState.stdout);
+    const plannedLane = stalePayload.parallelLanes.find((item) => item.id === "read-only-scout");
+    assert.equal(plannedLane.status, "planned");
+    assert.equal(plannedLane.evidenceStatus, "provisional");
+    assert.equal(stalePayload.watchdogSummary.stale, true);
+
+    const commandResult = await runCli([
+      "lane-runner",
+      "--cwd",
+      dir,
+      "--lane-id",
+      "read-only-scout",
+      "--command",
+      `${quoteForShell(process.execPath)} -e ""`,
+      "--allow-non-git-command",
+      "--yes",
+    ]);
+    assert.equal(commandResult.code, 0, commandResult.stderr);
+    const commandPayload = JSON.parse(commandResult.stdout);
+    assert.equal(commandPayload.result.status, "completed");
+    assert.equal(commandPayload.result.evidenceAccepted, true);
+
+    const freshState = await runCli(["state", "--cwd", dir, "--compact"]);
+    assert.equal(freshState.code, 0, freshState.stderr);
+    const freshPayload = JSON.parse(freshState.stdout);
+    const completedLane = freshPayload.parallelLanes.find((item) => item.id === "read-only-scout");
+    assert.equal(completedLane.status, "completed");
+    assert.equal(completedLane.evidenceStatus, "accepted");
+    assert.equal(freshPayload.watchdogSummary.stale, false);
   });
 });
 
@@ -4274,7 +4365,7 @@ test("tool schemas expose guidance and output contracts", async () => {
   const [
     { toolSchemas },
     { validateToolContracts },
-    { cliCommandForTool, toolMutates, validateToolRegistry },
+    { actionPolicyForTool, cliCommandForTool, toolMutates, validateToolRegistry },
   ] = await Promise.all([
     import("../lib/tool-schemas.js"),
     import("../lib/tool-contracts.js"),
@@ -4310,7 +4401,7 @@ test("tool schemas expose guidance and output contracts", async () => {
     "Read-only by default; starts a local dashboard only when start_dashboard=true.",
   );
   assert.equal(guided.annotations.readOnlyHint, false);
-  assert.equal(researchFanout.annotations.readOnlyHint, true);
+  assert.equal(researchFanout.annotations.readOnlyHint, false);
   assert.equal(researchFanout.annotations.openWorldHint, false);
   assert.equal(guided.annotations.openWorldHint, true);
   assert.equal(next.annotations.readOnlyHint, false);
@@ -4348,6 +4439,8 @@ test("tool schemas expose guidance and output contracts", async () => {
   assert.equal(cliCommandForTool("checks_inspect"), "checks-inspect");
   assert.equal(toolMutates("next_experiment"), true);
   assert.equal(toolMutates("research_fanout"), false);
+  assert.equal(actionPolicyForTool("research_fanout"), "read");
+  assert.equal(actionPolicyForTool("research_fanout", { yes: true }), "state_mutation");
   assert.equal(toolMutates("read_state"), false);
 });
 
@@ -4833,7 +4926,7 @@ test("dashboard renders an operator readout from ASI and failures", async () => 
 
     assert.match(dashboard, /Codex brief/);
     assert.match(dashboard, /Best kept change/);
-    assert.match(dashboard, /Recent failures/);
+    assert.match(dashboard, /Recent failure/);
     assert.match(dashboard, /Next action/);
     assert.match(dashboard, /Experiment portfolio/);
     assert.match(dashboard, /lower is better/);

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -365,6 +365,7 @@ test("evidence registry keeps rejected and provisional runs out of accepted curr
 
     const state = currentState(dir);
     assert.equal(state.best, 6);
+    assert.equal(state.development.best, 6);
     assert.equal(state.evidenceRegistry.counts.accepted, 1);
     assert.equal(state.evidenceRegistry.counts.provisional, 1);
     assert.equal(state.evidenceRegistry.counts.rejected, 1);
@@ -381,6 +382,68 @@ test("evidence registry keeps rejected and provisional runs out of accepted curr
       ["run-1", "run-2", "run-3"],
     );
   });
+});
+
+test("decision envelope omits rejected and superseded keeps from best evidence", () => {
+  const envelope = buildDecisionEnvelope({
+    state: {
+      config: { bestDirection: "lower" },
+      current: [
+        {
+          run: 1,
+          metric: 1,
+          status: "keep",
+          evidenceStatus: "rejected",
+          description: "Rejected perfect-looking run.",
+          metrics: { promotionGrade: true },
+        },
+        {
+          run: 2,
+          metric: 2,
+          status: "keep",
+          evidenceStatus: "superseded",
+          description: "Superseded run.",
+          metrics: { promotionGrade: true },
+        },
+        {
+          run: 3,
+          metric: 3,
+          status: "keep",
+          description: "Legacy accepted keep.",
+          metrics: { promotionGrade: true },
+        },
+      ],
+      results: [
+        {
+          run: 1,
+          metric: 1,
+          status: "keep",
+          evidenceStatus: "rejected",
+          description: "Rejected perfect-looking run.",
+          metrics: { promotionGrade: true },
+        },
+        {
+          run: 2,
+          metric: 2,
+          status: "keep",
+          evidenceStatus: "superseded",
+          description: "Superseded run.",
+          metrics: { promotionGrade: true },
+        },
+        {
+          run: 3,
+          metric: 3,
+          status: "keep",
+          description: "Legacy accepted keep.",
+          metrics: { promotionGrade: true },
+        },
+      ],
+    },
+    nextAction: "Continue.",
+  });
+
+  assert.equal(envelope.historicalBest.run, 3);
+  assert.equal(envelope.promotionGradeBest.run, 3);
 });
 
 test("evidence registry rejects quarantined artifacts and accepts current artifact evidence", async () => {

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -4,6 +4,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { finalizePreview } from "../lib/finalize-preview.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 
 const pluginRoot = resolvePackageRoot(import.meta.url);
@@ -787,6 +788,83 @@ test("finalizer plan keeps only kept commits and flags excluded history", async 
   assert.doesNotMatch(plan.groups[0].files.join("\n"), /autoresearch-dashboard\.html/);
   assert.match(plan.warnings.join("\n"), /Excluded 3 unkept commits/);
   assert.ok(unloggedHash);
+});
+
+test("finalization ignores rejected keeps while preserving legacy accepted keeps", async () => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "autoresearch-finalize-evidence-"));
+  const repo = path.join(root, "repo");
+  await fsp.mkdir(repo, { recursive: true });
+
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "codex@example.invalid"], repo);
+  await git(["config", "user.name", "Codex Test"], repo);
+  await writeFile(path.join(repo, "src", "base.txt"), "base\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "base"], repo);
+
+  await git(["switch", "-c", "codex/autoresearch-evidence"], repo);
+  await writeFile(path.join(repo, "src", "rejected.txt"), "rejected\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "rejected keep"], repo);
+  const rejectedHash = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+  await writeFile(path.join(repo, "src", "accepted.txt"), "accepted\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "legacy accepted keep"], repo);
+  const acceptedHash = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+  await writeFile(
+    path.join(repo, "autoresearch.jsonl"),
+    [
+      JSON.stringify({
+        type: "config",
+        name: "evidence loop",
+        metricName: "seconds",
+        bestDirection: "lower",
+      }),
+      JSON.stringify({
+        run: 1,
+        status: "keep",
+        evidenceStatus: "rejected",
+        metric: 1,
+        description: "Rejected keep",
+        commit: rejectedHash,
+      }),
+      JSON.stringify({
+        run: 2,
+        status: "keep",
+        metric: 2,
+        description: "Legacy accepted keep",
+        commit: acceptedHash,
+      }),
+    ].join("\n") + "\n",
+  );
+  await git(["add", "autoresearch.jsonl"], repo);
+  await git(["commit", "-m", "session log"], repo);
+
+  const preview = await finalizePreview({ cwd: repo, trunk: "main" });
+  assert.equal(preview.groups.length, 1);
+  assert.equal(preview.groups[0].commit, acceptedHash);
+
+  const output = path.join(root, "groups.json");
+  const result = await run(
+    process.execPath,
+    [finalizer, "plan", "--output", output, "--goal", "evidence-loop"],
+    repo,
+  );
+  assert.match(result.stdout, /Selected kept commits: 1/);
+
+  const plan = JSON.parse(await fsp.readFile(output, "utf8"));
+  assert.equal(plan.groups.length, 1);
+  assert.equal(plan.kept_commits.length, 1);
+  assert.equal(plan.groups[0].last_commit, acceptedHash);
+  assert.deepEqual(plan.kept_commits, [acceptedHash]);
+  assert.equal(
+    plan.excluded_commits.some(
+      (item) => item.commit === rejectedHash && item.status === "rejected",
+    ),
+    true,
+  );
 });
 
 test("finalizer plan recommends collapsing overlap and can collapse on request", async () => {


### PR DESCRIPTION
## Summary

- Require accepted/current keep evidence for best-run readouts, promotion-grade selection, finalize preview, and finalizer branch planning.
- Record empty `lane-runner --yes` handoffs as planned breadcrumbs instead of completed accepted evidence, and keep watchdog progress tied to real completed lane evidence.
- Correct `research_fanout` tool safety metadata so dry-run/default is read-oriented while `yes=true` is represented as a ledger mutation.

## Why

The new evidence contract was visible in audit surfaces but not authoritative everywhere promotion and finalization decisions were made. Rejected or superseded keeps could still influence historical/promotion bests or review branch grouping, and empty lane records could look like progress.

## Impact

Older ledgers remain compatible: legacy `keep` entries without `evidenceStatus` still count as accepted. Rejected, superseded, provisional, and quarantined evidence remains audit-visible but cannot drive finalization or promotion surfaces.

## Validation

- `git diff --check`
- `npm run check` from `plugins/codex-autoresearch`