### PR TITLE
[codex] Generate demo dashboard export during checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 ### Changed
 
 - Clarified first-run docs after install, the first successful packet ladder, package-root versus target `--cwd`, and command-index ownership.
-- Tightened the product gate so the checked-in demo dashboard export must match the current built dashboard CSS and JS, and documented the temporary review export path.
+- Changed the product gate to generate an ignored demo dashboard export during checks, preserving version/showcase/read-only/leak/asset-parity trust checks without requiring committed demo HTML churn in routine dashboard UI PRs.
 
 ## 2.4.0 - 2026-06-18
 

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -72,19 +72,21 @@ git diff --check
 
 For dashboard or view-model changes, export or serve a dashboard and inspect it. Static code and tests alone do not prove the operator surface is understandable.
 
-When refreshing the checked-in demo, use the public showcase export so workstation paths and transient branch warnings are scrubbed:
-
-```bash
-node scripts/autoresearch.mjs export --cwd examples/demo-session --output autoresearch-dashboard.html --showcase
-```
-
-For review without in-place churn, write a temporary ignored export in the demo session and compare or open that file instead:
+For dashboard or view-model review, write a temporary ignored showcase export in the demo session and compare or open that file:
 
 ```bash
 node scripts/autoresearch.mjs export --cwd examples/demo-session --output tmp/autoresearch-dashboard.review.html --showcase
 ```
 
-The product gate compares the checked-in demo export's inline dashboard CSS and JS with `assets/dashboard-build/dashboard-app.css` and `assets/dashboard-build/dashboard-app.js` after the exporter's `</style` and `</script` escaping rules. A stale inline script or stylesheet fails `npm run check`.
+`npm run check` generates its own ignored trust export at `examples/demo-session/tmp/autoresearch-dashboard.check.html`. That generated export must embed the current plugin version, public/showcase flags, scrub workstation paths and transient branch warnings, omit action routes, and match `assets/dashboard-build/dashboard-app.css` plus `assets/dashboard-build/dashboard-app.js` after the exporter's `</style` and `</script` escaping rules.
+
+The legacy checked-in `examples/demo-session/autoresearch-dashboard.html` is no longer the product-gate parity target. Do not refresh it just to make routine dashboard UI checks pass.
+
+When intentionally refreshing the legacy fixture, use the public showcase export so workstation paths and transient branch warnings are scrubbed:
+
+```bash
+node scripts/autoresearch.mjs export --cwd examples/demo-session --output autoresearch-dashboard.html --showcase
+```
 
 Before publishing, inspect the package artifact itself. Use dry-run pack output
 for routine review, then create and extract a real tarball for release smoke.

--- a/plugins/codex-autoresearch/scripts/check.ts
+++ b/plugins/codex-autoresearch/scripts/check.ts
@@ -56,7 +56,8 @@ const dashboardAssets = [
   "assets/dashboard-build/dashboard-app.js",
   "assets/dashboard-build/dashboard-app.css",
 ];
