### PR TITLE
Document guide setup guardrails in full help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses a root-only changelog because the root README is the public do
 
 - Restored served dashboard live refresh from the redacted view model path while keeping raw ledger access limited to the debug surface.
 - Added live-refresh tests and type coverage so dashboard snapshots can update without reintroducing raw-session payload exposure.
+- Corrected `--help --all` so `guide` documents the same setup guardrail and budget flags as the read-only setup planning flow.
 
 ### Release
 

--- a/plugins/codex-autoresearch/lib/cli/help.ts
+++ b/plugins/codex-autoresearch/lib/cli/help.ts
@@ -13,11 +13,29 @@ const DEFAULT_USAGE_LINES = [
   "  node scripts/autoresearch.mjs finalize-preview --cwd <project> [--trunk main] [--progress]",
 ];
 
+const SETUP_GUIDANCE_FLAGS = [
+  "[--recipe <id>]",
+  "[--catalog <path-or-url>]",
+  "[--trust-catalog]",
+  "[--name <name>]",
+  "[--metric-name <name>]",
+  "[--benchmark-command <cmd>]",
+  "[--checks-command <cmd>]",
+  "[--commit-paths <paths>]",
+  "[--protected-benchmark-paths <paths>]",
+  "[--secondary-metric-constraints <rules>]",
+  "[--secondary-metric-constraint-mode advisory|blocking]",
+  "[--max-iterations <n>]",
+  "[--packet-budget <n>]",
+  "[--wall-clock-budget-seconds <n>]",
+  "[--budget-note <text>]",
+].join(" ");
+
 const FULL_USAGE_LINES = [
   "  node scripts/autoresearch.mjs setup --cwd <project> --name <name> --metric-name <name> [--recipe <id>] [--catalog <path-or-url>] [--trust-catalog] [--benchmark-command <cmd>] [--benchmark-prints-metric true|false] [--checks-command <cmd>] [--shell bash|powershell] [--protected-benchmark-paths <paths>] [--secondary-metric-constraints <rules>] [--secondary-metric-constraint-mode advisory|blocking] [--max-iterations <n>] [--packet-budget <n>] [--wall-clock-budget-seconds <n>] [--budget-note <text>]",
   "  node scripts/autoresearch.mjs setup --cwd <project> --interactive",
-  "  node scripts/autoresearch.mjs setup-plan --cwd <project> [--recipe <id>] [--catalog <path-or-url>] [--trust-catalog] [--name <name>] [--metric-name <name>] [--benchmark-command <cmd>] [--checks-command <cmd>] [--commit-paths <paths>] [--protected-benchmark-paths <paths>] [--secondary-metric-constraints <rules>] [--max-iterations <n>] [--packet-budget <n>] [--wall-clock-budget-seconds <n>]",
-  "  node scripts/autoresearch.mjs guide --cwd <project> [--recipe <id>] [--catalog <path-or-url>] [--trust-catalog] [--name <name>] [--metric-name <name>] [--benchmark-command <cmd>] [--checks-command <cmd>] [--commit-paths <paths>] [--max-iterations <n>]",
+  `  node scripts/autoresearch.mjs setup-plan --cwd <project> ${SETUP_GUIDANCE_FLAGS}`,
+  `  node scripts/autoresearch.mjs guide --cwd <project> ${SETUP_GUIDANCE_FLAGS}`,
   "  node scripts/autoresearch.mjs prompt-plan --cwd <project> --prompt <text>",
   "  node scripts/autoresearch.mjs onboarding-packet --cwd <project> [--compact]",
   "  node scripts/autoresearch.mjs recommend-next --cwd <project> [--compact] [--operator-checklist]",

--- a/plugins/codex-autoresearch/tests/cli/help.test.ts
+++ b/plugins/codex-autoresearch/tests/cli/help.test.ts
@@ -23,3 +23,22 @@ test("full help preserves advanced and maintainer commands", () => {
   assert.match(help, /clear --cwd <project>/);
   assert.doesNotMatch(help, /Run `--help --all`/);
 });
+
+test("full help documents shared setup guardrails for guide", () => {
+  const help = renderCliHelp({ all: true });
+  const guideLine = help
+    .split("\n")
+    .find((line) => line.includes("node scripts/autoresearch.mjs guide --cwd <project>"));
+
+  assert.ok(guideLine, "guide usage line should be present");
+  for (const flag of [
+    "--protected-benchmark-paths",
+    "--secondary-metric-constraints",
+    "--secondary-metric-constraint-mode",
+    "--packet-budget",
+    "--wall-clock-budget-seconds",
+    "--budget-note",
+  ]) {
+    assert.match(guideLine, new RegExp(flag));
+  }
+});


### PR DESCRIPTION
## Summary
- Share the setup guidance flag list used by `setup-plan` and `guide` in full CLI help.
- Ensure `guide --help --all` documents protected benchmark paths, secondary metric constraints, packet/wall-clock budgets, and budget notes.
- Add a regression test for the `guide` usage line.

## Validation
- `npm run build:node`
- `node --test dist/tests/cli/help.test.mjs`
- `node dist/scripts/command-surface-map.mjs`
- `git diff --check`
- `npm run check`

## Notes
- No version bump; package and plugin versions remain `2.1.5`.