### PR TITLE
[codex] Finish autoresearch report backlog cleanup

### DIFF
--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -82,12 +82,13 @@ Before publishing, inspect the package artifact itself. Use dry-run pack output
 for routine review, then create and extract a real tarball for release smoke.
 The shipped `scripts/*.mjs` shims depend on `dist/`, but `dist/` is generated
 and ignored in the Git tree. If a Git marketplace source checkout is missing
-`dist/`, the CLI launcher downloads the matching GitHub release tarball plus
-`codex-autoresearch-<version>.tgz.sha256`, verifies the SHA-256 entry names that
-exact tarball, verifies the packaged name/version, and only then extracts
-`dist/` into the plugin cache before importing the runtime. A publishable
-release tarball must include the built runtime, publish the adjacent checksum
-asset, exclude authored source and tests, ship no MCP launcher/config, and pass
+`dist/`, the CLI launcher calls `scripts/bootstrap-runtime.mjs` to download the
+matching GitHub release tarball plus
+`codex-autoresearch-<version>.tgz.sha256`, verify the SHA-256 entry names that
+exact tarball, verify the packaged name/version, and only then extract `dist/`
+into the plugin cache before importing the runtime. A publishable release
+tarball must include the built runtime, publish the adjacent checksum asset,
+exclude authored source and tests, ship no MCP launcher/config, and pass
 `node <extracted-package>/scripts/autoresearch.mjs --help`.
 
 Do not push release tags by hand. After a synchronized version bump lands on `main`, the `Auto Release` GitHub Actions workflow compares the previous and current package versions and calls the reusable `Release` workflow when the package version changed. The release workflow still runs the checks, builds and smoke-tests the tarball, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. Use manual `Release` dispatch only as an explicit recovery path with the package version. This keeps update clients on the previous release until the new install artifact exists.

--- a/plugins/codex-autoresearch/lib/dashboard-transport.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-transport.ts
@@ -1,7 +1,25 @@
-type LooseObject = Record<string, unknown>;
+import fs from "node:fs";
+import path from "node:path";
+
+import { stripDashboardExportCommandFields } from "./dashboard-command-safety.js";
+import { boundDashboardLedgerEntries } from "./dashboard-ledger-bounds.js";
+import { redactEvidenceObject } from "./evidence-redaction.js";
+import { resolvePackageRoot, resolveRepoRoot } from "./runtime-paths.js";
+import { type UnknownRecord, unknownRecordOrNull } from "./types/json.js";
+
+type LooseObject = UnknownRecord;
 
 export const DASHBOARD_TRANSPORT_MEMORY_LIST_LIMIT = 100;
 export const DASHBOARD_TRANSPORT_ARRAY_LIMIT = 100;
+const DASHBOARD_STATIC_EXPORT_LEDGER_MAX_ENTRIES = 5000;
+const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
+const REPO_ROOT = resolveRepoRoot(import.meta.url);
+const DASHBOARD_TEMPLATE_PATH = path.join(PLUGIN_ROOT, "assets", "template.html");
+const DASHBOARD_BUILD_DIR = path.join(PLUGIN_ROOT, "assets", "dashboard-build");
+const DASHBOARD_DATA_PLACEHOLDER = "__AUTORESEARCH_DATA_PAYLOAD__";
+const DASHBOARD_META_PLACEHOLDER = "__AUTORESEARCH_META_PAYLOAD__";
+const DASHBOARD_APP_PLACEHOLDER = "__AUTORESEARCH_DASHBOARD_APP__";
+const DASHBOARD_CSS_PLACEHOLDER = "__AUTORESEARCH_DASHBOARD_CSS__";
 
 const LATEST_TRANSPORT_KEYS = new Set([
   "current",
@@ -31,6 +49,160 @@ export function compactDashboardTransportViewModel(value: LooseObject): LooseObj
     },
   };
   return compactTransportValue(compacted) as LooseObject;
