### PR TITLE
Redact persisted last-run benchmark contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project uses a root-only changelog because the root README is the public do
 ### Fixed
 
 - Routed ledger-integrity failures into state/report next-action guidance, made corrupt JSONL sessions return repair-first `ledger-doctor --json` readouts, kept `benchmark-lint` aligned with config-backed benchmark commands, and made `research-start --skip-init` skip baseline logging cleanly.
+- Redacted benchmark-contract command text, checks command text, option-file paths, and env-file labels from persisted last-run packet storage.
 
 ## 2.3.15 - 2026-06-16
 

--- a/plugins/codex-autoresearch/docs/privacy.md
+++ b/plugins/codex-autoresearch/docs/privacy.md
@@ -22,7 +22,7 @@ Benchmark and checks commands are not sandboxed. They run as local shell process
 
 Autoresearch records bounded evidence from those commands so later sessions can resume the loop. It attempts best-effort redaction for common secrets, credentials, home paths, and env-file references, but redaction is not a confidentiality guarantee. Do not print secrets, tokens, private customer data, credentials, or sensitive local paths into benchmark output, checks output, ASI, descriptions, or artifact files.
 
-Use `--command-file` and `--packet-env-file` for command text and environment overrides that need reviewable local files. Prefer project-local wrappers such as `autoresearch.sh` or `autoresearch.ps1` when benchmark setup is sensitive.
+Use `--command-file` and `--packet-env-file` for command text and environment overrides that need reviewable local files. Prefer project-local wrappers such as `autoresearch.sh` or `autoresearch.ps1` when benchmark setup is sensitive. Outside-workdir option files are allowed for trusted local CLI use, but persisted last-run packets replace their paths with placeholders.
 
 ## External services
 

--- a/plugins/codex-autoresearch/docs/trust.md
+++ b/plugins/codex-autoresearch/docs/trust.md
@@ -167,6 +167,10 @@ Prefer project-local `autoresearch.sh` or `autoresearch.ps1` scripts when possib
 
 Autoresearch does not sandbox benchmark or checks commands. Approved commands run as local shell processes with the current user's permissions. Review generated commands, keep secrets out of command lines and output, and prefer `--command-file` and `--packet-env-file` for fragile setup.
 
+`--command-file` and `--packet-env-file` are trusted local CLI inputs, including when they point outside the working directory. Keep them project-local when possible so reviewers can inspect them with the session. Persisted last-run packets reduce outside-workdir option-file paths to placeholders, but the commands still run with the current user's local permissions.
+
+If catalog or option-file inputs are exposed through a tool surface, keep them behind the existing explicit command gate (`allow_unsafe_command` for tools, `--trust-catalog` for external setup catalogs). Catalog recipes can materialize commands, so inspect the source before admitting them.
+
 `run` and `next` default to `--packet-env-mode inherit`. Use `--packet-env-mode minimal` for a smaller environment (PATH, SystemRoot, TEMP, TMP plus explicit packet env keys).
 
 Evidence redaction is best-effort, not a confidentiality guarantee. Keep sensitive data out of benchmark output and ASI in the first place.

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -6344,6 +6344,7 @@ function redactLastRunPacketForStorage(packet: LooseObject): LooseObject {
     stored.packetEvidence = redactEvidenceObject(stored.packetEvidence, context);
   }
   redactRunPacketProcessEvidence(stored.run, context);