-const dashboardDemoExport = "examples/demo-session/autoresearch-dashboard.html";
+const dashboardDemoExportOutput = "tmp/autoresearch-dashboard.check.html";
+export const dashboardGeneratedDemoExport = `examples/demo-session/${dashboardDemoExportOutput}`;
 
 const sourceCheckoutLauncherPaths = [
   "plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs",
@@ -544,8 +545,20 @@ async function runDemoTrustCheck() {
     console.log("ok demo:doctor");
   }
 
+  await fsp.mkdir(path.dirname(path.join(ROOT, dashboardGeneratedDemoExport)), {
+    recursive: true,
+  });
+  await fsp.rm(path.join(ROOT, dashboardGeneratedDemoExport), { force: true });
+  const exportResult = await runCommand(demoDashboardExportCommand());
+  if (exportResult.code !== 0) {
+    console.log("fail demo:export");
+    const output = `${exportResult.stdout}${exportResult.stderr}`.trim();
+    if (output) console.log(indent(output));
+    return false;
+  }
+
   const pkg = JSON.parse(await fsp.readFile(path.join(ROOT, "package.json"), "utf8"));
-  const html = await fsp.readFile(path.join(ROOT, dashboardDemoExport), "utf8");
+  const html = await fsp.readFile(path.join(ROOT, dashboardGeneratedDemoExport), "utf8");
   const parityIssues = dashboardExportAssetIssues(html, await readDashboardExportAssets());
   const showcaseIssues = demoShowcaseIssues(html);
   const forbidden = [
@@ -584,7 +597,7 @@ async function runDemoTrustCheck() {
         indent(
           `Demo export generated asset parity failed:\n${parityIssues.join(
             "\n",
-          )}\nRefresh it with: node scripts/autoresearch.mjs export --cwd examples/demo-session --output autoresearch-dashboard.html --showcase`,
+          )}\nGenerated check path: ${dashboardGeneratedDemoExport}`,
         ),
       );
     }
@@ -601,6 +614,22 @@ async function runDemoTrustCheck() {
   }
   console.log("ok demo:export");
   return true;
+}
+
+export function demoDashboardExportCommand(): CommandSpec {
+  return [
+    "demo:export",
+    node,
+    [
+      "scripts/autoresearch.mjs",
+      "export",
+      "--cwd",
+      "examples/demo-session",
+      "--output",
+      dashboardDemoExportOutput,
+      "--showcase",
+    ],
+  ];
 }
 
 async function readDashboardExportAssets(): Promise<DashboardExportAssets> {

--- a/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
+++ b/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
@@ -55,33 +55,6 @@ async function readJson(file: string): Promise<LooseObject> {
   return JSON.parse(await readText(file));
 }
 
-function parseDashboardMeta(html: string): LooseObject | null {
-  const match = html.match(/window\.__AUTORESEARCH_META__ = ([\s\S]*?);\n<\/script>/);
-  if (!match) return null;
-  try {
-    return JSON.parse(match[1]);
-  } catch {
-    return null;
-  }
-}
-
-function demoExportUsesShowcaseMode(html: string): boolean {
-  const meta = parseDashboardMeta(html);
-  return Boolean(
-    meta &&
-    meta.publicExport === true &&
-    meta.showcaseMode === true &&
-    meta.deliveryMode === "showcase" &&
-    meta.settings?.publicExport === true &&
-    meta.settings?.showcaseMode === true &&
-    meta.settings?.deliveryMode === "showcase" &&
-    meta.viewModel?.trustState?.mode !== "static-export" &&
-    meta.viewModel?.processHygiene?.mode !== "static-export" &&
-    !/Static export/i.test(JSON.stringify(meta.viewModel?.trustState?.reasons ?? [])) &&
-    !/Static export/i.test(JSON.stringify(meta.viewModel?.processHygiene?.warnings ?? [])),
-  );
-}
-
 async function fileExists(file: string): Promise<boolean> {
   try {
     await fsp.access(path.join(pluginRoot, file));
@@ -275,7 +248,7 @@ const checks = [
   },
   {
     id: "docs-split-and-showcase",
-    file: "../../README.md, docs/*.md, examples/, assets/showcase/",
+    file: "../../README.md, docs/*.md, examples/demo-session/autoresearch.jsonl, assets/showcase/",
     description:
       "Detailed guidance lives in focused docs while README surfaces the live dashboard demo.",
     run: async () => {
@@ -303,7 +276,6 @@ const checks = [
         !!screenshotDimensions &&
         screenshotDimensions.width >= 900 &&
         screenshotDimensions.height / screenshotDimensions.width <= 0.8;
-      const demoExport = await readText("examples/demo-session/autoresearch-dashboard.html");
       const demoJsonl = await readText("examples/demo-session/autoresearch.jsonl");
       const demoRuns = demoJsonl
         .split(/\r?\n/)
@@ -311,14 +283,6 @@ const checks = [
       return screenshotExists &&
         screenshotIsCompact &&
         demoRuns === 100 &&
-        demoExport.includes(`"pluginVersion":"${PLUGIN_VERSION}"`) &&
-        demoExportUsesShowcaseMode(demoExport) &&
-        !demoExport.includes("C:\\Users\\alber") &&
-        !demoExport.includes("C:\\Program Files") &&
-        !demoExport.includes("actionNonce") &&
-        !demoExport.includes("/actions/") &&
-        !demoExport.includes("live-actions-panel") &&
-        !demoExport.includes("action-receipt") &&
         !readme.includes("```mermaid") &&
         includesAll(readme, ["Docs index", "dashboard-demo.png"]) &&
         includesAll(joined, [
@@ -335,7 +299,7 @@ const checks = [
         ])
         ? pass()
         : fail(
-            "Docs split, compact README snapshot, visual docs, live demo, or scrubbed demo export is incomplete.",
+            "Docs split, compact README snapshot, visual docs, or live demo ledger is incomplete.",
           );
     },
   },

--- a/plugins/codex-autoresearch/tests/check-runner.test.ts
+++ b/plugins/codex-autoresearch/tests/check-runner.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { resolveSpawnCommand } from "../scripts/check-runner.js";
-import { dashboardExportAssetIssues, resolveNpmCommand } from "../scripts/check.js";
+import {
+  dashboardExportAssetIssues,
+  dashboardGeneratedDemoExport,
+  demoDashboardExportCommand,
+  resolveNpmCommand,
+} from "../scripts/check.js";
 
 test("check runner refuses Windows command scripts instead of routing through cmd", () => {
   assert.throws(
@@ -119,6 +124,30 @@ test("demo export asset parity rejects a stale inline dashboard script", () => {
   assert.deepEqual(dashboardExportAssetIssues(html, assets), [
     "inline dashboard script does not match assets/dashboard-build/dashboard-app.js after </script escaping",
   ]);
+});
+
+test("demo trust generates its dashboard export in ignored demo tmp", () => {
+  const [label, command, args] = demoDashboardExportCommand();
+
+  assert.equal(label, "demo:export");
+  assert.equal(command, process.execPath);
+  assert.deepEqual(args, [
+    "scripts/autoresearch.mjs",
+    "export",
+    "--cwd",
+    "examples/demo-session",
+    "--output",
+    "tmp/autoresearch-dashboard.check.html",
+    "--showcase",
+  ]);
+  assert.equal(
+    dashboardGeneratedDemoExport,
+    "examples/demo-session/tmp/autoresearch-dashboard.check.html",
+  );
+  assert.notEqual(
+    dashboardGeneratedDemoExport,
+    "examples/demo-session/autoresearch-dashboard.html",
+  );
 });
 
 test("demo export asset parity accepts documented closing-tag escaping", () => {

--- a/plugins/codex-autoresearch/tests/perfection-benchmark.test.ts
+++ b/plugins/codex-autoresearch/tests/perfection-benchmark.test.ts
@@ -39,6 +39,13 @@ test("perfection benchmark reports zero quality gaps for the local plugin", asyn
   assert.equal(passed, checks);
 });
 
+test("perfection benchmark does not depend on committed demo dashboard HTML", async () => {
+  const source = await readFile(benchmarkSource, "utf8");
+
+  assert.doesNotMatch(source, /examples\/demo-session\/autoresearch-dashboard\.html/);
+  assert.doesNotMatch(source, /demoExport/);
+});
+
 test("compact read command paths use loadSessionState cache-aware loading", async () => {
   const source = await readFile(path.join(pluginRoot, "scripts", "autoresearch.ts"), "utf8");
   const cliHandlers = await readFile(path.join(pluginRoot, "lib", "cli-handlers.ts"), "utf8");


### PR DESCRIPTION
## Context

Issue #176 moves the demo dashboard export trust check off the committed HTML fixture. The checked-in `examples/demo-session/autoresearch-dashboard.html` is not runtime-required, but using it as the parity target made normal dashboard UI PRs carry generated HTML churn.

Refs #176

## What Changed

- `npm run check` now generates a fresh showcase dashboard export at `examples/demo-session/tmp/autoresearch-dashboard.check.html` before running demo trust checks.
- The generated export is still checked for current plugin version, public/showcase flags, workstation path leaks, action-route/action-control leaks, and inline dashboard JS/CSS parity against `assets/dashboard-build/*` after closing-tag escaping.
- `scripts/perfection-benchmark.ts` no longer reads or asserts against the committed legacy demo export, so the product quality gate no longer depends on stale checked-in demo HTML.
- The tracked demo export is left as a legacy fixture in this slice, with no product-gate parity requirement.
- Maintainer docs now direct review exports to ignored `tmp/` paths and say committed demo HTML churn is not expected for routine dashboard UI changes.

```mermaid
flowchart LR
  A[npm run check] --> B[demo doctor]
  B --> C[generate showcase export in demo tmp]
  C --> D[trust checks]
  D --> E[version, showcase, leak, action-route, asset parity]
  A --> F[perfection benchmark]
  F --> G[docs, screenshot, demo ledger checks]
```

## How To Review

- Review `scripts/check.ts` first: `runDemoTrustCheck` now generates the temp export and validates that generated HTML.
- Review `scripts/perfection-benchmark.ts`: the docs/showcase item no longer reads `examples/demo-session/autoresearch-dashboard.html`.
- Review `tests/check-runner.test.ts` and `tests/perfection-benchmark.test.ts` for the generated-path guard, stale inline JS parity failure, and no-legacy-HTML regression guard.
- Review `docs/maintainers.md` and `CHANGELOG.md` for the new review/export expectation.

## Verification

- `npm run build:node` -> passed.
- `node --test dist/tests/perfection-benchmark.test.mjs` -> passed, 4/4 tests.
- `node --test dist/tests/check-runner.test.mjs` -> passed, 10/10 tests.
- `npm run check` -> passed; included `ok demo:export`, perfection benchmark `Passed: 30/30` with `METRIC quality_gap=0`, dashboard tests 105/105, core tests 272/272, `ok package-artifact`, and `ok package-runtime-smoke`.
- `git diff --check` from `plugins/codex-autoresearch` -> passed.

## Risk

- Low. The committed demo export is intentionally retained as a legacy fixture, but both demo trust and the product benchmark no longer use it as freshness/trust input.
- Remaining integration risk is CI environment drift around the existing export command; local `npm run check` exercised the generated export command end to end from the package root.