### PR TITLE
[codex] Add production audit script

### DIFF
--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -41,6 +41,7 @@
     "typecheck:dashboard": "tsgo --project tsconfig.dashboard.json --noEmit",
     "typecheck": "run-s typecheck:node typecheck:dashboard",
     "lint": "oxlint --deny-warnings --node-plugin --promise-plugin --react-plugin --jsx-a11y-plugin --no-error-on-unmatched-pattern dashboard/src lib scripts tests vite.dashboard.config.ts tsconfig.node.json tsconfig.dashboard.json tsdown.config.ts",
+    "audit:prod": "npm audit --omit=dev",
     "format": "oxfmt --write --no-error-on-unmatched-pattern dashboard/src lib scripts tests vite.dashboard.config.ts tsconfig.json tsconfig.node.json tsconfig.dashboard.json tsdown.config.ts package.json",
     "format:check": "oxfmt --check --no-error-on-unmatched-pattern dashboard/src lib scripts tests vite.dashboard.config.ts tsconfig.json tsconfig.node.json tsconfig.dashboard.json tsdown.config.ts package.json",
     "prepare": "npm run build:node",


### PR DESCRIPTION
## Context

Refs #165.

Issue #165 asks to reduce package/performance/local audit friction without speculative optimization. Existing maintainer docs already document read-only package inspection with `npm pack --dry-run --json --ignore-scripts`, so this PR keeps docs, dashboard assets, and startup code untouched.

## What Changed

- Added `audit:prod` in `plugins/codex-autoresearch/package.json` as `npm audit --omit=dev`.

## How To Review

- Inspect the one-line package script addition.
- Confirm `plugins/codex-autoresearch/docs/maintainers.md` already includes the read-only pack inspection command.

## Verification

- `npm run audit:prod` -> `found 0 vulnerabilities`
- `rg -n "audit:prod|npm audit --omit=dev|npm pack --dry-run --json --ignore-scripts" plugins\codex-autoresearch`
- `npm pack --dry-run --json --ignore-scripts` -> 43-file manifest; `package.json` included; scripts ignored.
- `git diff --check`
- Invalid-option probe: `npm run audit:prod -- --audit-level=not-a-level` -> npm emitted its native invalid-config warning, then completed with the current clean audit result.

## Risk

Low. This is a package-script alias only. It does not change runtime code, package contents, dashboard assets, or CLI startup behavior. The Dependabot alerts GitHub reported during push are on the default branch and remain outside this production-audit friction slice.
