### PR TITLE
Make recovery output human-first

### DIFF
--- a/plugins/codex-autoresearch/lib/action-metadata.ts
+++ b/plugins/codex-autoresearch/lib/action-metadata.ts
@@ -19,7 +19,14 @@ export const ACTION_METADATA: Record<string, ActionMetadata> = {
     label: "Resolve preflight",
     commandLabel: "Doctor",
     safeAction: "doctor",
-    fallbackKeys: ["doctorExplain", "doctor", "benchmarkLint", "state"],
+    fallbackKeys: [
+      "setupPlan",
+      "benchmarkLint",
+      "stateCompact",
+      "state",
+      "doctor",
+      "doctorExplain",
+    ],
   }),
   "portfolio-trust-blocker": actionMetadata({
     label: "Inspect portfolio trust",
@@ -152,13 +159,13 @@ export const ACTION_METADATA: Record<string, ActionMetadata> = {
     label: "Complete setup",
     commandLabel: "Setup",
     safeAction: "setup-plan",
-    fallbackKeys: ["setup", "setupPlan", "state"],
+    fallbackKeys: ["setupPlan", "stateCompact", "state", "setup"],
   }),
   "benchmark-command": actionMetadata({
     label: "Add benchmark command",
     commandLabel: "Setup",
     safeAction: "setup-plan",
-    fallbackKeys: ["setup", "setupPlan", "benchmarkLint", "state"],
+    fallbackKeys: ["setupPlan", "benchmarkLint", "stateCompact", "state", "setup"],
   }),
   "log-decision": actionMetadata({
     label: "Log last packet",

--- a/plugins/codex-autoresearch/lib/commands/continuation.ts
+++ b/plugins/codex-autoresearch/lib/commands/continuation.ts
@@ -16,6 +16,7 @@ export function buildContinuationCommands({
   const slug = shellQuote(researchSlug);
   return {
     state: `node ${script} state --cwd ${cwd}`,
+    stateCompact: `node ${script} state --cwd ${cwd} --compact`,
     doctor: `node ${script} doctor --cwd ${cwd}`,
     doctorExplain: `node ${script} doctor --cwd ${cwd} --explain`,
     next: `node ${script} next --cwd ${cwd} --compact`,
@@ -32,6 +33,7 @@ export function buildContinuationCommands({
     extendLimit: `node ${script} config --cwd ${cwd} --extend 10`,
     onboardingPacket: `node ${script} onboarding-packet --cwd ${cwd} --compact`,
     recommendNext: `node ${script} recommend-next --cwd ${cwd} --compact`,
+    setupPlan: `node ${script} setup-plan --cwd ${cwd}`,
     codexGoalBrief: `node ${script} codex-goal-brief --cwd ${cwd}`,
     benchmarkInspect: `node ${script} benchmark-inspect --cwd ${cwd}`,
     benchmarkLint: `node ${script} benchmark-lint --cwd ${cwd}`,

--- a/plugins/codex-autoresearch/lib/dashboard-command-safety.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-command-safety.ts
@@ -62,6 +62,7 @@ export const DASHBOARD_COMMAND_FIELD_NAMES: ReadonlySet<string> = new Set([
   "recommendNext",
   "replaceLast",
   "setupPlan",
+  "stateCompact",
   "staticExport",
   "suggestedCommand",
   "suggestedCommands",

--- a/plugins/codex-autoresearch/lib/decision-guidance.ts
+++ b/plugins/codex-autoresearch/lib/decision-guidance.ts
@@ -87,6 +87,13 @@ export async function buildDecisionGuidanceContext({
     "--check-benchmark",
     "--explain",
   ]);
+  const setupPlanCommand = renderCommand([
+    "node",
+    path.join(pluginRoot, "scripts", "autoresearch.mjs"),
+    "setup-plan",
+    "--cwd",
+    workDir,
+  ]);
   const runtimeSummary =
     runtimeDriftSummary ||
     (await inspectRuntimeDrift({
@@ -123,6 +130,7 @@ export async function buildDecisionGuidanceContext({
       benchmarkCommand: resolvedBenchmarkCommand,
       benchmarkLintCommand,
       doctorCommand,
+      setupPlanCommand,
       gateQuality,
       scaffoldHealth,
       warningDetails,

--- a/plugins/codex-autoresearch/lib/operator-checklist.ts
+++ b/plugins/codex-autoresearch/lib/operator-checklist.ts
@@ -15,10 +15,11 @@ export function buildOperatorChecklist(
   context: LooseObject = {},
 ): OperatorChecklist {
   const action = objectValue(canonicalAction) || {};
-  const command =
+  const rawCommand =
     stringValue(action.command) ||
     stringValue(context.primaryCommand) ||
     inspectCommandForAction(action, context);
+  const command = boundedChecklistCommand(rawCommand, action, context);
   return {
     command,
     safetyReason:
@@ -27,6 +28,15 @@ export function buildOperatorChecklist(
     evidenceRole: evidenceRoleForAction(stringValue(action.kind)),
     source: stringValue(context.source) || "canonical-next-action",
   };
+}
+
+function boundedChecklistCommand(
+  command: string,
+  action: LooseObject,
+  context: LooseObject,
+): string {
+  if (!/\bdoctor\b/i.test(command) || !/--explain\b/i.test(command)) return command;
+  return boundedInspectCommandForAction(action, context) || command;
 }
 
 function blockerForAction(action: LooseObject, context: LooseObject): string {
@@ -96,6 +106,24 @@ function inspectCommandForAction(action: LooseObject, context: LooseObject): str
       return actionMetadataForKind(action.kind)?.packetBrake === false
         ? ""
         : `${script} state --cwd ${cwd} --compact`;
+  }
+}
+
+function boundedInspectCommandForAction(action: LooseObject, context: LooseObject): string {
+  const workDir = stringValue(context.workDir || context.cwd);
+  if (!workDir) return "";
+  const script = scriptCommand(context);
+  const cwd = quoteCommandArg(workDir);
+  switch (stringValue(action.kind)) {
+    case "preflight":
+    case "setup":
+    case "benchmark-command":
+      return `${script} setup-plan --cwd ${cwd}`;
+    case "benchmark-mismatch":
+    case "gate-quality":
+      return `${script} benchmark-lint --cwd ${cwd}`;
+    default:
+      return `${script} state --cwd ${cwd} --compact`;
   }
 }
 

--- a/plugins/codex-autoresearch/lib/preflight-audit.ts
+++ b/plugins/codex-autoresearch/lib/preflight-audit.ts
@@ -5,6 +5,7 @@ export interface PreflightAuditInput {
   benchmarkCommand?: unknown;
   benchmarkLintCommand?: unknown;
   doctorCommand?: unknown;
+  setupPlanCommand?: unknown;
   gateQuality?: {
     posture?: unknown;
     blockers?: unknown[];
@@ -119,8 +120,16 @@ export function buildPreflightAudit(input: PreflightAuditInput): PreflightAudit 
 function nextCommand(input: PreflightAuditInput, blockers: string[], warnings: string[]): string {
   const benchmarkLintCommand = cleanString(input.benchmarkLintCommand);
   const doctorCommand = cleanString(input.doctorCommand);
+  const setupPlanCommand = cleanString(input.setupPlanCommand);
   if (blockers.some((blocker) => /benchmark|metric|setup|gate/i.test(blocker))) {
-    return benchmarkLintCommand || doctorCommand;
+    if (
+      blockers.some((blocker) =>
+        /No benchmark command|Missing setup|No primary metric/i.test(blocker),
+      )
+    ) {
+      return setupPlanCommand || benchmarkLintCommand || doctorCommand;
+    }
+    return benchmarkLintCommand || setupPlanCommand || doctorCommand;
   }
   if (blockers.length > 0 || warnings.some((warning) => /dirty|runtime|stale/i.test(warning))) {
     return doctorCommand || benchmarkLintCommand;

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -2408,8 +2408,9 @@ function compactRecommendCommands(
 ): LooseObject {
   if (!commands) return {};
   const compactCommands: LooseObject = {};
-  const primary = canonicalNextAction?.command || commands.state;
+  const primary = canonicalNextAction?.command || commands.stateCompact || commands.state;
   if (primary) compactCommands.primary = primary;
+  if (commands.stateCompact) compactCommands.stateCompact = commands.stateCompact;
   if (commands.state) compactCommands.state = commands.state;
   return compactCommands;
 }

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -9941,6 +9941,29 @@ test("guide, dashboard, and recommend-next share canonical preflight blocker", a
   });
 });
 
+test("recommend-next compact operator checklist uses bounded recovery for empty sessions", async () => {
+  await withTempDir("compact-empty-recovery", async (dir) => {
+    const recommend = await runCli([
+      "recommend-next",
+      "--cwd",
+      dir,
+      "--compact",
+      "--operator-checklist",
+    ]);
+    assert.equal(recommend.code, 0, recommend.stderr);
+    const payload = JSON.parse(recommend.stdout);
+    const command = payload.operatorChecklist.command || "";
+
+    assert.equal(payload.action.kind, "preflight");
+    assert.match(payload.nextAction, /benchmark command/i);
+    assert.match(payload.operatorChecklist.blocker, /benchmark command/i);
+    assert.match(command, /autoresearch\.mjs\b.*\b(setup-plan|state)\b/);
+    assert.match(command, /--cwd\b/);
+    assert.doesNotMatch(command, /\bdoctor\b.*--explain\b/);
+    assert.doesNotMatch(payload.commands.primary || "", /\bdoctor\b.*--explain\b/);
+  });
+});
+
 test("state and recommend-next expose advisory portfolio guidance", async () => {
   await withTempDir("portfolio-guidance", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "portfolio", "--metric-name", "seconds"]);

--- a/plugins/codex-autoresearch/tests/loop-governance.test.ts
+++ b/plugins/codex-autoresearch/tests/loop-governance.test.ts
@@ -955,9 +955,10 @@ test("compact recommend-next uses blocker metadata fallback instead of next", ()
   assert.equal((response.action as { kind?: string }).kind, "preflight");
   assert.equal(
     response.commands.primary,
-    "node scripts/autoresearch.mjs doctor --cwd C:/repo --explain",
+    "node scripts/autoresearch.mjs state --cwd C:/repo --compact",
   );
   assert.doesNotMatch(String(response.commands.primary), /\bnext\b/);
+  assert.doesNotMatch(String(response.commands.primary), /\bdoctor\b.*--explain\b/);
 });
 
 test("compact recommend-next skips process-starting metadata fallbacks", () => {


### PR DESCRIPTION
## Context

Refs #160.

Blocked or empty Autoresearch sessions could hand humans a verbose `doctor --explain` path from `recommend-next --compact --operator-checklist`, especially when no benchmark command existed yet. That made recovery output machine-shaped instead of giving one bounded next command.

## What Changed

- Added compact/read-only recovery commands to the continuation command map: `state --compact` and `setup-plan --cwd`.
- Routed missing metric/setup/benchmark preflight blockers to `setup-plan --cwd` before falling back to diagnostic detail.
- Added an operator-checklist guard so verbose `doctor --explain` commands are converted to bounded human recovery commands while preserving detailed doctor output for explicit doctor/runtime paths.
- Added a targeted CLI test for empty-session `recommend-next --compact --operator-checklist` recovery output.

## How To Review

1. Start with `lib/preflight-audit.ts` and `lib/operator-checklist.ts` to review the recovery-command boundary.
2. Check `scripts/autoresearch.ts` and `lib/commands/continuation.ts` for the compact handoff command propagation.
3. Review `tests/autoresearch-cli.test.ts` for the empty-session regression case.

## Verification

Post-refresh onto current `origin/dev`:

- `npm run build:node` passed.
- `npm run typecheck:node` passed.
- `npm run format:check` passed.
- `npm run lint` passed.
- `npm run command-surface-map` passed.
- `git diff --check` passed.
- `node --test --test-name-pattern "doctor --check-installed blocks non-fresh installed runtime before packet guidance|recommend-next compact operator checklist uses bounded recovery for empty sessions|recommend-next compact returns state-first handoff|guide, dashboard, and recommend-next share canonical preflight blocker" dist/tests/autoresearch-cli.test.mjs` passed, 4 tests.

Pre-refresh package-gate note: `npm run check` reached product checks but `test:compiled:cli` hit the shard runner's 300s timeout on shards 13 and 14 under `--jobs 4`; those exact shard ranges passed when rerun directly, and the compiled CLI suite passed with lower concurrency.

## Risk

Low. This keeps JSON/full doctor detail available through explicit doctor/runtime paths and narrows only the human recovery command selected for compact/operator-checklist and empty preflight states.