### PR TITLE
Fix auto-release source runtime rebuild guard

### DIFF
--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -39,7 +39,7 @@ async function rebuildStaleSourceRuntime(pluginRoot, target) {
   if (!(await fileExists(path.join(pluginRoot, "tsdown.config.ts")))) return;
   if (!(await fileExists(path.join(pluginRoot, "node_modules")))) return;
 
-  if ((await newestSourceMtime(pluginRoot)) <= (await fileMtime(target))) return;
+  if ((await newestSourceMtime(pluginRoot)) < (await fileMtime(target))) return;
 
   const build = npmBuildInvocation();
   await run(build.command, build.args, { cwd: pluginRoot });


### PR DESCRIPTION
## What changed
- Fixes the source-runtime freshness guard in `scripts/bootstrap-runtime.mjs`.
- Treats equal source/target mtimes as stale enough to rebuild instead of skipping the source runtime rebuild.

## Why it changed
- Auto Release run `27755879670` failed in `Release / test (ubuntu-latest)` because `source launcher rebuilds local source runtime before use` read `staleRuntime` instead of the rebuilt runtime.
- The guard used `<=`, so fast filesystem timestamp ties could skip the rebuild.

## How you verified it
- `npm run build:node`
- `node --test --test-name-pattern "source launcher rebuilds local source runtime before use" dist\\tests\\autoresearch-cli.test.mjs`
- `npm run check`
- `git diff --check`

## Remaining risk or follow-up
- After merge, rerun the Release workflow manually for version `2.4.0`; the auto-release path already fired and failed on the previous main SHA.