### PR TITLE
Clarify first-run docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes to Codex Autoresearch are recorded here.
 
 This project uses a root-only changelog because the root README is the public documentation surface for the plugin wrapper.
 
+Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older entries that mention MCP servers, MCP tools, or MCP resources describe historical release surfaces before the 1.3.3 removal.
+
+## Unreleased
+
+### Changed
+
+- Clarified first-run docs after install, the first successful packet ladder, package-root versus target `--cwd`, and command-index ownership.
+
 ## 2.4.0 - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ Some workspace plugin settings are managed from the Codex Apps/Plugins UI rather
 
 Start a new Codex thread after installation or refresh.
 
+### After install
+
+Open Codex in the repo you want to improve and ask for one measured first packet:
+
+```text
+/goal @Codex Autoresearch measure one baseline packet for this repo before making changes.
+Goal: <what should improve>
+Benchmark: <command that prints METRIC name=value>
+Metric: <metric name>, <higher|lower> is better
+Scope: <files or package Codex may edit>
+```
+
+The first safe ladder is:
+
+1. plan only if the essentials are unclear
+2. set up the session
+3. run `doctor`
+4. run one packet
+5. log it as `measure`
+6. read `state`
+
+See [Start](plugins/codex-autoresearch/docs/start.md) for copyable CLI commands and recovery steps. Use `node scripts/autoresearch.mjs --help --all` from `plugins/codex-autoresearch` for the full command index instead of relying on repeated command lists in the docs.
+
 ## How it works
 
 A normal session follows this shape:
@@ -105,13 +128,20 @@ Autoresearch helps you:
 5. inspect compact state before spending another run
 6. preview finalization readiness before creating reviewable branches
 
-`serve` is an optional live dashboard handoff. Advanced diagnostics (`prompt-plan`, `onboarding-packet`, `recommend-next`, `benchmark-inspect`, `partial-results`, `session-forensics`, `export`) are available with `--help --all` when a run needs deeper repair or recovery.
+`serve` is an optional live dashboard handoff. Advanced diagnostics are discoverable with `node scripts/autoresearch.mjs --help --all` from `plugins/codex-autoresearch` when a run needs deeper repair or recovery.
 
 When you use Codex Goal mode, `codex-goal-brief` turns Autoresearch state into a Goal objective draft and completion audit. It does not mutate Codex Goal state.
 
 A benchmark experiment is one measured cycle: make a scoped change, run the benchmark, inspect the metric, and record the evidence.
 
 Autoresearch keeps structured session context — hypothesis, evidence, next action hint, and relevant risk notes — so the next session knows what happened and which path deserves the next attempt.
+
+| Responsibility | What it owns |
+| --- | --- |
+| You | Goal, acceptable scope, benchmark trust, and final review decisions. |
+| Codex | Edits, command execution, evidence reading, and reporting from the current repo. |
+| Autoresearch | Session files, packet evidence, state, dashboard readouts, and finalization previews. |
+| Benchmark/check commands | The local measurement and correctness proof; they run with your normal local process permissions. |
 
 ## When to use it
 

--- a/plugins/codex-autoresearch/docs/start.md
+++ b/plugins/codex-autoresearch/docs/start.md
@@ -29,6 +29,20 @@ METRIC memory_mb=410
 
 The configured primary metric drives keep/discard decisions. `measure` records baseline or diagnostic evidence without promotion. Secondary metrics explain tradeoffs.
 
+## First successful packet
+
+Start with one baseline packet. Do not optimize yet.
+
+| Step | Action | Done when |
+| --- | --- | --- |
+| 1 | Name the goal, metric, benchmark, checks, and editable scope. | Codex can say what should improve and what files it may touch. |
+| 2 | Run read-only planning only if those essentials are unclear. | `setup-plan` or `prompt-plan` returns a setup path without creating session files. |
+| 3 | Set up the session. | `autoresearch.md`, `autoresearch.jsonl`, and config files exist in the target project. |
+| 4 | Run `doctor --check-benchmark --explain`. | The benchmark emits the primary `METRIC` and trust blockers are visible. |
+| 5 | Run one packet with `next`. | `autoresearch.last-run.json` records fresh packet evidence. |
+| 6 | Log the packet as `measure`. | Baseline evidence is saved without claiming a keep. |
+| 7 | Read `state --report` or `recommend-next --compact`. | The next action and blockers are explicit before spending another packet. |
+
 ## Codex prompt
 
 Broad prompt:
@@ -53,7 +67,7 @@ Ask for the live dashboard when you want a visual readout or fresh browser state
 
 ## CLI path
 
