### PR TITLE
Fix command rendering and finalizer cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses a root-only changelog because the root README is the public do
 
 ### Fixed
 
+- Render generated commands with explicit PowerShell/POSIX shell quoting, and include `--cwd` in finalizer plan suggestions so copied finalizer commands target the previewed repo.
 - Restored served dashboard live refresh from the redacted view model path while keeping raw ledger access limited to the debug surface.
 - Added live-refresh tests and type coverage so dashboard snapshots can update without reintroducing raw-session payload exposure.
 - Corrected `--help --all` so `guide` documents the same setup guardrail and budget flags as the read-only setup planning flow.

--- a/plugins/codex-autoresearch/docs/finish.md
+++ b/plugins/codex-autoresearch/docs/finish.md
@@ -52,7 +52,7 @@ Use this for current-final-tree finalization after stale bests, contaminated eva
 From the autoresearch source branch:
 
 ```bash
-node scripts/finalize-autoresearch.mjs plan --goal <short-goal>
+node scripts/finalize-autoresearch.mjs plan --cwd <project> --output groups.json --goal <short-goal>
 ```
 
 Review the plan before mutation:

--- a/plugins/codex-autoresearch/docs/walkthrough.md
+++ b/plugins/codex-autoresearch/docs/walkthrough.md
@@ -135,7 +135,7 @@ Total kept commits: 15
 Files affected: src/indexer.ts, src/cache.ts
 Estimated overlap: safe to collapse
 
-Next step: Review `finalize-preview`, approve branch creation, then run `node scripts/finalize-autoresearch.mjs plan` from the source branch that owns the kept work.
+Next step: Review `finalize-preview`, approve branch creation, then run `node scripts/finalize-autoresearch.mjs plan --cwd <project> --output groups.json` for the source branch that owns the kept work.
 ```
 
 The loop is complete, documented, and ready for human review.

--- a/plugins/codex-autoresearch/lib/cli-handlers.ts
+++ b/plugins/codex-autoresearch/lib/cli-handlers.ts
@@ -415,6 +415,7 @@ function setupArgs(args: LooseObject): LooseObject {
     benchmarkCommand: args.benchmarkCommand,
     benchmarkPrintsMetric: args.benchmarkPrintsMetric,
     checksCommand: args.checksCommand,
+    shell: args.shell,
     filesInScope: args.filesInScope,
     offLimits: args.offLimits,
     constraints: args.constraints,

--- a/plugins/codex-autoresearch/lib/command-rendering.ts
+++ b/plugins/codex-autoresearch/lib/command-rendering.ts
@@ -22,7 +22,7 @@ export function quoteShellArg(value: unknown, shell: CommandShell = defaultComma
   if (text === "") return "''";
   const safePattern = shell === "powershell" ? POWERSHELL_SAFE_ARG : BASH_SAFE_ARG;
   if (safePattern.test(text)) return text;
-  if (shell === "powershell") return `'${text.replace(/"/g, '\\"').replace(/'/g, "''")}'`;
+  if (shell === "powershell") return `'${escapePowerShellNativeQuotes(text).replace(/'/g, "''")}'`;
   return `'${text.replace(/'/g, "'\"'\"'")}'`;
 }
 
@@ -34,4 +34,8 @@ export function renderShellCommand(
   if (args.length === 0) return "";
   if (shell === "powershell" && args[0].startsWith("'")) return `& ${args.join(" ")}`;
   return args.join(" ");
+}
+
+function escapePowerShellNativeQuotes(text: string): string {
+  return text.replace(/(\\*)"/g, (_match, slashes: string) => `${slashes}${slashes}\\"`);
 }

--- a/plugins/codex-autoresearch/lib/command-rendering.ts
+++ b/plugins/codex-autoresearch/lib/command-rendering.ts
@@ -32,8 +32,12 @@ export function renderShellCommand(
 ): string {
   const args = argv.map((value) => quoteShellArg(value, shell));
   if (args.length === 0) return "";
-  if (shell === "powershell" && args[0].startsWith("'")) return `& ${args.join(" ")}`;
-  return args.join(" ");
+  const command =
+    shell === "powershell" && args[0].startsWith("'") ? `& ${args.join(" ")}` : args.join(" ");
+  if (shell === "powershell") {
+    return `& { $PSNativeCommandArgumentPassing = 'Legacy'; ${command} }`;
+  }
+  return command;
 }
 
 function escapePowerShellNativeQuotes(text: string): string {

--- a/plugins/codex-autoresearch/lib/command-rendering.ts
+++ b/plugins/codex-autoresearch/lib/command-rendering.ts
@@ -22,7 +22,7 @@ export function quoteShellArg(value: unknown, shell: CommandShell = defaultComma
   if (text === "") return "''";
   const safePattern = shell === "powershell" ? POWERSHELL_SAFE_ARG : BASH_SAFE_ARG;
   if (safePattern.test(text)) return text;
-  if (shell === "powershell") return `'${text.replace(/'/g, "''")}'`;
+  if (shell === "powershell") return `'${text.replace(/"/g, '\\"').replace(/'/g, "''")}'`;
   return `'${text.replace(/'/g, "'\"'\"'")}'`;
 }
 

--- a/plugins/codex-autoresearch/lib/command-rendering.ts
+++ b/plugins/codex-autoresearch/lib/command-rendering.ts
@@ -1,0 +1,37 @@
+export type CommandShell = "bash" | "powershell";
+
+const BASH_SAFE_ARG = /^[A-Za-z0-9_./:@%+=,-]+$/;
+const POWERSHELL_SAFE_ARG = /^[A-Za-z0-9_./:@%+=,\\:-]+$/;
+
+export function defaultCommandShell(platform = process.platform): CommandShell {
+  return platform === "win32" ? "powershell" : "bash";
+}
+
+export function normalizeCommandShell(
+  value: unknown,
+  fallback: CommandShell = defaultCommandShell(),
+): CommandShell {
+  const requested = String(value || "").toLowerCase();
+  if (["bash", "sh", "posix"].includes(requested)) return "bash";
+  if (["powershell", "pwsh", "ps1", "windows"].includes(requested)) return "powershell";
+  return fallback;
+}
+
+export function quoteShellArg(value: unknown, shell: CommandShell = defaultCommandShell()): string {
+  const text = String(value);
+  if (text === "") return "''";
+  const safePattern = shell === "powershell" ? POWERSHELL_SAFE_ARG : BASH_SAFE_ARG;
+  if (safePattern.test(text)) return text;
+  if (shell === "powershell") return `'${text.replace(/'/g, "''")}'`;
+  return `'${text.replace(/'/g, "'\"'\"'")}'`;
+}
+
+export function renderShellCommand(
+  argv: readonly unknown[],
+  shell: CommandShell = defaultCommandShell(),
+): string {
+  const args = argv.map((value) => quoteShellArg(value, shell));
+  if (args.length === 0) return "";
+  if (shell === "powershell" && args[0].startsWith("'")) return `& ${args.join(" ")}`;
+  return args.join(" ");
+}

