### PR TITLE
Validate command surface action metadata

### DIFF
--- a/plugins/codex-autoresearch/lib/action-metadata.ts
+++ b/plugins/codex-autoresearch/lib/action-metadata.ts
@@ -182,7 +182,7 @@ export const ACTION_METADATA: Record<string, ActionMetadata> = {
   watchdog: actionMetadata({
     label: "Inspect quiet window",
     commandLabel: "Inspect",
-    safeAction: "inspect",
+    safeAction: "state",
     fallbackKeys: ["finalizePreview", "liveDashboard", "doctor", "state"],
   }),
   finalization: actionMetadata({

--- a/plugins/codex-autoresearch/lib/dashboard-view-model.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.ts
@@ -2298,7 +2298,7 @@ function dashboardSafeActionOverride(
 ): string | null {
   if (kind === "stale-packet" && stalePacketCommand) return "";
   if (kind === "watchdog") {
-    return commandMap.get("finalize preview") ? "finalize-preview" : "inspect";
+    return commandMap.get("finalize preview") ? "finalize-preview" : "state";
   }
   return null;
 }

--- a/plugins/codex-autoresearch/scripts/command-surface-map.ts
+++ b/plugins/codex-autoresearch/scripts/command-surface-map.ts
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { ACTION_METADATA } from "../lib/action-metadata.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
+import { validateToolContracts } from "../lib/tool-contracts.js";
 import { toolSchemas } from "../lib/tool-schemas.js";
 import { toolRegistry } from "../lib/tool-registry.js";
 
@@ -34,6 +36,8 @@ type CommandSurfaceMap = {
   scans: SourceScan[];
   missingPublicReferences: string[];
   metadataIssues: string[];
+  contractIssues: string[];
+  actionMetadataIssues: string[];
   internalReferences: string[];
   argumentIssues: string[];
 };
@@ -85,6 +89,8 @@ export async function buildCommandSurfaceMap(): Promise<CommandSurfaceMap> {
   ]);
   const argumentIssues = await validateArgumentCoherence();
   const metadataIssues = validateRegistryMetadata(registry);
+  const contractIssues = validateToolContracts(toolSchemas).issues;
+  const actionMetadataIssues = validateActionMetadata(commandToEntry);
 
   const missingPublicReferences = scans
     .flatMap((scan) => {
@@ -99,11 +105,17 @@ export async function buildCommandSurfaceMap(): Promise<CommandSurfaceMap> {
     .concat(argumentIssues);
 
   return {
-    ok: missingPublicReferences.length === 0 && metadataIssues.length === 0,
+    ok:
+      missingPublicReferences.length === 0 &&
+      metadataIssues.length === 0 &&
+      contractIssues.length === 0 &&
+      actionMetadataIssues.length === 0,
     registry,
     scans,
     missingPublicReferences,
     metadataIssues,
+    contractIssues,
+    actionMetadataIssues,
     argumentIssues,
     internalReferences: registry
       .filter((entry) => entry.internal)
@@ -178,6 +190,30 @@ function validateRegistryMetadata(registry: RegistryEntry[]): string[] {
       }
       return issues;
     });
+}
+
+function validateActionMetadata(commandToEntry: Map<string, RegistryEntry>): string[] {
+  const issues: string[] = [];
+  for (const [kind, metadata] of Object.entries(ACTION_METADATA)) {
+    if (!metadata.label.trim()) issues.push(`${kind}: missing action label`);
+    if (!metadata.commandLabel.trim()) issues.push(`${kind}: missing command label`);
+    if (!metadata.safeAction.trim()) {
+      issues.push(`${kind}: missing safeAction`);
+    } else {
+      const entry = commandToEntry.get(metadata.safeAction);
+      if (!entry) {
+        issues.push(`${kind}: safeAction ${metadata.safeAction} is not a registered CLI command`);
+      } else if (!entry.public) {
+        issues.push(`${kind}: safeAction ${metadata.safeAction} references an internal command`);
+      }
+    }
+    if (!metadata.fallbackKeys.length) issues.push(`${kind}: missing fallback keys`);
+    const fallbackKeys = new Set(metadata.fallbackKeys);
+    if (fallbackKeys.size !== metadata.fallbackKeys.length) {
+      issues.push(`${kind}: duplicate fallback keys`);
+    }
+  }
+  return issues;
 }
 
 async function scanCommandSource({
@@ -293,6 +329,14 @@ export function formatCommandSurfaceMap(map: CommandSurfaceMap): string {
   lines.push(`metadata: missing=${map.metadataIssues.length}`);
   if (map.metadataIssues.length) {
     lines.push(`  metadata issues: ${map.metadataIssues.join(", ")}`);
+  }
+  lines.push(`contracts: issues=${map.contractIssues.length}`);
+  if (map.contractIssues.length) {
+    lines.push(`  contract issues: ${map.contractIssues.join(", ")}`);
+  }
+  lines.push(`action metadata: issues=${map.actionMetadataIssues.length}`);
+  if (map.actionMetadataIssues.length) {
+    lines.push(`  action metadata issues: ${map.actionMetadataIssues.join(", ")}`);
   }
   for (const scan of map.scans) {
     const missing = scan.missingCommands.length + scan.missingToolNames.length;

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -1376,6 +1376,7 @@ test("dashboard view model warns after a watchdog no-progress window", () => {
   assert.equal(viewModel.decisionEnvelope.watchdog.stale, true);
   assert.equal(viewModel.decisionEnvelopeSummary.kind, "watchdog");
   assert.match(viewModel.nextBestAction.detail, /Intervene|finalize|rescope/i);
+  assert.equal(viewModel.nextBestAction.safeAction, "state");
   assert.notEqual(viewModel.nextBestAction.safeAction, "next");
   assert.doesNotMatch(String(viewModel.nextBestAction.command || ""), /\bnext\b/);
   assert.match(viewModel.processHygiene.warnings.join("\n"), /Intervene|quiet/i);


### PR DESCRIPTION
## Context

Issue #163 tracks reducing drift across command/action policy surfaces. The #167 architecture research recommended a first behavior-preserving command-surface authority slice before any broad CLI extraction.

Refs #163

## What Changed

- Extended `scripts/command-surface-map.ts` so the command-surface gate also validates tool contracts and `ACTION_METADATA` labels/fallbacks/`safeAction` values against the registered public CLI commands.
- Corrected the watchdog action metadata from the unregistered `inspect` safe action to the registered read-only `state` action.
- Corrected the dashboard watchdog fallback override so the no-`finalize preview` path also emits the registered `state` safe action instead of `inspect`.
- Added a dashboard regression assertion for the no-command watchdog path.
- Kept runtime behavior and CLI dispatch stable; no broad `scripts/autoresearch.ts` rewrite and no #176 lane files touched.

```mermaid
flowchart LR
  R[tool-registry] --> M[command-surface-map]
  S[tool-schemas + contracts] --> M
  A[ACTION_METADATA] --> M
  H[help + handlers] --> M
  D[dashboard watchdog fallback] --> T[registered state action]
  M --> G[npm run command-surface-map]
```

## How To Review

- Start with `plugins/codex-autoresearch/scripts/command-surface-map.ts`, especially `validateActionMetadata` and the contract/action issue reporting.
- Review `plugins/codex-autoresearch/lib/action-metadata.ts` for the watchdog `safeAction` correction.
- Review `plugins/codex-autoresearch/lib/dashboard-view-model.ts` for the dashboard watchdog fallback correction.
- Review `plugins/codex-autoresearch/tests/dashboard-verification.test.ts` for the no-command watchdog regression assertion.
- Run `npm run command-surface-map` from `plugins/codex-autoresearch` to exercise the authority check.

## Verification

- `npm run command-surface-map` - passed; reported metadata/contracts/action metadata all zero issues.
- `npm run test:dashboard` - passed, 105 tests.
- `npm run test:core` - passed, 271 tests.
- `npm run check` - passed; includes typecheck, lint, format check, product gate, compiled tests, command-surface map, package artifact, and runtime smoke.
- `git diff --check` - passed.

## Risk

Low. This is primarily a validation-gate change plus registered safe-action corrections. The dashboard watchdog fallback command order remains behavior-preserving while its surfaced safe action now maps to a registered command. Installed marketplace runtime was not separately inspected; package smoke covered the source checkout artifact/runtime path.