### PR TITLE
Harden Autoresearch finalization and gate surfaces

### DIFF
--- a/plugins/codex-autoresearch/lib/gate-quality.ts
+++ b/plugins/codex-autoresearch/lib/gate-quality.ts
@@ -25,7 +25,8 @@ export interface GateQualitySummary {
   nextActionHint: string;
 }
 
-const CHECKS_VERB_PATTERN = /(?:^|[\s:._-])(test|typecheck|type-check|lint|build)(?:$|[\s:._-])/i;
+const CHECKS_VERB_PATTERN =
+  /(?:^|[\s:._-])(test|check|typecheck|type-check|lint|build)(?:$|[\s:._-])/i;
 
 export function evaluateGateQuality(input: GateQualityInput): GateQualitySummary {
   const malformedFields = malformedCommandFields(input);
@@ -106,7 +107,7 @@ export function evaluateGateQuality(input: GateQualityInput): GateQualitySummary
       blockers: [],
       warnings: [],
       evidence: [
-        "Checks command contains an obvious test, typecheck, lint, or build verification verb.",
+        "Checks command contains an obvious test, check, typecheck, lint, or build verification verb.",
       ],
       nextActionHint:
         "Run the checks gate and use pass/fail evidence alongside the benchmark metric.",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -29,6 +29,7 @@
     "build:node": "tsdown --config tsdown.config.ts",
     "build:dashboard": "vite build --config vite.dashboard.config.ts",
     "build": "run-s build:node build:dashboard",
+    "command-surface-map": "npm run build:node && node dist/scripts/command-surface-map.mjs",
     "dev:dashboard": "vite --config vite.dashboard.config.ts --host 127.0.0.1",
     "typecheck:node": "tsgo --project tsconfig.node.json --noEmit",
     "typecheck:dashboard": "tsgo --project tsconfig.dashboard.json --noEmit",
@@ -48,6 +49,7 @@
     "test:finalize": "run-s build:node test:compiled:finalize",
     "test:core": "run-s build:node test:compiled:core",
     "check:product": "npm run build:node && node scripts/check.mjs",
+    "check:source-hygiene": "node scripts/check.mjs --phase source-hygiene",
     "check": "run-p typecheck lint format:check && npm run check:product"
   },
   "devDependencies": {

--- a/plugins/codex-autoresearch/scripts/command-surface-map.ts
+++ b/plugins/codex-autoresearch/scripts/command-surface-map.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -1093,9 +1093,9 @@ async function main() {
   for (const branch of created) console.log(`  ${branch}`);
   console.log("");
   console.log("Runway: preview -> approve -> create review branch -> verify -> merge -> cleanup.");
-  console.log("Cleanup after merge only:");
-  console.log(`  PowerShell: git branch -D ${powershellQuote(sourceBranch)}`);
-  console.log("  POSIX: see the generated review summary for quoted cleanup guidance.");
+  console.log("Cleanup after verified merge:");
+  console.log("  Source branch and session-artifact cleanup commands are intentionally omitted here.");
+  console.log("  Use the generated review summary after trunk merge verification succeeds.");
 }
 
 function planFingerprint(plan: FinalizePlan): string {

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -1094,7 +1094,9 @@ async function main() {
   console.log("");
   console.log("Runway: preview -> approve -> create review branch -> verify -> merge -> cleanup.");
   console.log("Cleanup after verified merge:");
-  console.log("  Source branch and session-artifact cleanup commands are intentionally omitted here.");
+  console.log(
+    "  Source branch and session-artifact cleanup commands are intentionally omitted here.",
+  );
   console.log("  Use the generated review summary after trunk merge verification succeeds.");
 }
 
@@ -1152,10 +1154,6 @@ function buildPlanWarnings({
     );
   }
   return warnings;
-}
-
-function powershellQuote(value: unknown): string {
-  return `'${String(value).replace(/'/g, "''")}'`;
 }
 
 function posixQuote(value: unknown): string {

--- a/plugins/codex-autoresearch/tests/decision-guidance-gate-quality.test.ts
+++ b/plugins/codex-autoresearch/tests/decision-guidance-gate-quality.test.ts
@@ -101,6 +101,16 @@ test("gate quality recognizes correctness gates from common verification verbs",
   }
 });
 
+test("npm run check is classified as correctness gate", () => {
+  const summary = evaluateGateQuality({
+    benchmarkCommand: "node ./bench.mjs",
+    checksCommand: "npm run check",
+  });
+
+  assert.equal(summary.posture, "correctness");
+  assert.match(summary.evidence.join("\n"), /check/i);
+});
+
 test("gate quality recognizes holdout metadata without promotion metadata", () => {
   const summary = evaluateGateQuality({
     benchmarkCommand: "node bench.js",

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -252,6 +252,10 @@ testWithTempRoot(
     const result = await run(process.execPath, [finalizer, groupsPath], repo);
     assert.match(result.stdout, /Review summary: .+autoresearch-finalize.+\.md/);
     assert.match(result.stdout, /Created review branches:/);
+    assert.match(result.stdout, /Cleanup after verified merge/);
+    assert.doesNotMatch(result.stdout, /git branch -D/);
+    assert.doesNotMatch(result.stdout, /Remove-Item/);
+    assert.doesNotMatch(result.stdout, /rm -rf/);
 
     const summaryLine = result.stdout
       .split(/\r?\n/)


### PR DESCRIPTION
## What changed
- Removed premature source-branch/session cleanup commands from finalizer output.
- Clarified finalizer runway copy: preview, approve, create review branch, verify, merge, then cleanup.
- Tightened gate-quality and command-surface map behavior so maintainer command coverage is explicit.

## Why it changed
This is the finalization and maintainer-safety slice from the larger remediation stack. It keeps destructive cleanup out of the preview path and makes release/maintainer gates easier to trust in isolation.

## How I verified it
- From `plugins/codex-autoresearch`: `npm run check`
- Dogfood benchmark reported `METRIC quality_gap=0` and `32/32` checks.
- Package artifact and runtime smoke passed.

## Remaining risk or follow-up
- This PR intentionally does not include operator-loop guidance or dashboard UI polish; those are separate PRs.