--- a/plugins/codex-autoresearch/lib/decision-guidance.ts
+++ b/plugins/codex-autoresearch/lib/decision-guidance.ts
@@ -20,7 +20,7 @@ export interface DecisionGuidanceInput {
   checksCommand?: unknown;
   defaultBenchmarkCommand: (workDir: string) => Promise<string> | string;
   defaultChecksCommand: (workDir: string) => Promise<string | null> | string | null;
-  shellQuote: (value: string) => string;
+  renderCommand: (argv: readonly unknown[]) => string;
   errorMessage: (error: unknown) => string;
 }
 
@@ -38,7 +38,7 @@ export async function buildDecisionGuidanceContext({
   checksCommand = "",
   defaultBenchmarkCommand,
   defaultChecksCommand,
-  shellQuote,
+  renderCommand,
   errorMessage,
 }: DecisionGuidanceInput): Promise<LooseObject> {
   const configRecord = unknownRecordOrEmpty(config);
@@ -51,9 +51,27 @@ export async function buildDecisionGuidanceContext({
     cleanString(checksCommand) || cleanString(await defaultChecksCommand(workDir));
   const metricName = cleanString(stateConfig.metricName || configRecord.metricName) || "metric";
   const benchmarkLintCommand = resolvedBenchmarkCommand
-    ? `node ${shellQuote(path.join(pluginRoot, "scripts", "autoresearch.mjs"))} benchmark-lint --cwd ${shellQuote(workDir)} --metric-name ${shellQuote(metricName)} --command ${shellQuote(resolvedBenchmarkCommand)}`
+    ? renderCommand([
+        "node",
+        path.join(pluginRoot, "scripts", "autoresearch.mjs"),
+        "benchmark-lint",
+        "--cwd",
+        workDir,
+        "--metric-name",
+        metricName,
+        "--command",
+        resolvedBenchmarkCommand,
+      ])
     : "";
-  const doctorCommand = `node ${shellQuote(path.join(pluginRoot, "scripts", "autoresearch.mjs"))} doctor --cwd ${shellQuote(workDir)} --check-benchmark --explain`;
+  const doctorCommand = renderCommand([
+    "node",
+    path.join(pluginRoot, "scripts", "autoresearch.mjs"),
+    "doctor",
+    "--cwd",
+    workDir,
+    "--check-benchmark",
+    "--explain",
+  ]);
   const runtimeSummary =
     runtimeDriftSummary ||
     (await inspectRuntimeDrift({

--- a/plugins/codex-autoresearch/lib/finalize-preview.ts
+++ b/plugins/codex-autoresearch/lib/finalize-preview.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { renderShellCommand } from "./command-rendering.js";
 import { isAcceptedCurrentRun } from "./evidence-registry.js";
 import { finalizationPlanFingerprint, readAutoresearchLedger } from "./finalization-plan.js";
 import { resolvePackageRoot } from "./runtime-paths.js";
@@ -120,6 +121,8 @@ export async function finalizePreview(args: LooseObject) {
     process.execPath,
     path.join(PLUGIN_ROOT, "scripts", "finalize-autoresearch.mjs"),
     "plan",
+    "--cwd",
+    workDir,
     "--output",
     planOutput,
     "--goal",
@@ -171,12 +174,12 @@ export async function finalizePreview(args: LooseObject) {
       sessionDecisionCapsule,
       overlaps,
       warnings,
-      suggestedCommand: planArgv.map(shellQuote).join(" "),
+      suggestedCommand: renderShellCommand(planArgv),
       suggestedCommands: {
         finalizerPlan: {
           argv: planArgv,
           cwd: workDir,
-          display: planArgv.map(shellQuote).join(" "),
+          display: renderShellCommand(planArgv),
           purpose: "Write a review-branch plan without dirtying the source branch.",
           mutates: false,
         },
@@ -823,12 +826,6 @@ function safeSlug(value: unknown): string {
       .replace(/^-+|-+$/g, "")
       .slice(0, 80) || "autoresearch"
   );
-}
-
-function shellQuote(value: unknown): string {
-  const text = String(value);
-  if (/^--[A-Za-z0-9-]+$/.test(text) || text === "plan") return text;
-  return `"${text.replace(/[\\"]/g, "\\$&")}"`;
 }
 
 async function git(args: string[], cwd: string): Promise<GitResult> {

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -2528,28 +2528,28 @@ function replacementNextCommandFromLastRun(
   packet: any,
   defaultBenchmarkCommandReady: boolean,
 ) {
-  const parts = [
+  const argv = [
     "node",
-    shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs")),
+    path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
     "next",
     "--cwd",
-    shellQuote(workDir),
+    workDir,
   ];
   const command = packet?.history?.replayCommand || packet?.run?.command;
   if (command) {
-    parts.push("--command", shellQuote(command));
+    argv.push("--command", command);
   } else if (!defaultBenchmarkCommandReady) {
     return "";
   }
   const checksPolicy = packet?.run?.checksPolicy;
   if (CHECKS_POLICIES.has(checksPolicy)) {
-    parts.push("--checks-policy", shellQuote(checksPolicy));
+    argv.push("--checks-policy", checksPolicy);
   }
   const checksCommand = packet?.history?.replayChecksCommand || packet?.run?.checks?.command;
   if (checksCommand) {
-    parts.push("--checks-command", shellQuote(checksCommand));
+    argv.push("--checks-command", checksCommand);
   }
-  return parts.join(" ");
+  return commandLine(argv);
 }
 
 async function replacementNextCommandForLastRun(

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -30,6 +30,13 @@ import {
 import { createSessionForensicsCommand } from "../lib/commands/session-forensics.js";
 import { buildCompactStateResponse } from "../lib/commands/state.js";
 import {
+  defaultCommandShell,
+  normalizeCommandShell,
+  quoteShellArg,
+  renderShellCommand,
+  type CommandShell,
+} from "../lib/command-rendering.js";
+import {
   actionSafeActionForKind,
   actionTitleForKind,
   isPacketBrakeKind,
@@ -420,8 +427,15 @@ function evidenceStatusOption(value: unknown, status: string) {
   );
 }
 
-function shellQuote(value: unknown): string {
-  return JSON.stringify(String(value));
+function commandLine(
+  argv: readonly unknown[],
+  shell: CommandShell = defaultCommandShell(),
+): string {
+  return renderShellCommand(argv, shell);
+}
+
+function shellQuote(value: unknown, shell: CommandShell = defaultCommandShell()): string {
+  return quoteShellArg(value, shell);
 }
 
 function slashPath(value: unknown): string {
@@ -537,11 +551,8 @@ function replaceAllText(text: string, replacements: Record<string, unknown>): st
   return out;
 }
 
-function shellKindFromArgs(args: LooseObject): string {
-  const requested = String(args.shell || args.script || "").toLowerCase();
-  if (["bash", "sh", "posix"].includes(requested)) return "bash";
-  if (["powershell", "pwsh", "ps1", "windows"].includes(requested)) return "powershell";
-  return process.platform === "win32" ? "powershell" : "bash";
+function shellKindFromArgs(args: LooseObject): CommandShell {
+  return normalizeCommandShell(args.shell ?? args.script);
 }
 
 async function withRecipeDefaults(args: LooseObject): Promise<LooseObject> {
@@ -696,88 +707,154 @@ async function setupPlan(args: any) {
         : "This explicit benchmark command will be wrapped and timed by the generated script."
       : "No explicit benchmark command was provided; generated placeholder wrappers must be replaced before use.",
   };
-  const command = [
+  const commandArgs = [
     "node",
-    shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs")),
+    path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
     "setup",
     "--cwd",
-    shellQuote(workDir),
+    workDir,
     "--name",
-    shellQuote(planArgs.name || "Autoresearch session"),
-    planArgs.goal ? `--goal ${shellQuote(planArgs.goal)}` : "",
+    planArgs.name || "Autoresearch session",
+    ...(planArgs.goal ? ["--goal", planArgs.goal] : []),
     "--metric-name",
-    shellQuote(metricName),
-    planArgs.metric_unit || planArgs.metricUnit
-      ? `--metric-unit ${shellQuote(planArgs.metric_unit ?? planArgs.metricUnit)}`
-      : "",
+    metricName,
+    ...(planArgs.metric_unit || planArgs.metricUnit
+      ? ["--metric-unit", planArgs.metric_unit ?? planArgs.metricUnit]
+      : []),
     "--direction",
-    shellQuote(planArgs.direction || "lower"),
+    planArgs.direction || "lower",
     "--shell",
-    shellQuote(shellKind),
-    benchmarkCommand ? `--benchmark-command ${shellQuote(benchmarkCommand)}` : "",
-    planArgs.benchmark_prints_metric != null || planArgs.benchmarkPrintsMetric != null
-      ? `--benchmark-prints-metric ${shellQuote(planArgs.benchmark_prints_metric ?? planArgs.benchmarkPrintsMetric)}`
-      : "",
-    checksCommand ? `--checks-command ${shellQuote(checksCommand)}` : "",
-    listOption(planArgs.files_in_scope ?? planArgs.filesInScope).length
-      ? `--files-in-scope ${shellQuote(listOption(planArgs.files_in_scope ?? planArgs.filesInScope).join(","))}`
-      : "",
-    listOption(planArgs.off_limits ?? planArgs.offLimits).length
-      ? `--off-limits ${shellQuote(listOption(planArgs.off_limits ?? planArgs.offLimits).join(","))}`
-      : "",
-    listOption(planArgs.constraints).length
-      ? `--constraints ${shellQuote(listOption(planArgs.constraints).join(","))}`
-      : "",
-    listOption(planArgs.secondary_metrics ?? planArgs.secondaryMetrics).length
-      ? `--secondary-metrics ${shellQuote(listOption(planArgs.secondary_metrics ?? planArgs.secondaryMetrics).join(","))}`
-      : "",
-    listOption(planArgs.secondary_metric_constraints ?? planArgs.secondaryMetricConstraints).length
-      ? `--secondary-metric-constraints ${shellQuote(
+    shellKind,
+    ...(benchmarkCommand ? ["--benchmark-command", benchmarkCommand] : []),
+    ...(planArgs.benchmark_prints_metric != null || planArgs.benchmarkPrintsMetric != null
+      ? [
+          "--benchmark-prints-metric",
+          planArgs.benchmark_prints_metric ?? planArgs.benchmarkPrintsMetric,
+        ]
+      : []),
+    ...(checksCommand ? ["--checks-command", checksCommand] : []),
+    ...(listOption(planArgs.files_in_scope ?? planArgs.filesInScope).length
+      ? ["--files-in-scope", listOption(planArgs.files_in_scope ?? planArgs.filesInScope).join(",")]
+      : []),
+    ...(listOption(planArgs.off_limits ?? planArgs.offLimits).length
+      ? ["--off-limits", listOption(planArgs.off_limits ?? planArgs.offLimits).join(",")]
+      : []),
+    ...(listOption(planArgs.constraints).length
+      ? ["--constraints", listOption(planArgs.constraints).join(",")]
+      : []),
+    ...(listOption(planArgs.secondary_metrics ?? planArgs.secondaryMetrics).length
+      ? [
+          "--secondary-metrics",
+          listOption(planArgs.secondary_metrics ?? planArgs.secondaryMetrics).join(","),
+        ]
+      : []),
+    ...(listOption(planArgs.secondary_metric_constraints ?? planArgs.secondaryMetricConstraints)
+      .length
+      ? [
+          "--secondary-metric-constraints",
           listOption(
             planArgs.secondary_metric_constraints ?? planArgs.secondaryMetricConstraints,
           ).join(","),
-        )}`
-      : "",
-    (planArgs.secondary_metric_constraint_mode ?? planArgs.secondaryMetricConstraintMode)
-      ? `--secondary-metric-constraint-mode ${shellQuote(
+        ]
+      : []),
+    ...((planArgs.secondary_metric_constraint_mode ?? planArgs.secondaryMetricConstraintMode)
+      ? [
+          "--secondary-metric-constraint-mode",
           planArgs.secondary_metric_constraint_mode ?? planArgs.secondaryMetricConstraintMode,
-        )}`
-      : "",
-    listOption(planArgs.protected_benchmark_paths ?? planArgs.protectedBenchmarkPaths).length
-      ? `--protected-benchmark-paths ${shellQuote(
+        ]
+      : []),
+    ...(listOption(planArgs.protected_benchmark_paths ?? planArgs.protectedBenchmarkPaths).length
+      ? [
+          "--protected-benchmark-paths",
           listOption(planArgs.protected_benchmark_paths ?? planArgs.protectedBenchmarkPaths).join(
             ",",
           ),
-        )}`
-      : "",
-    setupMaxIterations != null ? `--max-iterations ${shellQuote(setupMaxIterations)}` : "",
-    (planArgs.packet_budget ?? planArgs.packetBudget)
-      ? `--packet-budget ${shellQuote(planArgs.packet_budget ?? planArgs.packetBudget)}`
-      : "",
-    (planArgs.wall_clock_budget_seconds ?? planArgs.wallClockBudgetSeconds)
-      ? `--wall-clock-budget-seconds ${shellQuote(
+        ]
+      : []),
+    ...(setupMaxIterations != null ? ["--max-iterations", setupMaxIterations] : []),
+    ...((planArgs.packet_budget ?? planArgs.packetBudget)
+      ? ["--packet-budget", planArgs.packet_budget ?? planArgs.packetBudget]
+      : []),
+    ...((planArgs.wall_clock_budget_seconds ?? planArgs.wallClockBudgetSeconds)
+      ? [
+          "--wall-clock-budget-seconds",
           planArgs.wall_clock_budget_seconds ?? planArgs.wallClockBudgetSeconds,
-        )}`
-      : "",
-    (planArgs.budget_note ?? planArgs.budgetNote)
-      ? `--budget-note ${shellQuote(planArgs.budget_note ?? planArgs.budgetNote)}`
-      : "",
-    commitPaths.length > 0 ? `--commit-paths ${shellQuote(commitPaths.join(","))}` : "",
-    recommended ? `--recipe ${shellQuote(recommended.id)}` : "",
-    args.catalog ? `--catalog ${shellQuote(args.catalog)}` : "",
-    args.catalog && trustCatalogOption(args) ? "--trust-catalog" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const doctorCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} doctor --cwd ${shellQuote(workDir)} --check-benchmark`;
+        ]
+      : []),
+    ...((planArgs.budget_note ?? planArgs.budgetNote)
+      ? ["--budget-note", planArgs.budget_note ?? planArgs.budgetNote]
+      : []),
+    ...(commitPaths.length > 0 ? ["--commit-paths", commitPaths.join(",")] : []),
+    ...(recommended ? ["--recipe", recommended.id] : []),
+    ...(args.catalog ? ["--catalog", args.catalog] : []),
+    ...(args.catalog && trustCatalogOption(args) ? ["--trust-catalog"] : []),
+  ];
+  const command = commandLine(commandArgs, shellKind);
+  const doctorCommand = commandLine(
+    [
+      "node",
+      path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+      "doctor",
+      "--cwd",
+      workDir,
+      "--check-benchmark",
+    ],
+    shellKind,
+  );
   const benchmarkLintCommand = benchmarkCommand
-    ? `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} benchmark-lint --cwd ${shellQuote(workDir)} --metric-name ${shellQuote(metricName)} --command ${shellQuote(benchmarkCommand)}`
+    ? commandLine(
+        [
+          "node",
+          path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+          "benchmark-lint",
+          "--cwd",
+          workDir,
+          "--metric-name",
+          metricName,
+          "--command",
+          benchmarkCommand,
+        ],
+        shellKind,
+      )
     : hasDefaultBenchmarkCommand
-      ? `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} benchmark-lint --cwd ${shellQuote(workDir)} --metric-name ${shellQuote(metricName)} --command ${shellQuote(await defaultBenchmarkCommand(workDir))}`
+      ? commandLine(
+          [
+            "node",
+            path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+            "benchmark-lint",
+            "--cwd",
+            workDir,
+            "--metric-name",
+            metricName,
+            "--command",
+            await defaultBenchmarkCommand(workDir),
+          ],
+          shellKind,
+        )
       : "";
-  const baselineCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} next --cwd ${shellQuote(workDir)}`;
-  const logCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} log --cwd ${shellQuote(workDir)} --from-last --status keep --description ${shellQuote("Describe the kept change")}`;
-  const guideCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} guide --cwd ${shellQuote(workDir)}`;
+  const baselineCommand = commandLine(
+    ["node", path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"), "next", "--cwd", workDir],
+    shellKind,
+  );
+  const logCommand = commandLine(
+    [
+      "node",
+      path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+      "log",
+      "--cwd",
+      workDir,
+      "--from-last",
+      "--status",
+      "keep",
+      "--description",
+      "Describe the kept change",
+    ],
+    shellKind,
+  );
+  const guideCommand = commandLine(
+    ["node", path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"), "guide", "--cwd", workDir],
+    shellKind,
+  );
   const scopeWarnings = scopeWarningsFromArgs(planArgs);
   const integrityPreflight = await benchmarkIntegrityPreflight(workDir, config, state);
   const scaffoldHealth = await buildScaffoldHealth({ workDir, config });
@@ -803,16 +880,28 @@ async function setupPlan(args: any) {
             ".gitattributes",
           ],
           commands: [
-            `git add -- ${[
-              "autoresearch.md",
-              "autoresearch.ideas.md",
-              shellKind === "bash" ? "autoresearch.sh" : "autoresearch.ps1",
-              "autoresearch.config.json",
-              ".gitattributes",
-            ]
-              .map(shellQuote)
-              .join(" ")}`,
-            `git commit -m ${shellQuote(`Start autoresearch session: ${planArgs.name || "Autoresearch session"}`)}`,
+            commandLine(
+              [
+                "git",
+                "add",
+                "--",
+                "autoresearch.md",
+                "autoresearch.ideas.md",
+                shellKind === "bash" ? "autoresearch.sh" : "autoresearch.ps1",
+                "autoresearch.config.json",
+                ".gitattributes",
+              ],
+              shellKind,
+            ),
+            commandLine(
+              [
+                "git",
+                "commit",
+                "-m",
+                `Start autoresearch session: ${planArgs.name || "Autoresearch session"}`,
+              ],
+              shellKind,
+            ),
           ],
           note: "Run after setup creates files and before the first experiment-scoped keep commit.",
         }
@@ -1063,7 +1152,13 @@ async function promptPlan(args: LooseObject): Promise<LooseObject> {
     trust_catalog: args.trust_catalog ?? args.trustCatalog ?? setupDefaults.trustCatalog,
   };
   const setup = await setupPlan(setupArgs);
-  const dashboardCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} serve --cwd ${shellQuote(workDir)}`;
+  const dashboardCommand = commandLine([
+    "node",
+    path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+    "serve",
+    "--cwd",
+    workDir,
+  ]);
   return {
     ok: true,
     workDir,
@@ -1072,7 +1167,15 @@ async function promptPlan(args: LooseObject): Promise<LooseObject> {
     intent,
     setup,
     commands: {
-      promptPlan: `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} prompt-plan --cwd ${shellQuote(workDir)} --prompt ${shellQuote(prompt)}`,
+      promptPlan: commandLine([
+        "node",
+        path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+        "prompt-plan",
+        "--cwd",
+        workDir,
+        "--prompt",
+        prompt,
+      ]),
       setup: setup.nextCommand,
       doctor: setup.guidedFlow.find((step: any) => step.step === "doctor")?.command || "",
       dashboard: dashboardCommand,
@@ -1699,10 +1802,27 @@ async function guidedSetup(args: LooseObject): Promise<LooseObject> {
     lastRun,
     setup.defaultBenchmarkCommandReady,
   );
-  const dashboardCommand = `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} serve --cwd ${shellQuote(workDir)}`;
+  const dashboardCommand = commandLine([
+    "node",
+    path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+    "serve",
+    "--cwd",
+    workDir,
+  ]);
   const baselineCommand = setup.baselineCommand;
   const logCommand = lastRun
-    ? `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} log --cwd ${shellQuote(workDir)} --from-last --status ${shellQuote(lastRunLogStatus)} --description ${shellQuote("Describe the last packet")}`
+    ? commandLine([
+        "node",
+        path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+        "log",
+        "--cwd",
+        workDir,
+        "--from-last",
+        "--status",
+        lastRunLogStatus,
+        "--description",
+        "Describe the last packet",
+      ])
     : setup.guidedFlow.find((step: any) => step.step === "log")?.command;
   let stage = "ready";
   let nextAction = "Run the next measured packet.";
@@ -1736,7 +1856,14 @@ async function guidedSetup(args: LooseObject): Promise<LooseObject> {
     logLast: logCommand,
     replaceLast: replaceLastRunCommand,
     dashboard: dashboardCommand,
-    newSegmentDryRun: `node ${shellQuote(path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"))} new-segment --cwd ${shellQuote(workDir)} --dry-run`,
+    newSegmentDryRun: commandLine([
+      "node",
+      path.join(PLUGIN_ROOT, "scripts", "autoresearch.mjs"),
+      "new-segment",
+      "--cwd",
+      workDir,
+      "--dry-run",
+    ]),
   };
   const canonicalGuideAction = canonicalActionForGuidedSetup({
     doctor,
@@ -2410,7 +2537,7 @@ function replacementNextCommandFromLastRun(
   ];
   const command = packet?.history?.replayCommand || packet?.run?.command;
   if (command) {
-    parts.push("--command", copyCommandArg(command));
+    parts.push("--command", shellQuote(command));
   } else if (!defaultBenchmarkCommandReady) {
     return "";
   }
@@ -2420,7 +2547,7 @@ function replacementNextCommandFromLastRun(
   }
   const checksCommand = packet?.history?.replayChecksCommand || packet?.run?.checks?.command;
   if (checksCommand) {
-    parts.push("--checks-command", copyCommandArg(checksCommand));
+    parts.push("--checks-command", shellQuote(checksCommand));
   }
   return parts.join(" ");
 }
@@ -2436,14 +2563,6 @@ async function replacementNextCommandForLastRun(
       ? defaultBenchmarkCommandReady
       : await defaultBenchmarkCommandExists(workDir);
   return replacementNextCommandFromLastRun(workDir, packet, defaultReady);
-}
-
-function copyCommandArg(value: unknown): string {
-  const text = String(value);
-  if (process.platform === "win32") {
-    return `'${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "''")}'`;
-  }
-  return shellQuote(text);
 }
 
 function replaySafeCommand(value: unknown, context: LooseObject): string {
@@ -2712,7 +2831,7 @@ function renderMissingCommandScript(shellKind: string, kind: string, optionName:
       "#!/usr/bin/env bash",
       "set -euo pipefail",
       "",
-      `printf '%s\\n' ${shellQuote(message)} >&2`,
+      `printf '%s\\n' ${shellQuote(message, "bash")} >&2`,
       "exit 2",
       "",
     ].join("\n");
@@ -2720,7 +2839,7 @@ function renderMissingCommandScript(shellKind: string, kind: string, optionName:
   return [
     '$ErrorActionPreference = "Stop"',
     "",
-    `Write-Error ${shellQuote(message)}`,
+    `Write-Error ${shellQuote(message, "powershell")}`,
     "exit 2",
     "",
   ].join("\n");
@@ -2745,14 +2864,14 @@ function renderResearchBenchmarkScript(slug: string, shellKind: string) {
       "#!/usr/bin/env bash",
       "set -euo pipefail",
       "",
-      `${shellQuote(process.execPath)} ${shellQuote(script)} quality-gap --cwd . --research-slug ${shellQuote(slug)}`,
+      `${shellQuote(process.execPath, "bash")} ${shellQuote(script, "bash")} quality-gap --cwd . --research-slug ${shellQuote(slug, "bash")}`,
       "",
     ].join("\n");
   }
   return [
     '$ErrorActionPreference = "Stop"',
     "",
-    `& ${shellQuote(process.execPath)} ${shellQuote(script)} quality-gap --cwd . --research-slug ${shellQuote(slug)}`,
+    `& ${shellQuote(process.execPath, "powershell")} ${shellQuote(script, "powershell")} quality-gap --cwd . --research-slug ${shellQuote(slug, "powershell")}`,
     "if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }",
     "",
   ].join("\n");
@@ -3914,7 +4033,7 @@ function setupCheckpointGuidance(workDir: string, files: any[], name: string) {
     paths,
     commands: paths.length
       ? [
-          `git add -- ${paths.map(shellQuote).join(" ")}`,
+          `git add -- ${paths.map((item) => shellQuote(item)).join(" ")}`,
           `git commit -m ${shellQuote(`Start autoresearch session: ${name}`)}`,
         ]
       : [],
@@ -4436,7 +4555,7 @@ async function decisionGuidance({
     checksCommand,
     defaultBenchmarkCommand,
     defaultChecksCommand,
-    shellQuote,
+    renderCommand: commandLine,
     errorMessage,
   });
 }

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -94,8 +94,8 @@ function usage() {
   return `Finalize an autoresearch branch into independent review branches.
 
 Usage:
-  node scripts/finalize-autoresearch.mjs plan --output groups.json [--goal short-slug] [--trunk main] [--collapse-overlap]
-  node scripts/finalize-autoresearch.mjs groups.json
+  node scripts/finalize-autoresearch.mjs plan --cwd <repo> --output groups.json [--goal short-slug] [--trunk main] [--collapse-overlap]
+  node scripts/finalize-autoresearch.mjs --cwd <repo> groups.json
 
 groups.json:
 {
@@ -143,6 +143,17 @@ function parseCliArgs(argv: string[]): CliArgs {
     }
   }
   return out;
+}
+
+function resolveFinalizerCwd(args: CliArgs): string {
+  const raw = args.cwd ?? args.workingDir;
+  if (raw == null || raw === "" || raw === true) return process.cwd();
+  return path.resolve(String(raw));
+}
+
+function resolveCliPath(input: unknown, cwd: string): string {
+  const text = String(input || "");
+  return path.isAbsolute(text) ? text : path.resolve(cwd, text);
 }
 
 async function run(
@@ -904,7 +915,7 @@ async function writeDraftPlan(args: CliArgs, cwd: string): Promise<FinalizePlan>
   }
   plan = { ...plan, plan_fingerprint: planFingerprint(plan) };
   const output = args.output
-    ? path.resolve(args.output)
+    ? resolveCliPath(args.output, cwd)
     : path.join(await gitCommonDir(cwd), REPORT_DIRNAME, `${safeSlug(plan.goal)}.groups.json`);
   await fsp.mkdir(path.dirname(output), { recursive: true });
   await fsp.writeFile(output, `${JSON.stringify(plan, null, 2)}\n`, "utf8");
@@ -936,7 +947,7 @@ async function main() {
     console.log(usage());
     return;
   }
-  const cwd = process.cwd();
+  const cwd = resolveFinalizerCwd(cli);
   if (command === "plan") {
     await withPhase(
       "plan generation",
@@ -947,7 +958,7 @@ async function main() {
     );
     return;
   }
-  const configPath = path.resolve(file);
+  const configPath = resolveCliPath(file, cwd);
   const config = await withPhase("configuration", "Fix groups.json and retry.", async () => {
     const parsed = JSON.parse(await fsp.readFile(configPath, "utf8"));
     if (!parsed.base || !parsed.final_tree || !parsed.goal || !Array.isArray(parsed.groups)) {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -5420,12 +5420,12 @@ test("setup-plan renders benchmark command arguments for the requested shell", a
     const powershellPayload = JSON.parse(powershellResult.stdout);
     assert.match(
       powershellPayload.nextCommand,
-      /--benchmark-command 'node -e "console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)"/,
+      /--benchmark-command 'node -e \\"console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)\\"/,
     );
     assert.doesNotMatch(powershellPayload.nextCommand, /--benchmark-command "/);
     assert.match(
       powershellPayload.benchmarkLintCommand,
-      /--command 'node -e "console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)"/,
+      /--command 'node -e \\"console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)\\"/,
     );
 
     const bashResult = await runCli([

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -5420,6 +5420,10 @@ test("setup-plan renders benchmark command arguments for the requested shell", a
     const powershellPayload = JSON.parse(powershellResult.stdout);
     assert.match(
       powershellPayload.nextCommand,
+      /^& \{ \$PSNativeCommandArgumentPassing = 'Legacy'; /,
+    );
+    assert.match(
+      powershellPayload.nextCommand,
       /--benchmark-command 'node -e \\"console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)\\"/,
     );
     assert.doesNotMatch(powershellPayload.nextCommand, /--benchmark-command "/);

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -5467,7 +5467,10 @@ test("setup-plan treats recommended recipe benchmark as configured", async () =>
     assert.deepEqual(payload.missing, []);
     assert.deepEqual(payload.missingEssentials, []);
     assert.doesNotMatch(payload.nextStep.nextAction.reason, /benchmark_command/);
-    assert.match(payload.nextCommand, /--recipe "node-test-runtime"/);
+    assert.match(
+      payload.nextCommand,
+      /--recipe (?:'node-test-runtime'|"node-test-runtime"|node-test-runtime)\b/,
+    );
   });
 });
 

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -5372,8 +5372,8 @@ test("setup-plan preserves explicit command and state inputs", async () => {
     assert.match(payload.nextCommand, /METRIC seconds=1/);
     assert.match(payload.nextCommand, /--checks-command/);
     assert.match(payload.nextCommand, /process\.exit\(0\)/);
-    assert.match(payload.nextCommand, /--commit-paths "src,tests"/);
-    assert.match(payload.nextCommand, /--max-iterations "7"/);
+    assert.match(payload.nextCommand, /--commit-paths ['"]?src,tests['"]?/);
+    assert.match(payload.nextCommand, /--max-iterations ['"]?7['"]?/);
     assert.equal(payload.benchmarkMode.printsMetric, true);
     assert.match(payload.benchmarkLintCommand, /benchmark-lint/);
     assert.equal(payload.missingEssentials.length, 0);
@@ -5395,6 +5395,60 @@ test("setup-plan preserves explicit command and state inputs", async () => {
     assert.equal(guidePayload.nextStep.nextAction.title, "Run baseline packet");
     assert.equal(guidePayload.nextStep.nextAction.safety, "process_start");
     assert.match(guidePayload.nextStep.nextAction.command, / next /);
+  });
+});
+
+test("setup-plan renders benchmark command arguments for the requested shell", async () => {
+  await withTempDir("setup-plan-shell-quoting", async (dir) => {
+    const benchmark =
+      "node -e \"console.log('METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path')\"";
+
+    const powershellResult = await runCli([
+      "setup-plan",
+      "--cwd",
+      dir,
+      "--name",
+      "shell quoting",
+      "--metric-name",
+      "seconds",
+      "--shell",
+      "powershell",
+      "--benchmark-command",
+      benchmark,
+    ]);
+    assert.equal(powershellResult.code, 0, powershellResult.stderr);
+    const powershellPayload = JSON.parse(powershellResult.stdout);
+    assert.match(
+      powershellPayload.nextCommand,
+      /--benchmark-command 'node -e "console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)"/,
+    );
+    assert.doesNotMatch(powershellPayload.nextCommand, /--benchmark-command "/);
+    assert.match(
+      powershellPayload.benchmarkLintCommand,
+      /--command 'node -e "console\.log\(''METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path''\)"/,
+    );
+
+    const bashResult = await runCli([
+      "setup-plan",
+      "--cwd",
+      dir,
+      "--name",
+      "shell quoting",
+      "--metric-name",
+      "seconds",
+      "--shell",
+      "bash",
+      "--benchmark-command",
+      benchmark,
+    ]);
+    assert.equal(bashResult.code, 0, bashResult.stderr);
+    const bashPayload = JSON.parse(bashResult.stdout);
+    assert.match(bashPayload.nextCommand, /--benchmark-command 'node -e "console\.log\('/);
+    assert.match(
+      bashPayload.nextCommand,
+      /'"'"'METRIC seconds=1 \$HOME \$\(whoami\) `whoami` C:\\bench path'"'"'/,
+    );
+    assert.doesNotMatch(bashPayload.nextCommand, /--benchmark-command "/);
   });
 });
 

--- a/plugins/codex-autoresearch/tests/command-builders.test.ts
+++ b/plugins/codex-autoresearch/tests/command-builders.test.ts
@@ -7,6 +7,28 @@ import {
 } from "../lib/commands/recommend-next.js";
 import { buildCompactStateResponse } from "../lib/commands/state.js";
 import { createCliCommandHandlers } from "../lib/cli-handlers.js";
+import { quoteShellArg, renderShellCommand } from "../lib/command-rendering.js";
+
+test("command rendering quotes hostile benchmark args for the selected shell", () => {
+  const benchmark =
+    "node -e \"console.log('METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path')\"";
+
+  assert.equal(
+    quoteShellArg(benchmark, "powershell"),
+    "'node -e \"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\"'",
+  );
+  assert.equal(
+    quoteShellArg(benchmark, "bash"),
+    "'node -e \"console.log('\"'\"'METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'\"'\"')\"'",
+  );
+  assert.equal(
+    renderShellCommand(
+      ["C:\\Program Files\\nodejs\\node.exe", "scripts\\autoresearch.mjs", "--flag", benchmark],
+      "powershell",
+    ),
+    "& 'C:\\Program Files\\nodejs\\node.exe' scripts\\autoresearch.mjs --flag 'node -e \"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\"'",
+  );
+});
 
 test("recommend-next response preserves stable fields and optional governance fields", () => {
   const response = buildRecommendNextResponse({

--- a/plugins/codex-autoresearch/tests/command-builders.test.ts
+++ b/plugins/codex-autoresearch/tests/command-builders.test.ts
@@ -15,7 +15,7 @@ test("command rendering quotes hostile benchmark args for the selected shell", (
 
   assert.equal(
     quoteShellArg(benchmark, "powershell"),
-    "'node -e \"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\"'",
+    "'node -e \\\"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\\\"'",
   );
   assert.equal(
     quoteShellArg(benchmark, "bash"),
@@ -26,7 +26,7 @@ test("command rendering quotes hostile benchmark args for the selected shell", (
       ["C:\\Program Files\\nodejs\\node.exe", "scripts\\autoresearch.mjs", "--flag", benchmark],
       "powershell",
     ),
-    "& 'C:\\Program Files\\nodejs\\node.exe' scripts\\autoresearch.mjs --flag 'node -e \"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\"'",
+    "& 'C:\\Program Files\\nodejs\\node.exe' scripts\\autoresearch.mjs --flag 'node -e \\\"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\\\"'",
   );
 });
 

--- a/plugins/codex-autoresearch/tests/command-builders.test.ts
+++ b/plugins/codex-autoresearch/tests/command-builders.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -26,9 +27,28 @@ test("command rendering quotes hostile benchmark args for the selected shell", (
       ["C:\\Program Files\\nodejs\\node.exe", "scripts\\autoresearch.mjs", "--flag", benchmark],
       "powershell",
     ),
-    "& 'C:\\Program Files\\nodejs\\node.exe' scripts\\autoresearch.mjs --flag 'node -e \\\"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\\\"'",
+    "& { $PSNativeCommandArgumentPassing = 'Legacy'; & 'C:\\Program Files\\nodejs\\node.exe' scripts\\autoresearch.mjs --flag 'node -e \\\"console.log(''METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path'')\\\"' }",
   );
 });
+
+if (process.platform === "win32") {
+  test("PowerShell command rendering preserves argv with embedded double quotes", () => {
+    const benchmark =
+      "node -e \"console.log('METRIC seconds=1 $HOME $(whoami) `whoami` C:\\bench path')\"";
+    const rendered = renderShellCommand(
+      [process.execPath, "-e", "process.stdout.write(process.argv[1])", benchmark],
+      "powershell",
+    );
+
+    const result = spawnSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", "-"], {
+      encoding: "utf8",
+      input: rendered,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, benchmark);
+  });
+}
 
 test("recommend-next response preserves stable fields and optional governance fields", () => {
   const response = buildRecommendNextResponse({

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -368,6 +368,65 @@ testWithTempRoot(
 );
 
 testWithTempRoot(
+  "finalize preview suggested plan command keeps the target cwd",
+  "autoresearch-finalize-preview-cwd-",
+  async (root) => {
+    const repo = path.join(root, "repo");
+    const otherCwd = path.join(root, "other-cwd");
+    await fsp.mkdir(repo, { recursive: true });
+    await fsp.mkdir(otherCwd, { recursive: true });
+
+    await git(["init", "-b", "main"], repo);
+    await git(["config", "user.email", "codex@example.invalid"], repo);
+    await git(["config", "user.name", "Codex Test"], repo);
+    await writeFile(path.join(repo, "src", "value.txt"), "base\n");
+    await git(["add", "-A"], repo);
+    await git(["commit", "-m", "base"], repo);
+
+    await git(["switch", "-c", "codex/autoresearch-preview-cwd"], repo);
+    await writeFile(path.join(repo, "src", "value.txt"), "kept\n");
+    await git(["add", "-A"], repo);
+    await git(["commit", "-m", "kept metric improvement"], repo);
+    const kept = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    await writeFile(
+      path.join(repo, "autoresearch.jsonl"),
+      [
+        JSON.stringify({
+          type: "config",
+          name: "preview cwd",
+          metricName: "score",
+          bestDirection: "higher",
+        }),
+        JSON.stringify({
+          run: 1,
+          status: "keep",
+          metric: 1,
+          description: "kept metric improvement",
+          commit: kept,
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const preview = await run(process.execPath, [cli, "finalize-preview", "--cwd", repo], repo);
+    const payload = JSON.parse(preview.stdout);
+    const command = payload.suggestedCommands.finalizerPlan.argv;
+    assert.deepEqual(command.slice(0, 5), [process.execPath, finalizer, "plan", "--cwd", repo]);
+
+    const result = await run(command[0], command.slice(1), otherCwd);
+    assert.match(result.stdout, /Wrote draft groups/);
+
+    const outputFlag = command.indexOf("--output");
+    assert.ok(outputFlag > -1);
+    const plan = JSON.parse(await fsp.readFile(command[outputFlag + 1], "utf8"));
+    assert.equal(plan.source_branch, "codex/autoresearch-preview-cwd");
+    assert.equal(plan.final_tree, kept);
+    assert.equal(plan.groups[0].last_commit, kept);
+  },
+);
+
+testWithTempRoot(
   "finalize preview refuses hard decision capsules",
   "autoresearch-finalize-capsule-",
   async (root) => {

--- a/plugins/codex-autoresearch/tests/full-product.test.ts
+++ b/plugins/codex-autoresearch/tests/full-product.test.ts
@@ -1091,7 +1091,10 @@ test("finalize-preview summarizes kept commits without creating branches", async
 
     const developPreview = await runCli(["finalize-preview", "--cwd", dir, "--trunk", "develop"]);
     assert.equal(developPreview.code, 0, developPreview.stderr);
-    assert.match(JSON.parse(developPreview.stdout).suggestedCommand, /--trunk "develop"/);
+    assert.match(
+      JSON.parse(developPreview.stdout).suggestedCommand,
+      /--trunk (?:'develop'|"develop"|develop)\b/,
+    );
 
     const branches = await git(dir, ["branch", "--list", "autoresearch-review/*"]);
     assert.equal(branches, "");


### PR DESCRIPTION
## What changed

- Replaced JSON-literal command quoting with shell-aware command rendering for setup-plan, prompt/guide commands, decision guidance, and generated checkpoint commands.
- Preserved `--shell` through the setup-plan/guide adapter so requested shell output is honored.
- Added `--cwd` support to the finalizer and included it in finalize-preview's structured/copyable plan command.
- Updated finalizer docs to include the required `--cwd` and `--output` arguments.

## Why

Review found that `JSON.stringify` was being used as a shell quoting function and that finalize-preview could emit a plan command that acted on the caller's repo instead of the `--cwd` target.

## Verification

- `npm ci --prefer-offline --no-audit`
- `npm run build:node`
- `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=113:115 node --test --test-concurrency=1 dist/tests/autoresearch-cli.test.mjs`
- `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=5:6 node --test --test-concurrency=1 dist/tests/finalize-report.test.mjs`
- `node --test --test-concurrency=1 dist/tests/command-builders.test.mjs`
- `npm run typecheck:node`
- `npm run format:check`
- `npm run lint`
- `node dist/scripts/finalize-autoresearch.mjs --help`
- `git diff --check`

## Risk or follow-up

- This PR focuses on generated command text and finalizer cwd behavior; other dashboard/docs fixes are split into separate PRs.
- Full `npm run check` is left for CI or the final integration pass.

## Checklist

- [x] I kept the diff focused.
- [x] I updated docs, skill guidance, or `CHANGELOG.md` when the user-facing contract changed.
- [x] I removed secrets, local credentials, caches, and unrelated artifacts.
- [x] I ran the narrowest relevant check, or explained why verification was not possible.