+}
+
+export function dashboardHtml(entries: LooseObject[], meta: LooseObject = {}) {
+  const settings = unknownRecordOrNull(meta.settings);
+  const offlineExport = ["static-export", "showcase"].includes(
+    String(meta.deliveryMode || settings?.deliveryMode || ""),
+  );
+  const dashboardContext = { workDir: meta.workDir || settings?.workDir || "" };
+  const publicExport = Boolean(
+    meta.publicExport || meta.showcaseMode || settings?.publicExport || settings?.showcaseMode,
+  );
+  const entriesForClient = offlineExport ? stripDashboardCommandFields(entries) : entries;
+  const boundedEntries = offlineExport
+    ? boundDashboardStaticExportEntries(entriesForClient)
+    : {
+        entries: entriesForClient,
+        truncated: false,
+        omittedEntries: 0,
+        maxEntries: Array.isArray(entriesForClient) ? entriesForClient.length : 0,
+      };
+  const dataForClient = redactEvidenceObject(
+    publicExport ? scrubDashboardPublicExport(boundedEntries.entries) : boundedEntries.entries,
+    dashboardContext,
+  );
+  const data = JSON.stringify(dataForClient).replace(/</g, "\\u003c");
+  const metaForClient = stripDashboardCommandFields({
+    ...meta,
+    ledgerBounds: offlineExport
+      ? {
+          truncated: boundedEntries.truncated,
+          omittedEntries: boundedEntries.omittedEntries,
+          maxEntries: boundedEntries.maxEntries,
+        }
+      : undefined,
+  });
+  const metaData = JSON.stringify(
+    redactEvidenceObject(
+      publicExport ? scrubDashboardPublicExport(metaForClient) : metaForClient,
+      dashboardContext,
+    ),
+  ).replace(/</g, "\\u003c");
+  const template = fs.readFileSync(DASHBOARD_TEMPLATE_PATH, "utf8");
+  if (!template.includes(DASHBOARD_DATA_PLACEHOLDER)) {
+    throw new Error(`Dashboard template is missing ${DASHBOARD_DATA_PLACEHOLDER}`);
+  }
+  if (
+    !template.includes(DASHBOARD_APP_PLACEHOLDER) ||
+    !template.includes(DASHBOARD_CSS_PLACEHOLDER)
+  ) {
+    throw new Error("Dashboard template is missing React build placeholders.");
+  }
+  const dashboardApp = readDashboardBuildAsset("dashboard-app.js").replace(
+    /<\/script/gi,
+    "<\\/script",
+  );
+  const dashboardCss = readDashboardBuildAsset("dashboard-app.css").replace(
+    /<\/style/gi,
+    "<\\/style",
+  );
+  return template
+    .replace(DASHBOARD_DATA_PLACEHOLDER, () => data)
+    .replace(DASHBOARD_META_PLACEHOLDER, () => metaData)
+    .replace(DASHBOARD_CSS_PLACEHOLDER, () => dashboardCss)
+    .replace(DASHBOARD_APP_PLACEHOLDER, () => dashboardApp);
+}
+
+export function dashboardSafeGuidanceText(value: unknown): string {
+  const text = String(value ?? "").trim();
+  if (!/autoresearch\.mjs|benchmark-lint|doctor --cwd/i.test(text)) return text;
+  if (/runtime/i.test(text)) return "Inspect runtime drift with the CLI before acting.";
+  if (/benchmark|metric|setup|gate/i.test(text)) {
+    return "Run the CLI benchmark or doctor check before trusting the next packet.";
+  }
+  return "Use the CLI check before continuing.";
+}
+
+function boundDashboardStaticExportEntries(entries: LooseObject[]): {
+  entries: LooseObject[];
+  maxEntries: number;
+  omittedEntries: number;
+  truncated: boolean;
+} {
+  return boundDashboardLedgerEntries(
+    Array.isArray(entries) ? entries : [],
+    DASHBOARD_STATIC_EXPORT_LEDGER_MAX_ENTRIES,
+  );
+}
+
+function readDashboardBuildAsset(fileName: string) {
+  const filePath = path.join(DASHBOARD_BUILD_DIR, fileName);
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && (error as { code?: unknown }).code === "ENOENT") {
+      throw new Error(
+        `Dashboard build asset is missing: ${filePath}. Run npm run build:dashboard from ${PLUGIN_ROOT}.`,
+      );
+    }
+    throw error;
+  }
+}
+
+function stripDashboardCommandFields<T>(value: T): T {
+  return stripDashboardExportCommandFields(value, {
+    stringScrubber: dashboardSafeGuidanceText,
+  }) as T;
+}
+
+function scrubDashboardPublicExport(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => scrubDashboardPublicExport(item));
+  if (typeof value === "string") return scrubDashboardPublicExportString(value);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]: [string, unknown]) => {
+      if (key === "dirtyFiles") return [key, scrubDashboardPublicExportDirtyFiles()];
+      if (isDashboardPublicExportPathList(key, item)) {
+        return [key, []];
+      }
+      return [key, scrubDashboardPublicExport(item)];
+    }),
+  );
+}
+
+function isDashboardPublicExportPathList(key: string, value: unknown) {
+  return (
+    (key === "files" || key.endsWith("Files")) &&
+    Array.isArray(value) &&
+    value.every((entry) => typeof entry === "string")
+  );
+}
+
+function scrubDashboardPublicExportDirtyFiles() {
+  return {
+    sessionArtifacts: [],
+    scopedExperimentFiles: [],
+    unrelatedFiles: [],
+  };
+}
+
+function scrubDashboardPublicExportString(value: string) {
+  const placeholders = [
+    [PLUGIN_ROOT, "<plugin-root>"],
+    [REPO_ROOT, "<repo-root>"],
+    [process.execPath, "node"],
+  ];
+  let scrubbed = value;
+  for (const [needle, replacement] of placeholders) {
+    if (!needle) continue;
+    scrubbed = scrubbed.replaceAll(String(needle), replacement);
+    scrubbed = scrubbed.replaceAll(String(needle).replaceAll("\\", "/"), replacement);
+  }
+  return scrubbed
+    .replace(/[A-Za-z]:\\[^\r\n"]+/g, "<local-path>")
+    .replace(/[A-Za-z]:\/[^\r\n" ]+/g, "<local-path>");
 }
 
 function compactExperimentMemoryForTransport(value: unknown) {

--- a/plugins/codex-autoresearch/lib/tool-registry.ts
+++ b/plugins/codex-autoresearch/lib/tool-registry.ts
@@ -1,4 +1,6 @@
-type LooseObject = Record<string, any>;
+import { type UnknownRecord } from "./types/json.js";
+
+type LooseObject = UnknownRecord;
 export type ActionPolicy =
   | "read"
   | "preview"
@@ -93,7 +95,7 @@ const toolNameByCliCommand: Readonly<Record<string, string>> = Object.freeze(
   Object.fromEntries(TOOL_REGISTRY.map((tool) => [tool.cliCommand, tool.name])),
 );
 
-export function toolMetadata(name: string): LooseObject | null {
+export function toolMetadata(name: string): ToolRegistryEntry | null {
   return toolRegistry[name] || null;
 }
 

--- a/plugins/codex-autoresearch/lib/tool-schemas.ts
+++ b/plugins/codex-autoresearch/lib/tool-schemas.ts
@@ -5,6 +5,7 @@ import {
   UNSAFE_COMMAND_PROPERTY,
   toolArgumentsContainUnsafeCommand,
 } from "./tool-unsafe-command-gate.js";
+import { toolNameForCliCommand } from "./tool-registry.js";
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
@@ -692,42 +693,6 @@ export const toolSchemas = applyToolContracts([
   },
 ]);
 
-const CLI_COMMAND_TO_TOOL: Record<string, string> = {
-  setup: "setup_session",
-  "setup-plan": "setup_plan",
-  guide: "guided_setup",
-  "prompt-plan": "prompt_plan",
-  "onboarding-packet": "onboarding_packet",
-  "recommend-next": "recommend_next",
-  "codex-goal-brief": "codex_goal_bridge",
-  "session-forensics": "session_forensics",
-  recipes: "list_recipes",
-  "research-setup": "setup_research_session",
-  "research-fanout": "research_fanout",
-  "lane-runner": "lane_runner",
-  config: "configure_session",
-  "quality-gap": "measure_quality_gap",
-  "gap-candidates": "gap_candidates",
-  "finalize-preview": "finalize_preview",
-  "finalize-current-tree": "finalize_current_tree",
-  integrations: "integrations",
-  init: "init_experiment",
-  run: "run_experiment",
-  next: "next_experiment",
-  "partial-results": "partial_results",
-  log: "log_experiment",
-  state: "read_state",
-  doctor: "doctor_session",
-  "benchmark-lint": "benchmark_lint",
-  "benchmark-inspect": "benchmark_inspect",
-  "checks-inspect": "checks_inspect",
-  "new-segment": "new_segment",
-  "promote-gate": "promote_gate",
-  export: "export_dashboard",
-  serve: "serve_dashboard",
-  clear: "clear_session",
-};
-
 const RUNTIME_ARG_ALIASES: Record<string, string> = {
   allow_add_all: "allowAddAll",
   allow_non_git_command: "allowNonGitCommand",
@@ -854,7 +819,7 @@ export function normalizeRuntimeToolArguments(name: string, args: ToolArgs = {})
 }
 
 export function normalizeCliCommandArguments(command: string, args: ToolArgs = {}): ToolArgs {
-  const toolName = CLI_COMMAND_TO_TOOL[command];
+  const toolName = toolNameForCliCommand(command);
   if (!toolName) return args || {};
   return normalizeRuntimeToolArguments(toolName, args);
 }

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -14,11 +14,8 @@ import {
   buildServeRegistryHealthInput,
   readServeRegistry,
 } from "../lib/dashboard-server-registry.js";
-import {
-  stripDashboardExportCommandFields,
-  stripDashboardGuidanceCommandFields,
-} from "../lib/dashboard-command-safety.js";
-import { boundDashboardLedgerEntries } from "../lib/dashboard-ledger-bounds.js";
+import { stripDashboardGuidanceCommandFields } from "../lib/dashboard-command-safety.js";
+import { dashboardHtml, dashboardSafeGuidanceText } from "../lib/dashboard-transport.js";
 import {
   buildDashboardCommands,
   buildDashboardSettings as dashboardSettings,
@@ -251,13 +248,6 @@ const OUTPUT_MAX_BYTES = 8192;
 const MAX_PARSED_METRICS = 512;
 const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
 const REPO_ROOT = resolveRepoRoot(import.meta.url);
-const DASHBOARD_TEMPLATE_PATH = path.join(PLUGIN_ROOT, "assets", "template.html");
-const DASHBOARD_BUILD_DIR = path.join(PLUGIN_ROOT, "assets", "dashboard-build");
-const DASHBOARD_DATA_PLACEHOLDER = "__AUTORESEARCH_DATA_PAYLOAD__";
-const DASHBOARD_META_PLACEHOLDER = "__AUTORESEARCH_META_PAYLOAD__";
-const DASHBOARD_APP_PLACEHOLDER = "__AUTORESEARCH_DASHBOARD_APP__";
-const DASHBOARD_CSS_PLACEHOLDER = "__AUTORESEARCH_DASHBOARD_CSS__";
-const DASHBOARD_STATIC_EXPORT_LEDGER_MAX_ENTRIES = 5000;
 const EMPTY_COMMIT_PATHS_WARNING_CODE = "empty_commit_paths_in_git_repo";
 const PENDING_LOG_TRANSACTION_CODE = "pending_log_transaction";
 const PENDING_LOG_TRANSACTION_GIT_PATH = "autoresearch/pending-log-transaction.json";
@@ -4964,16 +4954,6 @@ function dashboardSafeRuntimeHint(runtimeDriftSummary: LooseObject): string {
   return "Runtime drift evidence is unavailable; inspect the runtime with the CLI before acting.";
 }
 
-function dashboardSafeGuidanceText(value: unknown): string {
-  const text = String(value ?? "").trim();
-  if (!/autoresearch\.mjs|benchmark-lint|doctor --cwd/i.test(text)) return text;
-  if (/runtime/i.test(text)) return "Inspect runtime drift with the CLI before acting.";
-  if (/benchmark|metric|setup|gate/i.test(text)) {
-    return "Run the CLI benchmark or doctor check before trusting the next packet.";
-  }
-  return "Use the CLI check before continuing.";
-}
-
 async function dashboardViewModel(workDir: string, config: any, context: LooseObject = {}) {
   const readCache = context.readCache || createSessionReadCache();
   const qualityGap = await currentQualityGapSummary(workDir);
@@ -6015,150 +5995,6 @@ async function clearSession(args: any) {
     deleted,
     missing,
   };
-}
-
-function dashboardHtml(entries: any[], meta: LooseObject = {}) {
-  const offlineExport = ["static-export", "showcase"].includes(
-    String(meta.deliveryMode || meta.settings?.deliveryMode || ""),
-  );
-  const dashboardContext = { workDir: meta.workDir || meta.settings?.workDir || "" };
-  const publicExport = Boolean(
-    meta.publicExport ||
-    meta.showcaseMode ||
-    meta.settings?.publicExport ||
-    meta.settings?.showcaseMode,
-  );
-  const entriesForClient = offlineExport ? stripDashboardCommandFields(entries) : entries;
-  const boundedEntries = offlineExport
-    ? boundDashboardStaticExportEntries(entriesForClient)
-    : {
-        entries: entriesForClient,
-        truncated: false,
-        omittedEntries: 0,
-        maxEntries: Array.isArray(entriesForClient) ? entriesForClient.length : 0,
-      };
-  const dataForClient = redactEvidenceObject(
-    publicExport ? scrubDashboardPublicExport(boundedEntries.entries) : boundedEntries.entries,
-    dashboardContext,
-  );
-  const data = JSON.stringify(dataForClient).replace(/</g, "\\u003c");
-  const metaForClient = stripDashboardCommandFields({
-    ...meta,
-    ledgerBounds: offlineExport
-      ? {
-          truncated: boundedEntries.truncated,
-          omittedEntries: boundedEntries.omittedEntries,
-          maxEntries: boundedEntries.maxEntries,
-        }
-      : undefined,
-  });
-  const metaData = JSON.stringify(
-    redactEvidenceObject(
-      publicExport ? scrubDashboardPublicExport(metaForClient) : metaForClient,
-      dashboardContext,
-    ),
-  ).replace(/</g, "\\u003c");
-  const template = fs.readFileSync(DASHBOARD_TEMPLATE_PATH, "utf8");
-  if (!template.includes(DASHBOARD_DATA_PLACEHOLDER)) {
-    throw new Error(`Dashboard template is missing ${DASHBOARD_DATA_PLACEHOLDER}`);
-  }
-  if (
-    !template.includes(DASHBOARD_APP_PLACEHOLDER) ||
-    !template.includes(DASHBOARD_CSS_PLACEHOLDER)
-  ) {
-    throw new Error("Dashboard template is missing React build placeholders.");
-  }
-  const dashboardApp = readDashboardBuildAsset("dashboard-app.js").replace(
-    /<\/script/gi,
-    "<\\/script",
-  );
-  const dashboardCss = readDashboardBuildAsset("dashboard-app.css").replace(
-    /<\/style/gi,
-    "<\\/style",
-  );
-  return template
-    .replace(DASHBOARD_DATA_PLACEHOLDER, () => data)
-    .replace(DASHBOARD_META_PLACEHOLDER, () => metaData)
-    .replace(DASHBOARD_CSS_PLACEHOLDER, () => dashboardCss)
-    .replace(DASHBOARD_APP_PLACEHOLDER, () => dashboardApp);
-}
-
-function boundDashboardStaticExportEntries(entries: any[]): {
-  entries: any[];
-  maxEntries: number;
-  omittedEntries: number;
-  truncated: boolean;
-} {
-  return boundDashboardLedgerEntries(
-    Array.isArray(entries) ? entries : [],
-    DASHBOARD_STATIC_EXPORT_LEDGER_MAX_ENTRIES,
-  );
-}
-
-function readDashboardBuildAsset(fileName: string) {
-  const filePath = path.join(DASHBOARD_BUILD_DIR, fileName);
-  try {
-    return fs.readFileSync(filePath, "utf8");
-  } catch (error) {
-    if (error && typeof error === "object" && (error as { code?: unknown }).code === "ENOENT") {
-      throw new Error(
-        `Dashboard build asset is missing: ${filePath}. Run npm run build:dashboard from ${PLUGIN_ROOT}.`,
-      );
-    }
-    throw error;
-  }
-}
-
-function stripDashboardCommandFields(value: any): any {
-  return stripDashboardExportCommandFields(value, { stringScrubber: dashboardSafeGuidanceText });
-}
-
-function scrubDashboardPublicExport(value: any): any {
-  if (Array.isArray(value)) return value.map((item: any) => scrubDashboardPublicExport(item));
-  if (typeof value === "string") return scrubDashboardPublicExportString(value);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(
-    Object.entries(value).map(([key, item]: [string, unknown]) => {
-      if (key === "dirtyFiles") return [key, scrubDashboardPublicExportDirtyFiles()];
-      if (isDashboardPublicExportPathList(key, item)) {
-        return [key, []];
-      }
-      return [key, scrubDashboardPublicExport(item)];
-    }),
-  );
-}
-
-function isDashboardPublicExportPathList(key: string, value: unknown) {
-  return (
-    (key === "files" || key.endsWith("Files")) &&
-    Array.isArray(value) &&
-    value.every((entry) => typeof entry === "string")
-  );
-}
-
-function scrubDashboardPublicExportDirtyFiles() {
-  return {
-    sessionArtifacts: [],
-    scopedExperimentFiles: [],
-    unrelatedFiles: [],
-  };
-}
-
-function scrubDashboardPublicExportString(value: any) {
-  const placeholders = [
-    [PLUGIN_ROOT, "<plugin-root>"],
-    [REPO_ROOT, "<repo-root>"],
-    [process.execPath, "node"],
-  ];
-  let scrubbed = value;
-  for (const [needle, replacement] of placeholders) {
-    if (!needle) continue;
-    scrubbed = scrubbed.replaceAll(String(needle), replacement);
-    scrubbed = scrubbed.replaceAll(String(needle).replaceAll("\\", "/"), replacement);
-  }
-  return scrubbed
-    .replace(/[A-Za-z]:\\[^\r\n"]+/g, "<local-path>")
-    .replace(/[A-Za-z]:\/[^\r\n" ]+/g, "<local-path>");
 }
 
 async function resolveLastRunPath(workDir: string) {

--- a/plugins/codex-autoresearch/scripts/check.ts
+++ b/plugins/codex-autoresearch/scripts/check.ts
@@ -1144,11 +1144,44 @@ async function runSourceCheckoutLauncherCheck() {
     return false;
   }
 
+  const runtimeDocs = await sourceRuntimeDocsProblems();
+  if (runtimeDocs.length) {
+    console.log("ok source-launcher-files");
+    console.log("ok source-launcher-committable");
+    console.log("ok source-dist-untracked");
+    console.log("ok source-dist-ignored");
+    console.log("fail source-runtime-docs");
+    console.log(indent(runtimeDocs.join("\n")));
+    return false;
+  }
+
   console.log("ok source-launcher-files");
   console.log("ok source-launcher-committable");
   console.log("ok source-dist-untracked");
   console.log("ok source-dist-ignored");
+  console.log("ok source-runtime-docs");
   return true;
+}
+
+async function sourceRuntimeDocsProblems(): Promise<string[]> {
+  const requiredDocs: Array<[string, string[]]> = [
+    ["docs/maintainers.md", ["dist/", "bootstrap-runtime", "Installed cache drift"]],
+    ["docs/troubleshooting.md", ["Source checkout missing `dist/`", "Installed runtime drift"]],
+  ];
+  const problems: string[] = [];
+  for (const [file, expected] of requiredDocs) {
+    let content = "";
+    try {
+      content = await fsp.readFile(path.join(ROOT, file), "utf8");
+    } catch (error) {
+      problems.push(`${file} could not be read: ${String(error)}`);
+      continue;
+    }
+    for (const text of expected) {
+      if (!content.includes(text)) problems.push(`${file} should mention ${text}`);
+    }
+  }
+  return problems;
 }
 
 function runCommand(

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -17,11 +17,12 @@ import {
   REPORT_DIRNAME,
   isAutoresearchSessionArtifact,
 } from "../lib/session-artifacts.js";
+import { parseCliArgs, type ParsedCliArgs } from "../lib/cli/args.js";
 
 type LooseObject = Record<string, any>;
 type LocalProcessResult = { code: number | null; stderr: string; stdout: string };
 type FinalizePhaseError = Error & { cause?: unknown; finalizePhase?: string };
-type CliArgs = LooseObject & { _: string[] };
+type CliArgs = ParsedCliArgs & LooseObject;
 type RunEntry = LooseObject & {
   commit?: string;
   description?: string;
@@ -121,36 +122,6 @@ groups.json:
   ]
 }
 `;
-}
-
-function parseCliArgs(argv: string[]): CliArgs {
-  const out: CliArgs = { _: [] };
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === "--") {
-      out._.push(...argv.slice(i + 1));
-      break;
-    }
-    if (!arg.startsWith("--")) {
-      out._.push(arg);
-      continue;
-    }
-    const equalsAt = arg.indexOf("=");
-    const rawKey = equalsAt > 2 ? arg.slice(2, equalsAt) : arg.slice(2);
-    const key = rawKey.replace(/-([a-z])/g, (_: string, c: string) => c.toUpperCase());
-    if (equalsAt > 2) {
-      out[key] = arg.slice(equalsAt + 1);
-      continue;
-    }
-    const next = argv[i + 1];
-    if (next == null || next.startsWith("--")) {
-      out[key] = true;
-    } else {
-      out[key] = next;
-      i += 1;
-    }
-  }
-  return out;
 }
 
 function resolveFinalizerCwd(args: CliArgs): string {
@@ -1153,7 +1124,7 @@ async function writeDraftPlan(args: CliArgs, cwd: string): Promise<FinalizePlan>
 }
 
 async function main() {
-  const cli = parseCliArgs(process.argv.slice(2));
+  const cli = parseCliArgs(process.argv.slice(2)) as CliArgs;
   const command = cli._[0];
   const file = command;
   if (!file || file === "--help" || file === "-h") {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -7790,7 +7790,13 @@ test("tool schemas expose guidance and output contracts", async () => {
   const [
     { toolSchemas },
     { validateToolContracts },
-    { actionPolicyForTool, cliCommandForTool, toolMutates, validateToolRegistry },
+    {
+      actionPolicyForTool,
+      cliCommandForTool,
+      toolMutates,
+      toolNameForCliCommand,
+      validateToolRegistry,
+    },
   ] = await Promise.all([
     import("../lib/tool-schemas.js"),
     import("../lib/tool-contracts.js"),
@@ -7934,6 +7940,9 @@ test("tool schemas expose guidance and output contracts", async () => {
   assert.equal(cliCommandForTool("next_experiment"), "next");
   assert.equal(cliCommandForTool("research_fanout"), "research-fanout");
   assert.equal(cliCommandForTool("checks_inspect"), "checks-inspect");
+  assert.equal(toolNameForCliCommand("next"), "next_experiment");
+  assert.equal(toolNameForCliCommand("research-fanout"), "research_fanout");
+  assert.equal(toolNameForCliCommand("checks-inspect"), "checks_inspect");
   assert.equal(toolMutates("next_experiment"), true);
   assert.equal(toolMutates("research_fanout"), false);
   assert.equal(actionPolicyForTool("research_fanout"), "read");

--- a/plugins/codex-autoresearch/tests/command-builders.test.ts
+++ b/plugins/codex-autoresearch/tests/command-builders.test.ts
@@ -144,6 +144,30 @@ test("CLI arg parser preserves camel aliases and passthrough args", () => {
   assert.equal(parsed.jsonFull, true);
 });
 
+test("CLI arg parser covers finalizer positional mode and flags", () => {
+  const plan = parseCliArgs([
+    "plan",
+    "--cwd",
+    "C:\\repo",
+    "--output=groups.json",
+    "--goal",
+    "speed-loop",
+    "--trunk",
+    "dev",
+    "--collapse-overlap",
+  ]);
+  const apply = parseCliArgs(["--cwd", "C:\\repo", "groups.json"]);
+
+  assert.deepEqual(plan._, ["plan"]);
+  assert.equal(plan.cwd, "C:\\repo");
+  assert.equal(plan.output, "groups.json");
+  assert.equal(plan.goal, "speed-loop");
+  assert.equal(plan.trunk, "dev");
+  assert.equal(plan.collapseOverlap, true);
+  assert.deepEqual(apply._, ["groups.json"]);
+  assert.equal(apply.cwd, "C:\\repo");
+});
+
 test("CLI option helpers preserve loose command input behavior", () => {
   assert.deepEqual(parseJsonOption('{"metric":1}', null), { metric: 1 });
   assert.equal(parseJsonOption("", "fallback"), "fallback");


### PR DESCRIPTION
## Context
This follows the codebase report backlog after PR #147. PR #147 fixed the showcase/static export bug, finalization wording, demo refresh, version bump, and the first dependency/parser cleanup. This PR keeps the remaining work ponytail-sized: delete duplication where it is directly removable, move helpers to the existing module that already owns the concern, and add a small gate where runtime drift is a product contract.

## What changed
- Reused the shared CLI parser in `scripts/finalize-autoresearch.ts` and deleted the finalizer-local parser copy.
- Moved dashboard static/showcase export HTML, command stripping, ledger bounding, and public-export scrubbing out of the 9k-line CLI into existing `lib/dashboard-transport.ts`.
- Deleted the duplicated CLI command-to-tool map from `lib/tool-schemas.ts`; normalization now asks `lib/tool-registry.ts` via `toolNameForCliCommand`.
- Tightened the touched registry type alias to `UnknownRecord` and added parity coverage for reverse CLI command lookup.
- Added a source-runtime docs gate so `npm run check` keeps the `dist/`/`bootstrap-runtime`/installed-cache drift contract visible.

## Why it changed
The report called out duplicated parsers, CLI god-file weight, repeated command truth, loose typing, and source/runtime drift. This PR addresses those without creating a new catalog or sweeping unrelated `any` debt.

## Verification
- `npm run typecheck`
- Focused compiled tests:
  - parser + tool schema parity
  - showcase/static dashboard export behavior
  - dashboard command safety
- `npm run check`
- `git diff --check`
- Manual diff inspection before commit

## Remaining risk / follow-up
- The main CLI still has legacy broad `any` surfaces. I tried replacing the top-level alias with `UnknownRecord`; it created hundreds of unrelated type errors, so this PR keeps that out of scope instead of turning a cleanup into a type migration.
- This PR does not redesign runtime hydration; it gates the existing contract and names `scripts/bootstrap-runtime.mjs` in maintainer docs.