### PR TITLE
[codex] Fix Windows finalizer clean-status test

### DIFF
--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -305,7 +305,7 @@ testWithTempRoot(
     assert.doesNotMatch(branchFiles, /autoresearch\.research/);
     assert.doesNotMatch(branchFiles, /autoresearch-dashboard\.html/);
 
-    const status = (await git(["status", "--porcelain"], repo)).stdout.trim();
+    const status = (await run("git", ["status", "--porcelain"], repo)).stdout.trim();
     assert.equal(status, "");
   },
 );


### PR DESCRIPTION
## What changed
- Fixes the Windows-only finalizer clean-status assertion that failed on the v2 release PR.
- The test now checks `git status --porcelain` through the same plain Git config surface used by the finalizer, instead of the test helper that forces `core.autocrlf=false`.

## Why
The test intentionally configures its temp repo with `core.autocrlf=true` to exercise Windows behavior. The finalizer restores and verifies using normal Git, but the assertion used the test helper's forced `core.autocrlf=false`, which can report committed session artifacts as modified after checkout line-ending normalization.

## Validation
- `npm run build:node`
- `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=2:4 node --test --test-concurrency=1 dist/tests/finalize-report.test.mjs`
- `node dist/scripts/run-test-shards.mjs --jobs 6 dist/tests/finalize-report.test.mjs 12`
- `git diff --check`