-From `plugins/codex-autoresearch`:
+Run package-local commands from `plugins/codex-autoresearch`. The `--cwd <project>` argument points at the repo or child package you want to improve; it is not necessarily the package root.
 
 ```bash
 # Optional read-only planning; choose setup-plan for structured inputs or prompt-plan for prose.
@@ -69,7 +83,7 @@ node scripts/autoresearch.mjs finalize-preview --cwd <project>
 
 Happy path: `setup -> doctor -> next -> log -> state -> finalize-preview`.
 
-`setup-plan` and `prompt-plan` are read-only. Use them when essentials are ambiguous; skip them when goal, metric, benchmark, and scope are already known. `serve` is the optional live dashboard handoff. Advanced diagnostics (`onboarding-packet`, `benchmark-lint`, `recommend-next`, `partial-results`) are on `--help --all`.
+`setup-plan` and `prompt-plan` are read-only. Use them when essentials are ambiguous; skip them when goal, metric, benchmark, and scope are already known. `serve` is the optional live dashboard handoff. Use `node scripts/autoresearch.mjs --help --all` for the full command index.
 
 `benchmark-lint` and `doctor` answer different questions. `benchmark-lint` can pass because the benchmark emits the configured primary `METRIC`; `doctor --check-benchmark --explain` can still block because the worktree is dirty, runtime is stale, promotion metadata is missing, or other trust checks fail.
 

--- a/plugins/codex-autoresearch/docs/walkthrough.md
+++ b/plugins/codex-autoresearch/docs/walkthrough.md
@@ -36,6 +36,8 @@ Codex confirms the evidence source and research slug before creating session fil
 
 Codex creates the research scratchpad, configures the quality-gap session, and verifies the benchmark.
 
+Run the launcher from `plugins/codex-autoresearch`. `--cwd` points at the target repo or child package being improved. In this walkthrough the target is the package itself, so `--cwd .` is correct only because the command is already running from `plugins/codex-autoresearch`.
+
 ```bash
 node scripts/autoresearch.mjs research-start --cwd . --slug dashboard-study --goal "Study the dashboard and docs, accept evidence-backed UX gaps, and close the quality_gap checklist."
 ```

--- a/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
+++ b/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
@@ -19,7 +19,7 @@ The job: make one measured improvement loop trustworthy enough that a human can 
 
 - Use the short command path unless the session is ambiguous or blocked: `setup`, `doctor`, `next`, `log`, `state`, then `finalize-preview`.
 - For qualitative or deep-research improvement loops, start with `research-start --cwd <project> --slug <slug> --goal "<goal>"`. It creates the scratchpad, configures `quality_gap`, validates the command, and records the first baseline as `measure` unless `--no-baseline-log` is passed.
-- Use advanced diagnostics only when needed: `onboarding-packet`, `recommend-next`, `prompt-plan`, `setup-plan`, `benchmark-inspect`, `partial-results`, `session-forensics`, `guide`, or `serve`.
+- Use advanced diagnostics only when needed. Check `node scripts/autoresearch.mjs --help --all` from the package root before naming a less common command.
 - Use `new-segment` when the active segment is maxed, stale, phase-changing, or no longer comparable.
 - Prefer CLI JSON and durable session files over chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.ideas.md`, `autoresearch.last-run.json`, and `autoresearch.research/<slug>/`.
 - Keep every packet decision recoverable through `METRIC name=value`, packet evidence, ASI, continuation data, promotion labels, and the ledger.


### PR DESCRIPTION
## Context

Refs #161.

Issue #161 asks for the smallest docs slice that makes the first run less scattered: what to do after install, how to get one successful packet, how package-root commands relate to target `--cwd`, and how to avoid stale command lists or historical MCP confusion.

## What Changed

- Added a README `After install` block with one baseline-packet prompt and a short first-safe-ladder.
- Added a `First successful packet` table to `docs/start.md` before the deeper prompt/CLI detail.
- Clarified in `docs/walkthrough.md` that `node scripts/autoresearch.mjs ...` runs from `plugins/codex-autoresearch`, while `--cwd` points at the target project.
- Replaced repeated advanced-command lists in README/skill copy with the package-local `--help --all` command index.
- Added a changelog note that older MCP entries are historical because the current package contract is CLI/skill-only.

## How To Review

1. Read README install -> After install -> How it works for the first-run story.
2. Read `plugins/codex-autoresearch/docs/start.md` for the canonical ladder and copyable CLI commands.
3. Check `plugins/codex-autoresearch/docs/walkthrough.md` for the `--cwd .` explanation.
4. Search the changelog for MCP and confirm old entries no longer contradict the current contract.

## Verification

- Markdown readback/inspection of the changed sections via `git diff` and targeted `rg` checks.
- `git diff --check`

## Risk

Docs-only. The main tradeoff is keeping this intentionally small: it clarifies the first run and command ownership without rewriting the broader docs map.