### PR TITLE
Promote auto-release fix to main

### DIFF
--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -39,7 +39,7 @@ async function rebuildStaleSourceRuntime(pluginRoot, target) {
   if (!(await fileExists(path.join(pluginRoot, "tsdown.config.ts")))) return;
   if (!(await fileExists(path.join(pluginRoot, "node_modules")))) return;
 
-  if ((await newestSourceMtime(pluginRoot)) <= (await fileMtime(target))) return;
+  if ((await newestSourceMtime(pluginRoot)) < (await fileMtime(target))) return;
 
   const build = npmBuildInvocation();
   await run(build.command, build.args, { cwd: pluginRoot });


### PR DESCRIPTION
## What changed
- Promotes `dev` to `main` with the auto-release fix from #154.
- The fix changes the source-runtime rebuild freshness guard so equal mtimes rebuild instead of keeping stale `dist` runtime.

## Why it changed
- Auto Release run `27755879670` failed after #152 merged because `Release / test (ubuntu-latest)` hit `source launcher rebuilds local source runtime before use` and read `staleRuntime`.

## How you verified it
- Local: `npm run build:node`
- Local: `node --test --test-name-pattern "source launcher rebuilds local source runtime before use" dist\\tests\\autoresearch-cli.test.mjs`
- Local: `npm run check`
- Local: `git diff --check`
- PR #154 checks passed on Ubuntu, macOS, Windows, and CodeQL before merging into `dev`.

## Remaining risk or follow-up
- After merge, manually dispatch `Release` for version `2.4.0` and watch it to completion. The original auto-release already failed on the previous main SHA, so source-only promotion will not create the release by itself.