### PR TITLE
Harden autoresearch path containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses a root-only changelog because the root README is the public do
 - Restored served dashboard live refresh from the redacted view model path while keeping raw ledger access limited to the debug surface.
 - Added live-refresh tests and type coverage so dashboard snapshots can update without reintroducing raw-session payload exposure.
 - Corrected `--help --all` so `guide` documents the same setup guardrail and budget flags as the read-only setup planning flow.
+- Hardened artifact evidence and dashboard exports so symlinks or junctions cannot make trusted paths escape `--cwd`.
 
 ### Release
 

--- a/plugins/codex-autoresearch/lib/evidence-registry.ts
+++ b/plugins/codex-autoresearch/lib/evidence-registry.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import path from "node:path";
 
 import { redactPathDisplay } from "./evidence-redaction.js";
+import { resolvePathInsideRootSync } from "./path-containment.js";
 import { isKeepStatus, isRejectedRunStatus } from "./run-status.js";
 
 type LooseObject = Record<string, any>;
@@ -199,14 +199,17 @@ function evidenceStatusCounts(entries: EvidenceRegistryEntry[]): Record<Evidence
 
 export function artifactList(artifacts: LooseObject = {}, workDir = "") {
   return Object.entries(artifacts || {}).map(([name, artifactPath]) => {
-    const quarantined = String(artifactPath || "") === "<outside-workdir>";
+    const value = String(artifactPath || "");
+    const resolved =
+      value && value !== "<outside-workdir>"
+        ? resolvePathInsideRootSync(workDir || process.cwd(), value)
+        : null;
+    const quarantined = value === "<outside-workdir>" || Boolean(resolved && !resolved.inside);
     return {
       id: `artifact-${name}`,
       name,
-      path: quarantined
-        ? "<outside-workdir>"
-        : redactPathDisplay(String(artifactPath || ""), workDir),
-      exists: quarantined ? false : artifactExists(String(artifactPath || ""), workDir),
+      path: quarantined ? "<outside-workdir>" : redactPathDisplay(value, workDir),
+      exists: quarantined ? false : artifactExists(value, workDir),
       quarantined,
       warning: quarantined ? "Artifact path is outside the working directory." : "",
     };
@@ -215,8 +218,6 @@ export function artifactList(artifacts: LooseObject = {}, workDir = "") {
 
 function artifactExists(artifactPath: string, workDir: string) {
   if (!artifactPath) return false;
-  const resolved = path.isAbsolute(artifactPath)
-    ? artifactPath
-    : path.resolve(workDir || process.cwd(), artifactPath);
-  return fs.existsSync(resolved);
+  const resolved = resolvePathInsideRootSync(workDir || process.cwd(), artifactPath);
+  return resolved.inside && fs.existsSync(resolved.absolutePath);
 }

--- a/plugins/codex-autoresearch/lib/path-containment.ts
+++ b/plugins/codex-autoresearch/lib/path-containment.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface PathContainmentResult {
+  absolutePath: string;
+  error: string;
+  inside: boolean;
+  realPath: string;
+  realRoot: string;
+  relativePath: string;
+}
+
+export function resolvePathInsideRootSync(root: string, target: string): PathContainmentResult {
+  const absoluteRoot = path.resolve(root || process.cwd());
+  const absolutePath = path.isAbsolute(target)
+    ? path.resolve(target)
+    : path.resolve(absoluteRoot, target);
+  const relativePath = slashPath(path.relative(absoluteRoot, absolutePath));
+  const lexicalInside = isPathInside(absoluteRoot, absolutePath);
+  const rootReal = realPathForTargetSync(absoluteRoot);
+  const targetReal = lexicalInside
+    ? realPathForTargetSync(absolutePath)
+    : { error: "", path: absolutePath };
+  const error = rootReal.error || targetReal.error;
+  return {
+    absolutePath,
+    error,
+    inside: lexicalInside && !error && isPathInside(rootReal.path, targetReal.path),
+    realPath: targetReal.path,
+    realRoot: rootReal.path,
+    relativePath,
+  };
+}
+
+export function isPathInside(root: string, target: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function realPathForTargetSync(target: string): { error: string; path: string } {
+  const resolved = path.resolve(target);
+  if (fs.existsSync(resolved)) return realPathOrErrorSync(resolved);
+  const parent = nearestExistingParentSync(path.dirname(resolved));
+  const parentReal = realPathOrErrorSync(parent);
+  if (parentReal.error) return { error: parentReal.error, path: resolved };
+  return { error: "", path: path.resolve(parentReal.path, path.relative(parent, resolved)) };
+}
+
+function realPathOrErrorSync(target: string): { error: string; path: string } {
+  try {
+    return { error: "", path: fs.realpathSync.native(target) };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      path: path.resolve(target),
+    };
+  }
+}
+
+function nearestExistingParentSync(start: string): string {
+  let cursor = path.resolve(start);
+  while (!fs.existsSync(cursor)) {
+    const next = path.dirname(cursor);
+    if (next === cursor) return cursor;
+    cursor = next;
+  }
+  return cursor;
+}
+
+function slashPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -68,6 +68,7 @@ import {
   artifactList,
   defaultEvidenceStatusForRun,
 } from "../lib/evidence-registry.js";
+import { resolvePathInsideRootSync } from "../lib/path-containment.js";
 import { buildExperimentMemory } from "../lib/experiment-memory.js";
 import {
   finalizeCurrentTree as buildFinalizeCurrentTree,
@@ -461,12 +462,11 @@ function normalizeRelativePaths(paths: unknown, optionName: string = "paths"): s
 }
 
 function resolveOutputInside(workDir: string, output: string) {
-  const target = path.resolve(workDir, output || "autoresearch-dashboard.html");
-  const relative = path.relative(workDir, target);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new Error(`Dashboard output is outside the working directory: ${target}`);
+  const resolved = resolvePathInsideRootSync(workDir, output || "autoresearch-dashboard.html");
+  if (!resolved.inside) {
+    throw new Error(`Dashboard output is outside the working directory: ${resolved.absolutePath}`);
   }
-  return target;
+  return resolved.absolutePath;
 }
 
 async function pathExists(filePath: string) {
@@ -2950,10 +2950,9 @@ function parseArtifactLines(output: string, workDir: string) {
     const name = match[1];
     const value = match[2].trim();
     if (!value) continue;
-    const absolute = path.isAbsolute(value) ? value : path.resolve(workDir, value);
-    const relative = path.relative(workDir, absolute);
-    if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
-      artifacts[name] = relative.replace(/\\/g, "/");
+    const resolved = resolvePathInsideRootSync(workDir, value);
+    if (resolved.inside && resolved.relativePath) {
+      artifacts[name] = resolved.relativePath;
     } else {
       artifacts[name] = "<outside-workdir>";
       artifactWarnings.push(

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -8124,7 +8124,21 @@ async function taskManifestPathsForRun(run: LooseObject) {
   const warnings: string[] = [];
 
   for (const [name, artifactPath] of Object.entries(run.artifacts || {})) {
-    if (!/task[_-]?manifest/i.test(name) || !isUsableArtifactPath(artifactPath)) continue;
+    if (!/task[_-]?manifest/i.test(name)) continue;
+    if (!isUsableArtifactPath(artifactPath)) {
+      if (artifactPath === "<outside-workdir>") {
+        quarantineTaskManifestPath({
+          resolved: "<outside-workdir>",
+          reason: "outside_workdir",
+          detail:
+            "path escapes the working directory and was quarantined before task manifest indexing",
+          workDir,
+          quarantinedTasks,
+          warnings,
+        });
+      }
+      continue;
+    }
 
     const artifactValue = String(artifactPath);
     const resolved = path.isAbsolute(artifactValue)

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -1477,6 +1477,80 @@ test("external ARTIFACT paths are quarantined instead of stored as usable paths"
   });
 });
 
+test("ARTIFACT paths through linked directories outside the workdir are quarantined", async (t) => {
+  await withTempDir("linked-external-artifact", async (dir) => {
+    const outsideDir = path.join(path.dirname(dir), `${path.basename(dir)}-outside`);
+    await mkdir(outsideDir, { recursive: true });
+    try {
+      await writeFile(path.join(outsideDir, "manifest.json"), '{"secret":true}\n', "utf8");
+      const linkPath = path.join(dir, "linked-out");
+      try {
+        await symlink(outsideDir, linkPath, process.platform === "win32" ? "junction" : "dir");
+      } catch (error) {
+        t.skip(
+          `directory symlink creation unavailable: ${error instanceof Error ? error.message : error}`,
+        );
+        return;
+      }
+
+      await runCli([
+        "init",
+        "--cwd",
+        dir,
+        "--name",
+        "linked external artifact",
+        "--metric-name",
+        "score",
+        "--direction",
+        "higher",
+      ]);
+      await writeFile(
+        path.join(dir, "packet-runner.mjs"),
+        [
+          "console.log('METRIC score=7');",
+          "console.log('ARTIFACT manifest=linked-out/manifest.json');",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const packet = await runCli([
+        "next",
+        "--cwd",
+        dir,
+        "--command",
+        `${quoteForShell(process.execPath)} packet-runner.mjs`,
+      ]);
+      assert.equal(packet.code, 0, packet.stderr);
+      const payload = JSON.parse(packet.stdout);
+      assert.equal(payload.run.artifacts.manifest, "<outside-workdir>");
+      assert.equal(payload.packetEvidence.artifacts[0].exists, false);
+      assert.equal(payload.packetEvidence.artifacts[0].quarantined, true);
+      assert.match(payload.packetEvidence.artifactWarnings.join("\n"), /quarantined/);
+      assert.doesNotMatch(JSON.stringify(payload.packetEvidence), /secret/);
+
+      const logged = await runCli([
+        "log",
+        "--cwd",
+        dir,
+        "--from-last",
+        "--status",
+        "keep",
+        "--description",
+        "Keep linked external artifact evidence",
+      ]);
+      assert.equal(logged.code, 0, logged.stderr);
+      assert.equal(JSON.parse(logged.stdout).experiment.artifacts.manifest, "<outside-workdir>");
+      const state = await runCli(["state", "--cwd", dir]);
+      assert.equal(state.code, 0, state.stderr);
+      const statePayload = JSON.parse(state.stdout);
+      assert.equal(statePayload.evidenceRegistry.currentArtifacts.length, 0);
+      assert.equal(statePayload.evidenceRegistry.counts.rejected, 1);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
 test("accepted logged artifacts become current evidence in state registry", async () => {
   await withTempDir("accepted-artifact-registry", async (dir) => {
     await runCli([
@@ -6314,6 +6388,49 @@ test("export refuses to write outside the working directory", async () => {
     const result = await runCli(["export", "--cwd", dir, "--output", "../escape.html"]);
     assert.notEqual(result.code, 0);
     assert.match(result.stderr, /outside the working directory/);
+  });
+});
+
+test("export refuses to write through linked directories outside the working directory", async (t) => {
+  await withTempDir("linked-contained-export", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "linked export", "--metric-name", "seconds"]);
+    await runCli([
+      "log",
+      "--cwd",
+      dir,
+      "--metric",
+      "1",
+      "--status",
+      "keep",
+      "--description",
+      "Baseline",
+    ]);
+    const outsideDir = path.join(path.dirname(dir), `${path.basename(dir)}-outside`);
+    await mkdir(outsideDir, { recursive: true });
+    try {
+      const linkPath = path.join(dir, "linked-output");
+      try {
+        await symlink(outsideDir, linkPath, process.platform === "win32" ? "junction" : "dir");
+      } catch (error) {
+        t.skip(
+          `directory symlink creation unavailable: ${error instanceof Error ? error.message : error}`,
+        );
+        return;
+      }
+
+      const result = await runCli([
+        "export",
+        "--cwd",
+        dir,
+        "--output",
+        "linked-output/escape.html",
+      ]);
+      assert.notEqual(result.code, 0);
+      assert.match(result.stderr, /outside the working directory/);
+      await assert.rejects(readFile(path.join(outsideDir, "escape.html"), "utf8"));
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
@@ -594,6 +594,51 @@ test("evidence registry rejects quarantined artifacts and accepts current artifa
     assert.equal(outside?.evidenceStatus, "rejected");
     assert.equal(outside?.current, false);
     assert.equal(outside?.quarantined, true);
+  });
+});
+
+test("evidence registry rejects artifacts that resolve outside the workdir through links", async (t) => {
+  await withTempDir("evidence-registry-linked-artifacts", async (dir) => {
+    const outsideDir = path.join(path.dirname(dir), `${path.basename(dir)}-outside`);
+    await mkdir(outsideDir, { recursive: true });
+    try {
+      await writeFile(path.join(outsideDir, "accepted.json"), "{}\n", "utf8");
+      const linkPath = path.join(dir, "linked-out");
+      try {
+        await symlink(outsideDir, linkPath, process.platform === "win32" ? "junction" : "dir");
+      } catch (error) {
+        t.skip(
+          `directory symlink creation unavailable: ${error instanceof Error ? error.message : error}`,
+        );
+        return;
+      }
+
+      const linked = artifactEvidenceList(
+        { manifest: "linked-out/accepted.json" },
+        dir,
+        "accepted",
+      );
+      assert.equal(linked[0].quarantined, true);
+      assert.equal(linked[0].exists, false);
+      assert.equal(linked[0].evidenceStatus, "rejected");
+      assert.equal(linked[0].path, "<outside-workdir>");
+
+      const registry = buildEvidenceRegistry({
+        runs: [
+          {
+            run: 1,
+            status: "keep",
+            evidenceStatus: "accepted",
+            artifactEvidence: linked,
+          },
+        ],
+      });
+
+      assert.equal(registry.currentArtifacts.length, 0);
+      assert.equal(registry.counts.rejected, 1);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## What changed

- Added a shared realpath-aware path containment helper for workdir-scoped paths.
- Routed dashboard export output and generic ARTIFACT parsing/evidence through the containment helper.
- Added regressions for ARTIFACT paths and dashboard exports that traverse symlinks or junctions outside `--cwd`.

## Why

Review found that lexical containment was not enough for trusted evidence or export outputs because symlinks/junctions can point outside the workdir while still looking project-relative.

## Verification

- `npm ci --prefer-offline --no-audit`
- `npm run build:node`
- `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=24:26 node --test --test-concurrency=1 dist/tests/autoresearch-cli.test.mjs`
- `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=133:135 node --test --test-concurrency=1 dist/tests/autoresearch-cli.test.mjs`
- `node --test --test-concurrency=1 dist/tests/evidence-core.test.mjs`
- `npm run format:check`
- `npm run typecheck:node`
- `npm run lint`
- `git diff --check`

## Risk or follow-up

- Symlink/junction regression tests skip only when the platform cannot create the link type.
- Full `npm run check` is left for CI or the final integration pass.

## Checklist

- [x] I kept the diff focused.
- [x] I updated docs, skill guidance, or `CHANGELOG.md` when the user-facing contract changed.
- [x] I removed secrets, local credentials, caches, and unrelated artifacts.
- [x] I ran the narrowest relevant check, or explained why verification was not possible.