### PR TITLE
[codex] mention Ponytail pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses a root-only changelog because the root README is the public do
 
 ### Changed
 
+- README: added the Ponytail plugin pairing note for short, measured improvement loops.
 - README: problem/solution opener, worked example, and questions section (structure only; no behavior change).
 - Documentation rewrite: plain-warm senior-engineer voice, clearer audience split between human docs and agent contracts, restructured docs index, and `concepts.md#state-fields` glossary for compact-state labels.
 - Removed brittle doc-copy test gates (`ax-ux-golden-path`, `full-product-docs`, `loop-governance-docs`) and relaxed README phrase assertions in product tests.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Codex Autoresearch keeps each attempt measured, logged, and scoped so you can se
 
 Inspired by the AI-focused [karpathy/autoresearch](https://github.com/karpathy/autoresearch) and [pi-autoresearch](https://github.com/davebcn87/pi-autoresearch). Codex Autoresearch adapts measured improvement loops for Codex: local benchmarks, durable state, live readouts, and reviewable branch previews.
 
+This project pairs especially well with [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail): Ponytail keeps Codex on the shortest workable implementation path, while Autoresearch checks whether the result actually improves.
+
 ## Try it
 
 Ask Codex to use Codex Autoresearch.


### PR DESCRIPTION
## What changed

- Added a README note that Codex Autoresearch pairs especially well with DietrichGebert/ponytail.
- Added an Unreleased changelog entry for the README documentation change.

## Why it changed

Ponytail keeps Codex biased toward the shortest workable implementation path, and Autoresearch supplies the measured loop that proves whether that smaller change helped.

## How I verified it

- Inspected the README and changelog diff.
- Ran `git diff --check`.
- Ran `git diff --cached --check` before committing.

## Remaining risk or follow-up

- Docs-only change; no runtime behavior changed.