+  redactBenchmarkContractForStorage(stored.run?.benchmarkContract, context);
   if (stored.doctor) stored.doctor = redactEvidenceObject(stored.doctor, context);
   if (stored.history) {
     if (stored.history.command) {
@@ -6351,7 +6352,91 @@ function redactLastRunPacketForStorage(packet: LooseObject): LooseObject {
     }
     redactBenchmarkContractForStorage(stored.history.benchmarkContract, context);
   }
+  applyLastRunStorageReplacements(stored, lastRunStorageReplacements(packet, context));
   return stored;
+}
+
+function lastRunStorageReplacements(packet: LooseObject, context: LooseObject) {
+  const replacements: Array<{ token: string; replacement: string }> = [];
+  addOptionPathReplacements(replacements, packet?.run?.commandFile, context, {
+    replacement: redactPathDisplay(packet?.run?.commandFile, context.workDir),
+  });
+  addOptionPathReplacements(replacements, packet?.run?.envFile, context, {
+    replacement: "<env-file>",
+    includeBasename: true,
+  });
+  addOptionPathReplacements(replacements, packet?.run?.benchmarkContract?.commandFile, context, {
+    replacement: redactPathDisplay(packet?.run?.benchmarkContract?.commandFile, context.workDir),
+  });
+  addOptionPathReplacements(replacements, packet?.run?.benchmarkContract?.envFile, context, {
+    replacement: "<env-file>",
+    includeBasename: true,
+  });
+  addOptionPathReplacements(
+    replacements,
+    packet?.history?.benchmarkContract?.commandFile,
+    context,
+    {
+      replacement: redactPathDisplay(
+        packet?.history?.benchmarkContract?.commandFile,
+        context.workDir,
+      ),
+    },
+  );
+  addOptionPathReplacements(replacements, packet?.history?.benchmarkContract?.envFile, context, {
+    replacement: "<env-file>",
+    includeBasename: true,
+  });
+  return replacements
+    .filter((entry) => entry.token && entry.token !== entry.replacement)
+    .sort((a, b) => b.token.length - a.token.length);
+}
+
+function addOptionPathReplacements(
+  replacements: Array<{ token: string; replacement: string }>,
+  value: unknown,
+  context: LooseObject,
+  options: { replacement: string; includeBasename?: boolean },
+) {
+  const raw = String(value || "").trim();
+  if (!raw) return;
+  const tokens = new Set([raw, raw.replace(/\\/g, "/"), raw.replace(/\//g, "\\")]);
+  const resolved = path.isAbsolute(raw)
+    ? path.resolve(raw)
+    : path.resolve(context.workDir || "", raw);
+  tokens.add(resolved);
+  tokens.add(resolved.replace(/\\/g, "/"));
+  tokens.add(resolved.replace(/\//g, "\\"));
+  if (options.includeBasename || options.replacement === "<outside-workdir>") {
+    const basename = path.basename(raw);
+    if (basename) tokens.add(basename);
+  }
+  for (const token of tokens) {
+    if (token.length > 2) replacements.push({ token, replacement: options.replacement });
+  }
+}
+
+function applyLastRunStorageReplacements(
+  value: unknown,
+  replacements: Array<{ token: string; replacement: string }>,
+): void {
+  if (!replacements.length) return;
+  if (Array.isArray(value)) {
+    for (const item of value) applyLastRunStorageReplacements(item, replacements);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value as LooseObject)) {
+    if (typeof child === "string") {
+      let text = child;
+      for (const { token, replacement } of replacements) {
+        text = text.split(token).join(replacement);
+      }
+      (value as LooseObject)[key] = text;
+      continue;
+    }
+    applyLastRunStorageReplacements(child, replacements);
+  }
 }
 
 function redactRunPacketProcessEvidence(
@@ -6405,6 +6490,12 @@ function redactBenchmarkContractForStorage(
   }
   if (value.commandFile) value.commandFile = redactPathDisplay(value.commandFile, context.workDir);
   if (value.envFile) value.envFile = "<env-file>";
+  if (Array.isArray(value.files)) {
+    for (const file of value.files) {
+      if (!file || typeof file !== "object" || !file.path) continue;
+      file.path = redactEvidenceText(redactPathDisplay(file.path, context.workDir), context);
+    }
+  }
 }
 
 const CLI_RESPONSE_TEXT_EVIDENCE_KEYS = new Set([

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -6345,15 +6345,43 @@ function redactLastRunPacketForStorage(packet: LooseObject): LooseObject {
   }
   redactRunPacketProcessEvidence(stored.run, context);
   redactBenchmarkContractForStorage(stored.run?.benchmarkContract, context);
-  if (stored.doctor) stored.doctor = redactEvidenceObject(stored.doctor, context);
+  if (stored.doctor) {
+    redactKnownOptionFileFields(stored.doctor, context);
+    stored.doctor = redactEvidenceObject(stored.doctor, context);
+  }
   if (stored.history) {
     if (stored.history.command) {
       stored.history.command = redactCommandDisplay(stored.history.command, context);
     }
     redactBenchmarkContractForStorage(stored.history.benchmarkContract, context);
   }
+  redactKnownOptionFileFields(stored, context);
   applyLastRunStorageReplacements(stored, lastRunStorageReplacements(packet, context));
   return stored;
+}
+
+const STORAGE_COMMAND_FILE_KEYS = new Set(["commandFile", "command_file"]);
+const STORAGE_ENV_FILE_KEYS = new Set(["envFile", "env_file", "packetEnvFile", "packet_env_file"]);
+
+function redactKnownOptionFileFields(value: unknown, context: LooseObject): void {
+  if (Array.isArray(value)) {
+    for (const item of value) redactKnownOptionFileFields(item, context);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value as LooseObject)) {
+    if (typeof child === "string") {
+      if (STORAGE_COMMAND_FILE_KEYS.has(key)) {
+        (value as LooseObject)[key] = redactPathDisplay(child, context.workDir);
+        continue;
+      }
+      if (STORAGE_ENV_FILE_KEYS.has(key) && child) {
+        (value as LooseObject)[key] = "<env-file>";
+        continue;
+      }
+    }
+    redactKnownOptionFileFields(child, context);
+  }
 }
 
 function lastRunStorageReplacements(packet: LooseObject, context: LooseObject) {
@@ -6363,14 +6391,12 @@ function lastRunStorageReplacements(packet: LooseObject, context: LooseObject) {
   });
   addOptionPathReplacements(replacements, packet?.run?.envFile, context, {
     replacement: "<env-file>",
-    includeBasename: true,
   });
   addOptionPathReplacements(replacements, packet?.run?.benchmarkContract?.commandFile, context, {
     replacement: redactPathDisplay(packet?.run?.benchmarkContract?.commandFile, context.workDir),
   });
   addOptionPathReplacements(replacements, packet?.run?.benchmarkContract?.envFile, context, {
     replacement: "<env-file>",
-    includeBasename: true,
   });
   addOptionPathReplacements(
     replacements,
@@ -6385,7 +6411,6 @@ function lastRunStorageReplacements(packet: LooseObject, context: LooseObject) {
   );
   addOptionPathReplacements(replacements, packet?.history?.benchmarkContract?.envFile, context, {
     replacement: "<env-file>",
-    includeBasename: true,
   });
   return replacements
     .filter((entry) => entry.token && entry.token !== entry.replacement)
@@ -6396,24 +6421,27 @@ function addOptionPathReplacements(
   replacements: Array<{ token: string; replacement: string }>,
   value: unknown,
   context: LooseObject,
-  options: { replacement: string; includeBasename?: boolean },
+  options: { replacement: string },
 ) {
   const raw = String(value || "").trim();
   if (!raw) return;
-  const tokens = new Set([raw, raw.replace(/\\/g, "/"), raw.replace(/\//g, "\\")]);
+  const tokens = new Set<string>();
   const resolved = path.isAbsolute(raw)
     ? path.resolve(raw)
     : path.resolve(context.workDir || "", raw);
-  tokens.add(resolved);
-  tokens.add(resolved.replace(/\\/g, "/"));
-  tokens.add(resolved.replace(/\//g, "\\"));
-  if (options.includeBasename || options.replacement === "<outside-workdir>") {
-    const basename = path.basename(raw);
-    if (basename) tokens.add(basename);
+  for (const candidate of [raw, resolved]) {
+    if (!isPathLikeReplacementToken(candidate)) continue;
+    tokens.add(candidate);
+    tokens.add(candidate.replace(/\\/g, "/"));
+    tokens.add(candidate.replace(/\//g, "\\"));
   }
   for (const token of tokens) {
     if (token.length > 2) replacements.push({ token, replacement: options.replacement });
   }
+}
+
+function isPathLikeReplacementToken(value: string) {
+  return path.isAbsolute(value) || /[\\/]/.test(value);
 }
 
 function applyLastRunStorageReplacements(
@@ -6453,6 +6481,7 @@ function redactRunPacketProcessEvidence(
   redactProgressEvidence(value.progress, context);
   redactProgressEvidence(value.progressSnapshot, context);
   if (value.commandDiagnostics) {
+    redactKnownOptionFileFields(value.commandDiagnostics, context);
     value.commandDiagnostics = redactEvidenceObject(value.commandDiagnostics, context);
   }
   if (value.checks && typeof value.checks === "object") {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -3471,6 +3471,60 @@ test("last-run packet storage redacts run benchmark contract command and option-
   });
 });
 
+test("last-run packet storage does not corrupt common option-file basenames", async () => {
+  await withTempDir("last-run-common-basename-redaction", async (dir) => {
+    const outsideDir = path.join(path.dirname(dir), `${path.basename(dir)}-outside`);
+    try {
+      await mkdir(outsideDir, { recursive: true });
+      const commandFile = path.join(outsideDir, "run");
+      const envFile = path.join(outsideDir, "env");
+      await writeFile(
+        commandFile,
+        [
+          `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3'); console.log('ordinary run env node packet text')"`,
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await writeFile(envFile, "PACKET_TOKEN=common-name-env-value\n", "utf8");
+      await runCli([
+        "init",
+        "--cwd",
+        dir,
+        "--name",
+        "common basename contract",
+        "--metric-name",
+        "seconds",
+      ]);
+
+      const packet = await runCli([
+        "next",
+        "--cwd",
+        dir,
+        "--command-file",
+        commandFile,
+        "--packet-env-file",
+        envFile,
+      ]);
+      assert.equal(packet.code, 0, packet.stderr);
+
+      const lastRunText = await readFile(path.join(dir, "autoresearch.last-run.json"), "utf8");
+      assert.match(lastRunText, /ordinary run env node packet text/);
+      assert.doesNotMatch(
+        lastRunText,
+        new RegExp(outsideDir.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")),
+      );
+
+      const stored = JSON.parse(lastRunText);
+      assert.equal(stored.run.benchmarkContract.commandFile, "<outside-workdir>");
+      assert.equal(stored.run.benchmarkContract.envFile, "<env-file>");
+      assert.equal(stored.run.tailOutput.includes("ordinary run env node packet text"), true);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
 test("run command response redacts raw benchmark evidence", async () => {
   await withTempDir("run-response-redaction", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "redacted run", "--metric-name", "seconds"]);

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -3399,6 +3399,78 @@ test("last-run packet storage redacts raw benchmark evidence and still logs from
   });
 });
 
+test("last-run packet storage redacts run benchmark contract command and option-file metadata", async () => {
+  await withTempDir("last-run-contract-redaction", async (dir) => {
+    const outsideDir = path.join(path.dirname(dir), `${path.basename(dir)}-outside`);
+    try {
+      await mkdir(outsideDir, { recursive: true });
+      const commandSecret = "command-secret-abcdefghijklmnop";
+      const checksSecret = "checks-secret-zyxwvutsrqpon";
+      const commandFile = path.join(outsideDir, "private-packet.command");
+      const envFile = path.join(outsideDir, ".env.private");
+      await writeFile(
+        commandFile,
+        `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=2')" -- --api-key ${commandSecret}\n`,
+        "utf8",
+      );
+      await writeFile(envFile, "PACKET_TOKEN=env-secret-qwertyuiop\n", "utf8");
+      await runCli([
+        "init",
+        "--cwd",
+        dir,
+        "--name",
+        "redacted contract",
+        "--metric-name",
+        "seconds",
+      ]);
+
+      const packet = await runCli([
+        "next",
+        "--cwd",
+        dir,
+        "--command-file",
+        commandFile,
+        "--packet-env-file",
+        envFile,
+        "--checks-command",
+        `${quoteForShell(process.execPath)} -e "process.exit(0)" -- --token ${checksSecret}`,
+      ]);
+      assert.equal(packet.code, 0, packet.stderr);
+
+      const lastRunText = await readFile(path.join(dir, "autoresearch.last-run.json"), "utf8");
+      assert.doesNotMatch(lastRunText, new RegExp(commandSecret));
+      assert.doesNotMatch(lastRunText, new RegExp(checksSecret));
+      assert.doesNotMatch(lastRunText, /private-packet\.command/);
+      assert.doesNotMatch(lastRunText, /\.env\.private/);
+      assert.doesNotMatch(
+        lastRunText,
+        new RegExp(outsideDir.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")),
+      );
+
+      const stored = JSON.parse(lastRunText);
+      const contract = stored.run.benchmarkContract;
+      assert.match(contract.command, /--api-key <redacted>/);
+      assert.match(contract.checksCommand, /--token <redacted>/);
+      assert.equal(contract.commandFile, "<outside-workdir>");
+      assert.equal(contract.envFile, "<env-file>");
+      assert.equal(
+        contract.files.some((file: Record<string, unknown>) =>
+          String(file.path || "").includes("private-packet.command"),
+        ),
+        false,
+      );
+      assert.equal(
+        contract.files.some((file: Record<string, unknown>) =>
+          String(file.path || "").includes(".env.private"),
+        ),
+        false,
+      );
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
 test("run command response redacts raw benchmark evidence", async () => {
   await withTempDir("run-response-redaction", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "redacted run", "--metric-name", "seconds"]);


### PR DESCRIPTION
## Context

Refs #158

Persisted last-run packets already redacted `history.benchmarkContract`, but the copied `run.benchmarkContract` could still carry raw benchmark command text, checks command text, command-file paths, and env-file labels into `.git/autoresearch/last-run.json` or `autoresearch.last-run.json`.

## What Changed

- Redacts `run.benchmarkContract` at the same storage boundary used for last-run packet evidence.
- Scrubs benchmark-contract `files[].path` labels and raw option-file path tokens anywhere else in the saved last-run packet, including embedded doctor/state guidance.
- Documents the outside-workdir decision: direct CLI option files remain trusted local inputs; persisted packets use placeholders; tool/catalog command surfaces stay behind explicit trust gates.
- Adds a focused regression that runs `next` with an outside `--command-file`, outside `--packet-env-file`, and sensitive checks command, then asserts the persisted last-run JSON omits the sensitive command/path/env metadata.

```mermaid
flowchart LR
  Next[next packet] --> Packet[last-run packet]
  Packet --> Storage[storage redactor]
  Storage --> Contract[run.benchmarkContract]
  Storage --> Guidance[doctor/state guidance]
  Contract --> Saved[persisted JSON]
  Guidance --> Saved
```

## How To Review

1. Start at `plugins/codex-autoresearch/scripts/autoresearch.ts` around `redactLastRunPacketForStorage`.
2. Check `plugins/codex-autoresearch/tests/autoresearch-cli.test.ts` for the new storage-level regression.
3. Review `docs/trust.md` and `docs/privacy.md` for the outside-workdir/catalog decision.

## Verification

- `npm ci` (installed missing worktree dependencies; prepare ran `npm run build:node`) passed.
- `npm run build:node` passed.
- `node --test --test-name-pattern "last-run packet storage redacts" dist\tests\autoresearch-cli.test.mjs` passed: 2/2 tests.
- `npm run format:check` passed.
- `npm run typecheck:node` passed.
- `git diff --check` passed.

## Risk

- Redaction is applied only at the persisted last-run storage boundary; CLI command execution behavior is unchanged.
- Outside-workdir option files remain allowed for trusted local CLI workflows. The mitigation is persistence redaction plus clearer docs, not a new breaking guard.
- `npm ci`/push reported existing dependency vulnerability notices; this PR does not change dependencies.
