### PR TITLE
Add repo-local session path resolver

### DIFF
--- a/plugins/codex-autoresearch/lib/commands/dashboard.ts
+++ b/plugins/codex-autoresearch/lib/commands/dashboard.ts
@@ -34,7 +34,7 @@ export interface DashboardCommandDeps {
   pluginRoot: string;
   pluginVersion: string;
   readJsonl: (workDir: string) => LooseObject[];
-  resolveOutputInside: (workDir: string, output: string) => string;
+  resolveOutputInside: (workDir: string, output?: string) => string;
   resolveWorkDir: (value: string) => { workDir: string; config: LooseObject; sessionCwd?: string };
   serveAutoresearch: (options: LooseObject) => Promise<LooseObject>;
   shellQuote: (value: string) => string;
@@ -138,7 +138,7 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
     emitProgress(args, "export", `reading session ledger from ${workDir}`);
     const entries = deps.readJsonl(workDir);
     if (entries.length === 0) throw new Error(`No autoresearch.jsonl found in ${workDir}`);
-    const output = deps.resolveOutputInside(workDir, args.output || "autoresearch-dashboard.html");
+    const output = deps.resolveOutputInside(workDir, args.output);
     const commands = deps.dashboardCommands(workDir);
     const generatedAt = new Date().toISOString();
     const showcaseExport = deps.boolOption(args.showcase ?? args.showcaseMode, false);

--- a/plugins/codex-autoresearch/lib/dashboard-server-registry.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-server-registry.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { type DashboardHealthSummary, verifyDashboardHealthSummary } from "./dashboard-health.js";
+import { resolveSessionPaths } from "./session-paths.js";
 
 type Liveness = "alive" | "dead" | "unknown";
 type CwdRelation = "same-cwd" | "different-cwd" | "unknown";
@@ -65,7 +66,11 @@ export function registryPathForWorkDir(workDir: string): string {
   const resolvedWorkDir = path.resolve(workDir);
   const gitDir = findGitDir(resolvedWorkDir);
   if (gitDir) return path.join(gitDir, "autoresearch", "serve-registry.json");
-  return path.join(resolvedWorkDir, "autoresearch.research", ".runtime", "serve-registry.json");
+  return path.join(
+    resolveSessionPaths({ workDir: resolvedWorkDir }).researchRoot,
+    ".runtime",
+    "serve-registry.json",
+  );
 }
 
 export async function readServeRegistry(

--- a/plugins/codex-autoresearch/lib/finalization-plan.ts
+++ b/plugins/codex-autoresearch/lib/finalization-plan.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
-import path from "node:path";
 import { productClaimCoverageFingerprintMaterial } from "./product-claim-coverage.js";
+import { jsonlPath } from "./session-records.js";
 
 export type LooseObject = Record<string, any>;
 
@@ -18,7 +18,7 @@ export async function readAutoresearchLedger(
   { mode = "silent-empty" }: { mode?: LedgerReadMode } = {},
 ): Promise<LooseObject[]> {
   try {
-    const text = await fsp.readFile(path.join(cwd, "autoresearch.jsonl"), "utf8");
+    const text = await fsp.readFile(jsonlPath(cwd), "utf8");
     return text
       .split(/\r?\n/)
       .map((line, index) => {

--- a/plugins/codex-autoresearch/lib/live-server.ts
+++ b/plugins/codex-autoresearch/lib/live-server.ts
@@ -7,6 +7,7 @@ import { createInterface } from "node:readline";
 import type { DashboardLedgerBounds } from "./dashboard-ledger-bounds.js";
 import { compactDashboardTransportViewModel } from "./dashboard-transport.js";
 import { redactEvidenceObject, redactEvidenceText } from "./evidence-redaction.js";
+import { resolveSessionPaths } from "./session-paths.js";
 
 type LooseObject = Record<string, unknown>;
 
@@ -93,7 +94,9 @@ export async function serveAutoresearch(args: LooseObject) {
           );
           return;
         }
-        const ledgerLines = await readBoundedLedgerLines(path.join(workDir, "autoresearch.jsonl"));
+        const ledgerLines = await readBoundedLedgerLines(
+          resolveSessionPaths({ workDir }).ledgerPath,
+        );
         send(
           res,
           200,
@@ -405,13 +408,14 @@ async function liveSessionSnapshot(
   ) {
     return { fingerprint: options.cached.fingerprint, stamp };
   }
+  const sessionPaths = resolveSessionPaths({ workDir });
   const parts = await Promise.all([
-    fingerprintPath(path.join(workDir, "autoresearch.jsonl"), "autoresearch.jsonl"),
-    fingerprintPath(path.join(workDir, "autoresearch.config.json"), "autoresearch.config.json"),
-    fingerprintPath(path.join(workDir, "autoresearch.last-run.json"), "autoresearch.last-run.json"),
-    fingerprintPath(path.join(workDir, "autoresearch.md"), "autoresearch.md"),
-    fingerprintPath(path.join(workDir, "autoresearch.ideas.md"), "autoresearch.ideas.md"),
-    fingerprintTree(path.join(workDir, "autoresearch.research"), "autoresearch.research"),
+    fingerprintPath(sessionPaths.ledgerPath, "autoresearch.jsonl"),
+    fingerprintPath(sessionPaths.configPath, "autoresearch.config.json"),
+    fingerprintPath(sessionPaths.lastRunFallbackPath, "autoresearch.last-run.json"),
+    fingerprintPath(sessionPaths.notesPath, "autoresearch.md"),
+    fingerprintPath(sessionPaths.ideasPath, "autoresearch.ideas.md"),
+    fingerprintTree(sessionPaths.researchRoot, "autoresearch.research"),
   ]);
   return { fingerprint: parts.join("|"), stamp };
 }
@@ -419,13 +423,14 @@ async function liveSessionSnapshot(
 async function liveSessionStamp(workDir: string): Promise<string> {
   // TTL-bounded dashboard reuse compares this stamp; a stale stamp can serve briefly
   // until the next health poll notices ledger/config drift.
+  const sessionPaths = resolveSessionPaths({ workDir });
   const parts = await Promise.all([
-    fingerprintPath(path.join(workDir, "autoresearch.jsonl"), "autoresearch.jsonl"),
-    fingerprintPath(path.join(workDir, "autoresearch.config.json"), "autoresearch.config.json"),
-    fingerprintPath(path.join(workDir, "autoresearch.last-run.json"), "autoresearch.last-run.json"),
-    fingerprintPath(path.join(workDir, "autoresearch.md"), "autoresearch.md"),
-    fingerprintPath(path.join(workDir, "autoresearch.ideas.md"), "autoresearch.ideas.md"),
-    fingerprintPath(path.join(workDir, "autoresearch.research"), "autoresearch.research"),
+    fingerprintPath(sessionPaths.ledgerPath, "autoresearch.jsonl"),
+    fingerprintPath(sessionPaths.configPath, "autoresearch.config.json"),
+    fingerprintPath(sessionPaths.lastRunFallbackPath, "autoresearch.last-run.json"),
+    fingerprintPath(sessionPaths.notesPath, "autoresearch.md"),
+    fingerprintPath(sessionPaths.ideasPath, "autoresearch.ideas.md"),
+    fingerprintPath(sessionPaths.researchRoot, "autoresearch.research"),
   ]);
   return parts.join("|");
 }
@@ -488,7 +493,7 @@ async function readRedactedLedgerEntries(
   workDir: string,
   context: LooseObject,
 ): Promise<LedgerReadout> {
-  const boundedLines = await readBoundedLedgerLines(path.join(workDir, "autoresearch.jsonl"));
+  const boundedLines = await readBoundedLedgerLines(resolveSessionPaths({ workDir }).ledgerPath);
   const parsedEntries = boundedLines.lines.flatMap((line) => {
     try {
       const entry = redactEvidenceObject(JSON.parse(line), context);

--- a/plugins/codex-autoresearch/lib/research-gaps.ts
+++ b/plugins/codex-autoresearch/lib/research-gaps.ts
@@ -7,8 +7,8 @@ import {
   parseQualityGaps,
   researchDirPath,
   safeSlug,
-  RESEARCH_DIR,
 } from "./session-core.js";
+import { resolveSessionPaths } from "./session-paths.js";
 
 const MAX_MODEL_CANDIDATES = 100;
 const MAX_CANDIDATE_TEXT_LENGTH = 1000;
@@ -133,7 +133,7 @@ export function resolveResearchSlugForQualityGapSync(
 }
 
 export function activeQualityGapSlugCandidatesSync(workDir = process.cwd()): SlugCandidate[] {
-  const researchRoot = path.join(path.resolve(workDir), RESEARCH_DIR);
+  const researchRoot = resolveSessionPaths({ workDir: path.resolve(workDir) }).researchRoot;
   if (!fs.existsSync(researchRoot)) return [];
   return fs
     .readdirSync(researchRoot, { withFileTypes: true })

--- a/plugins/codex-autoresearch/lib/research-path-guard.ts
+++ b/plugins/codex-autoresearch/lib/research-path-guard.ts
@@ -3,7 +3,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 
 import { isPathInside } from "./path-containment.js";
-import { RESEARCH_DIR } from "./session-core.js";
+import { AUTORESEARCH_RESEARCH_DIR, resolveSessionPaths } from "./session-paths.js";
 
 export interface SafeResearchPath {
   root: string;
@@ -41,7 +41,7 @@ export async function resolveSafeResearchPath(
 ): Promise<SafeResearchPath> {
   const workDir = path.resolve(cwd || process.cwd());
   const safeSlug = validateResearchSlug(slug);
-  const root = path.join(workDir, RESEARCH_DIR);
+  const root = resolveSessionPaths({ workDir }).researchRoot;
   const outputDir = path.join(root, safeSlug);
   await assertInsideResearchRoot(root, outputDir);
   return { root, slug: safeSlug, outputDir };
@@ -53,7 +53,7 @@ export async function assertInsideResearchRoot(root: string, target: string): Pr
   const rootReal = await realPathForTarget(resolvedRoot);
   const targetReal = await realPathForTarget(resolvedTarget);
   if (!isPathInside(rootReal, targetReal)) {
-    throw new Error(`target path escapes ${RESEARCH_DIR}: ${target}`);
+    throw new Error(`target path escapes ${AUTORESEARCH_RESEARCH_DIR}: ${target}`);
   }
 }
 

--- a/plugins/codex-autoresearch/lib/session-core.ts
+++ b/plugins/codex-autoresearch/lib/session-core.ts
@@ -26,6 +26,11 @@ import {
   refreshSessionReadCacheForLedgerStamp,
   type SessionReadCache,
 } from "./session-records.js";
+import {
+  AUTORESEARCH_RESEARCH_DIR,
+  researchDirPathForSession,
+  resolveSessionPaths,
+} from "./session-paths.js";
 
 export {
   appendJsonl,
@@ -51,7 +56,7 @@ export {
   isRejectedRunStatus,
   normalizeRunStatus,
 } from "./run-status.js";
-export const RESEARCH_DIR = "autoresearch.research";
+export const RESEARCH_DIR = AUTORESEARCH_RESEARCH_DIR;
 type LooseObject = Record<string, any>;
 type Direction = "lower" | "higher";
 type RunRecord = LooseObject & {
@@ -129,7 +134,7 @@ export async function pathExists(filePath: string): Promise<boolean> {
 }
 
 export function readConfig(sessionCwd: string): LooseObject {
-  const configPath = path.join(sessionCwd, "autoresearch.config.json");
+  const configPath = resolveSessionPaths({ sessionCwd, workDir: sessionCwd }).configPath;
   if (!fs.existsSync(configPath)) return {};
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
 }
@@ -1359,5 +1364,5 @@ export function researchSlugFromArgs(args: LooseObject): string {
 }
 
 export function researchDirPath(workDir: string, slug: string): string {
-  return path.join(workDir, RESEARCH_DIR, slug);
+  return researchDirPathForSession(workDir, slug);
 }

--- a/plugins/codex-autoresearch/lib/session-decision-capsule.ts
+++ b/plugins/codex-autoresearch/lib/session-decision-capsule.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { resolveSessionPaths } from "./session-paths.js";
+
 type LooseObject = Record<string, any>;
 
 export const SESSION_DECISION_CAPSULE_SCHEMA_VERSION = 1;
 export const SESSION_DECISION_CAPSULE_KIND = "session-decision-capsule";
-const RESEARCH_DIR = "autoresearch.research";
 
 export type SessionDecisionSeverity = "info" | "warning" | "blocker";
 export type SessionDecisionEnforcementMode = "advisory" | "bounded-next" | "hard-block";
@@ -676,7 +677,7 @@ export function readActiveSessionDecisionCapsule(
   workDir: string,
   entries: LooseObject[] = [],
 ): SessionDecisionCapsule | null {
-  const researchRoot = path.join(path.resolve(workDir), RESEARCH_DIR);
+  const researchRoot = resolveSessionPaths({ workDir }).researchRoot;
   if (!fs.existsSync(researchRoot)) return null;
   const capsules: SessionDecisionCapsule[] = [];
   for (const entry of fs.readdirSync(researchRoot, { withFileTypes: true })) {

--- a/plugins/codex-autoresearch/lib/session-paths.ts
+++ b/plugins/codex-autoresearch/lib/session-paths.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+
+export const AUTORESEARCH_LEDGER_FILE = "autoresearch.jsonl";
+export const AUTORESEARCH_CONFIG_FILE = "autoresearch.config.json";
+export const AUTORESEARCH_NOTES_FILE = "autoresearch.md";
+export const AUTORESEARCH_IDEAS_FILE = "autoresearch.ideas.md";
+export const AUTORESEARCH_DASHBOARD_FILE = "autoresearch-dashboard.html";
+export const AUTORESEARCH_LAST_RUN_FILE = "autoresearch.last-run.json";
+export const AUTORESEARCH_PROGRESS_FILE = "autoresearch.progress.json";
+export const AUTORESEARCH_PENDING_TRANSACTION_FILE = "autoresearch.pending-transaction.json";
+export const AUTORESEARCH_RESEARCH_DIR = "autoresearch.research";
+
+export const AUTORESEARCH_SESSION_FILES = [
+  AUTORESEARCH_LEDGER_FILE,
+  AUTORESEARCH_NOTES_FILE,
+  AUTORESEARCH_IDEAS_FILE,
+  "autoresearch.sh",
+  "autoresearch.ps1",
+  "autoresearch.checks.sh",
+  "autoresearch.checks.ps1",
+  AUTORESEARCH_CONFIG_FILE,
+  AUTORESEARCH_LAST_RUN_FILE,
+  AUTORESEARCH_PENDING_TRANSACTION_FILE,
+] as const;
+
+export type SessionStorageMode = "repo";
+
+export interface ResolveSessionPathsInput {
+  cwd?: string;
+  sessionCwd?: string;
+  workDir?: string;
+}
+
+export interface SessionPaths {
+  mode: SessionStorageMode;
+  targetCwd: string;
+  sessionCwd: string;
+  sessionDir: string;
+  ledgerPath: string;
+  configPath: string;
+  notesPath: string;
+  ideasPath: string;
+  researchRoot: string;
+  dashboardExportPath: string;
+  lastRunFallbackPath: string;
+  progressFallbackPath: string;
+  pendingLogTransactionFallbackPath: string;
+  sessionFilePaths: string[];
+  clearTargets: string[];
+}
+
+export function resolveSessionPaths(input: ResolveSessionPathsInput = {}): SessionPaths {
+  const targetCwd = path.resolve(input.workDir || input.cwd || input.sessionCwd || process.cwd());
+  const sessionCwd = path.resolve(input.sessionCwd || targetCwd);
+  const sessionDir = targetCwd;
+  const sessionFilePaths = AUTORESEARCH_SESSION_FILES.map((fileName) =>
+    path.join(sessionDir, fileName),
+  );
+  const configPath = path.join(sessionCwd, AUTORESEARCH_CONFIG_FILE);
+  const researchRoot = path.join(sessionDir, AUTORESEARCH_RESEARCH_DIR);
+  const dashboardExportPath = path.join(sessionDir, AUTORESEARCH_DASHBOARD_FILE);
+  return {
+    mode: "repo",
+    targetCwd,
+    sessionCwd,
+    sessionDir,
+    ledgerPath: path.join(sessionDir, AUTORESEARCH_LEDGER_FILE),
+    configPath,
+    notesPath: path.join(sessionDir, AUTORESEARCH_NOTES_FILE),
+    ideasPath: path.join(sessionDir, AUTORESEARCH_IDEAS_FILE),
+    researchRoot,
+    dashboardExportPath,
+    lastRunFallbackPath: path.join(sessionDir, AUTORESEARCH_LAST_RUN_FILE),
+    progressFallbackPath: path.join(sessionDir, AUTORESEARCH_PROGRESS_FILE),
+    pendingLogTransactionFallbackPath: path.join(sessionDir, AUTORESEARCH_PENDING_TRANSACTION_FILE),
+    sessionFilePaths,
+    clearTargets: [...sessionFilePaths, researchRoot, dashboardExportPath, configPath],
+  };
+}
+
+export function researchDirPathForSession(workDir: string, slug: string): string {
+  return path.join(resolveSessionPaths({ workDir }).researchRoot, slug);
+}

--- a/plugins/codex-autoresearch/lib/session-records.ts
+++ b/plugins/codex-autoresearch/lib/session-records.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 
+import { resolveSessionPaths } from "./session-paths.js";
 import type { UnknownRecord } from "./types/json.js";
 
 export type SessionRecord = UnknownRecord & Record<string, any>;
@@ -25,7 +26,7 @@ export function createSessionReadCache(
 }
 
 export function jsonlPath(workDir: string): string {
-  return path.join(workDir, "autoresearch.jsonl");
+  return resolveSessionPaths({ workDir }).ledgerPath;
 }
 
 export function appendJsonl(workDir: string, entry: UnknownRecord): void {

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -191,11 +191,20 @@ import { analyzeWorkflowFriction } from "../lib/workflow-friction.js";
 import { resolvePackageRoot, resolveRepoRoot } from "../lib/runtime-paths.js";
 import { PLUGIN_VERSION } from "../lib/plugin-version.js";
 import { isBoundedNextAllowedByCapsule } from "../lib/session-decision-capsule.js";
+import {
+  AUTORESEARCH_DASHBOARD_FILE,
+  AUTORESEARCH_RESEARCH_DIR,
+  AUTORESEARCH_SESSION_FILES,
+  researchDirPathForSession,
+  resolveSessionPaths,
+  type SessionPaths,
+} from "../lib/session-paths.js";
 import { indexTaskArtifacts } from "../lib/task-artifact-indexer.js";
 
 type LooseObject = Record<string, any>;
 type WorkDirResolution = {
   config: LooseObject;
+  sessionPaths: SessionPaths;
   sessionCwd: string;
   workDir: string;
 };
@@ -221,26 +230,15 @@ interface LocalProcessResult {
   stdout: string;
 }
 
-const SESSION_FILES = [
-  "autoresearch.jsonl",
-  "autoresearch.md",
-  "autoresearch.ideas.md",
-  "autoresearch.sh",
-  "autoresearch.ps1",
-  "autoresearch.checks.sh",
-  "autoresearch.checks.ps1",
-  "autoresearch.config.json",
-  "autoresearch.last-run.json",
-  "autoresearch.pending-transaction.json",
-];
+const SESSION_FILES: readonly string[] = AUTORESEARCH_SESSION_FILES;
 const AUTORESEARCH_GITATTRIBUTES_BLOCK = [
   "# Codex Autoresearch ledger files",
   "autoresearch.jsonl text eol=lf",
   "autoresearch.md text eol=lf",
   "autoresearch.ideas.md text eol=lf",
 ].join("\n");
-const RESEARCH_DIR = "autoresearch.research";
-const AUTORESEARCH_OWNED_FILES = ["autoresearch-dashboard.html"];
+const RESEARCH_DIR = AUTORESEARCH_RESEARCH_DIR;
+const AUTORESEARCH_OWNED_FILES = [AUTORESEARCH_DASHBOARD_FILE];
 const AUTORESEARCH_OWNED_DIRS = [RESEARCH_DIR, "target/autoresearch", ".autoresearch-cache"];
 
 const AUTONOMY_MODES = new Set(["guarded", "owner-autonomous", "manual"]);
@@ -267,7 +265,6 @@ const REPO_ROOT = resolveRepoRoot(import.meta.url);
 const EMPTY_COMMIT_PATHS_WARNING_CODE = "empty_commit_paths_in_git_repo";
 const PENDING_LOG_TRANSACTION_CODE = "pending_log_transaction";
 const PENDING_LOG_TRANSACTION_GIT_PATH = "autoresearch/pending-log-transaction.json";
-const PENDING_LOG_TRANSACTION_FALLBACK_FILE = "autoresearch.pending-transaction.json";
 const DASHBOARD_GUIDANCE_EXTRA_DROP_FIELDS = new Set([
   "runtimeDriftSummary",
   "gateQuality",
@@ -431,8 +428,11 @@ function normalizeRelativePaths(paths: unknown, optionName: string = "paths"): s
   });
 }
 
-function resolveOutputInside(workDir: string, output: string) {
-  const resolved = resolvePathInsideRootSync(workDir, output || "autoresearch-dashboard.html");
+function resolveOutputInside(workDir: string, output?: string) {
+  const defaultOutput = resolveSessionPaths({ workDir }).dashboardExportPath;
+  const resolved = output
+    ? resolvePathInsideRootSync(workDir, output)
+    : { absolutePath: defaultOutput, inside: true, relativePath: AUTORESEARCH_DASHBOARD_FILE };
   if (!resolved.inside) {
     throw new Error(`Dashboard output is outside the working directory: ${resolved.absolutePath}`);
   }
@@ -461,13 +461,13 @@ function isMissingPathError(error: unknown): boolean {
 }
 
 function readConfig(sessionCwd: string): LooseObject {
-  const configPath = path.join(sessionCwd, "autoresearch.config.json");
+  const configPath = resolveSessionPaths({ sessionCwd, workDir: sessionCwd }).configPath;
   if (!fs.existsSync(configPath)) return {};
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
 }
 
 function runtimeConfigPath(sessionCwd: string): string {
-  return path.join(sessionCwd, "autoresearch.config.json");
+  return resolveSessionPaths({ sessionCwd, workDir: sessionCwd }).configPath;
 }
 
 function resolveWorkDir(cwdArg: unknown): WorkDirResolution {
@@ -479,7 +479,12 @@ function resolveWorkDir(cwdArg: unknown): WorkDirResolution {
   if (!fs.existsSync(workDir) || !fs.statSync(workDir).isDirectory()) {
     throw new Error(`Working directory does not exist: ${workDir}`);
   }
-  return { sessionCwd, workDir, config };
+  return {
+    sessionCwd,
+    workDir,
+    config,
+    sessionPaths: resolveSessionPaths({ sessionCwd, workDir }),
+  };
 }
 
 function assetPath(fileName: string) {
@@ -3171,7 +3176,7 @@ function researchRelativeDir(slug: string) {
 }
 
 function researchDirPath(workDir: string, slug: string) {
-  return path.join(workDir, RESEARCH_DIR, slug);
+  return researchDirPathForSession(workDir, slug);
 }
 
 function renderResearchBenchmarkScript(slug: string, shellKind: string) {
@@ -3671,7 +3676,7 @@ async function gitPrivatePath(cwd: string, relativePath: string) {
 }
 
 function fallbackPendingLogTransactionPath(workDir: string) {
-  return path.join(workDir, PENDING_LOG_TRANSACTION_FALLBACK_FILE);
+  return resolveSessionPaths({ workDir }).pendingLogTransactionFallbackPath;
 }
 
 async function pendingLogTransactionPath(workDir: string, inGit?: boolean) {
@@ -3706,7 +3711,7 @@ async function writePendingLogTransaction(workDir: string, inGit: boolean, recei
         version: 1,
         createdAt: new Date().toISOString(),
         workDir,
-        ledgerPath: path.join(workDir, "autoresearch.jsonl"),
+        ledgerPath: resolveSessionPaths({ workDir }).ledgerPath,
         ...receipt,
       },
       null,
@@ -6228,14 +6233,8 @@ async function clearSession(args: any) {
   if (!dryRun && !boolOption(args.confirm ?? args.yes, false)) {
     throw new Error("clear requires --yes for CLI confirmation");
   }
-  const { sessionCwd, workDir } = resolveWorkDir(args.working_dir || args.cwd);
-  const targets = new Set([
-    ...SESSION_FILES.map((file: any) => path.join(workDir, file)),
-    await resolveLastRunPath(workDir),
-    path.join(workDir, RESEARCH_DIR),
-    path.join(workDir, "autoresearch-dashboard.html"),
-    path.join(sessionCwd, "autoresearch.config.json"),
-  ]);
+  const { sessionCwd, workDir, sessionPaths } = resolveWorkDir(args.working_dir || args.cwd);
+  const targets = new Set([...sessionPaths.clearTargets, await resolveLastRunPath(workDir)]);
   const deleted = [];
   const wouldDelete = [];
   const missing = [];
@@ -6267,14 +6266,14 @@ async function resolveLastRunPath(workDir: string) {
   if (await insideGitRepo(workDir)) {
     return await gitPrivatePath(workDir, "autoresearch/last-run.json");
   }
-  return path.join(workDir, "autoresearch.last-run.json");
+  return resolveSessionPaths({ workDir }).lastRunFallbackPath;
 }
 
 async function resolveProgressPath(workDir: string) {
   if (await insideGitRepo(workDir)) {
     return await gitPrivatePath(workDir, "autoresearch/progress.json");
   }
-  return path.join(workDir, "autoresearch.progress.json");
+  return resolveSessionPaths({ workDir }).progressFallbackPath;
 }
 
 async function writeLastRunPacket(workDir: string, packet: any, filePath: string | null = null) {
@@ -6610,7 +6609,7 @@ function looksLikeProcessEvidence(value: LooseObject): boolean {
 
 async function readLastRunPacket(workDir: string) {
   const filePath = await resolveLastRunPath(workDir);
-  const legacyPath = path.join(workDir, "autoresearch.last-run.json");
+  const legacyPath = resolveSessionPaths({ workDir }).lastRunFallbackPath;
   const readablePath = fs.existsSync(filePath) ? filePath : legacyPath;
   if (!fs.existsSync(readablePath))
     throw new Error(
@@ -6625,7 +6624,7 @@ async function readLastRunPacket(workDir: string) {
 
 async function lastRunPacketFingerprint(workDir: string) {
   const filePath = await resolveLastRunPath(workDir);
-  const legacyPath = path.join(workDir, "autoresearch.last-run.json");
+  const legacyPath = resolveSessionPaths({ workDir }).lastRunFallbackPath;
   const readablePath = fs.existsSync(filePath) ? filePath : legacyPath;
   if (!fs.existsSync(readablePath)) return "";
   return createHash("sha256").update(fs.readFileSync(readablePath, "utf8")).digest("hex");
@@ -6805,7 +6804,7 @@ function lastRunConfigSnapshot(config: LooseObject = {}) {
 
 async function deleteLastRunPacket(workDir: string) {
   const filePath = await resolveLastRunPath(workDir);
-  const legacyPath = path.join(workDir, "autoresearch.last-run.json");
+  const legacyPath = resolveSessionPaths({ workDir }).lastRunFallbackPath;
   for (const target of new Set([filePath, legacyPath])) {
     await fsp.rm(target, { force: true }).catch(() => {});
   }

--- a/plugins/codex-autoresearch/tests/session-control-plane.test.ts
+++ b/plugins/codex-autoresearch/tests/session-control-plane.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
@@ -10,6 +10,7 @@ import {
   resolveApproval,
 } from "../lib/approval-ledger.js";
 import { classifyEvidenceMaturity } from "../lib/evidence-maturity.js";
+import { registryPathForWorkDir } from "../lib/dashboard-server-registry.js";
 import {
   fixedControlStateSummary,
   fixedControlViolationForCommand,
@@ -21,7 +22,10 @@ import { planFailureRecoveryLanes } from "../lib/lane-orchestration-controller.j
 import { buildLoopContractStatus } from "../lib/loop-governance.js";
 import { buildOperatorReadout } from "../lib/operator-readout.js";
 import { buildResourcePreflight } from "../lib/process-governor.js";
+import { resolveSafeResearchPath } from "../lib/research-path-guard.js";
+import { appendJsonl, jsonlPath, readJsonl } from "../lib/session-records.js";
 import { parseSessionForensics } from "../lib/session-forensics.js";
+import { resolveSessionPaths } from "../lib/session-paths.js";
 import {
   codeStoryLanguageSupportFrictionFixtureEntries,
   fixtureJsonl,
@@ -31,6 +35,78 @@ import { withTempDir as withNamedTempDir } from "./helpers/process.js";
 
 const withTempDir = (name: string, fn: (dir: string) => Promise<void>) =>
   withNamedTempDir("autoresearch-control-plane", name, fn);
+
+test("session path resolver preserves repo-local defaults", async () => {
+  await withTempDir("session-paths-repo-defaults", async (dir) => {
+    const sessionCwd = path.join(dir, "session-cwd");
+    const workDir = path.join(dir, "target");
+    const paths = resolveSessionPaths({ sessionCwd, workDir });
+
+    assert.equal(paths.mode, "repo");
+    assert.equal(paths.targetCwd, path.resolve(workDir));
+    assert.equal(paths.sessionCwd, path.resolve(sessionCwd));
+    assert.equal(paths.sessionDir, path.resolve(workDir));
+    assert.equal(paths.ledgerPath, path.join(workDir, "autoresearch.jsonl"));
+    assert.equal(paths.configPath, path.join(sessionCwd, "autoresearch.config.json"));
+    assert.equal(paths.notesPath, path.join(workDir, "autoresearch.md"));
+    assert.equal(paths.ideasPath, path.join(workDir, "autoresearch.ideas.md"));
+    assert.equal(paths.researchRoot, path.join(workDir, "autoresearch.research"));
+    assert.equal(paths.dashboardExportPath, path.join(workDir, "autoresearch-dashboard.html"));
+    assert.equal(paths.lastRunFallbackPath, path.join(workDir, "autoresearch.last-run.json"));
+    assert.equal(paths.progressFallbackPath, path.join(workDir, "autoresearch.progress.json"));
+    assert.equal(
+      paths.pendingLogTransactionFallbackPath,
+      path.join(workDir, "autoresearch.pending-transaction.json"),
+    );
+    assert.ok(paths.clearTargets.includes(path.join(workDir, "autoresearch.config.json")));
+    assert.ok(paths.clearTargets.includes(path.join(sessionCwd, "autoresearch.config.json")));
+  });
+});
+
+test("session record ledger helpers use the repo-local resolver path", async () => {
+  await withTempDir("session-paths-ledger", async (dir) => {
+    const paths = resolveSessionPaths({ workDir: dir });
+
+    assert.equal(jsonlPath(dir), paths.ledgerPath);
+    appendJsonl(dir, { type: "config", metricName: "score", bestDirection: "higher" });
+
+    assert.deepEqual(readJsonl(dir), [
+      { type: "config", metricName: "score", bestDirection: "higher" },
+    ]);
+  });
+});
+
+test("research path guard roots scratchpads through the repo-local resolver", async () => {
+  await withTempDir("session-paths-research", async (dir) => {
+    const paths = resolveSessionPaths({ workDir: dir });
+    const researchPath = await resolveSafeResearchPath(dir, "project-study");
+
+    assert.equal(researchPath.root, paths.researchRoot);
+    assert.equal(researchPath.outputDir, path.join(paths.researchRoot, "project-study"));
+  });
+});
+
+test("dashboard serve registry keeps Git-private storage and uses repo-local fallback", async () => {
+  await withTempDir("session-paths-dashboard-registry", async (dir) => {
+    const nonGit = path.join(dir, "plain");
+    const gitRepo = path.join(dir, "repo");
+    await mkdir(nonGit, { recursive: true });
+    await mkdir(path.join(gitRepo, ".git"), { recursive: true });
+
+    assert.equal(
+      registryPathForWorkDir(nonGit),
+      path.join(
+        resolveSessionPaths({ workDir: nonGit }).researchRoot,
+        ".runtime",
+        "serve-registry.json",
+      ),
+    );
+    assert.equal(
+      registryPathForWorkDir(gitRepo),
+      path.join(gitRepo, ".git", "autoresearch", "serve-registry.json"),
+    );
+  });
+});
 
 test("fixed control config normalizes command patterns and invalidators", () => {
   const fixedControl = normalizeFixedControlConfig({


### PR DESCRIPTION
## Context

Refs #183

This is the first implementation slice from #182: add a typed session path resolver while preserving the current repo-local default behavior. It deliberately does not add external defaults, migration commands, state-root settings, or a behavior flip.

## What Changed

- Added `lib/session-paths.ts` with a typed `SessionPaths` resolver in repo mode.
- Routed central repo-local session consumers through the resolver where practical for this slice:
  - ledger path helpers
  - config path helpers
  - research root/path guard and quality-gap discovery
  - dashboard export default path dependency
  - live dashboard ledger/fingerprint paths
  - dashboard serve registry non-Git fallback
  - finalization ledger read path
  - CLI clear targets, pending-log fallback metadata, and non-Git last-run/progress fallbacks
- Preserved Git-private behavior for `.git/autoresearch/*` last-run/progress/pending-log and serve-registry paths.
- Added focused resolver/routed-consumer tests in `tests/session-control-plane.test.ts`.

## How To Review

1. Start with `plugins/codex-autoresearch/lib/session-paths.ts` for the new repo-mode contract.
2. Check `plugins/codex-autoresearch/scripts/autoresearch.ts` for CLI routing without command-surface changes.
3. Review the small library call-site changes to confirm they now use `resolveSessionPaths` or existing wrappers.
4. Confirm no dashboard UI/generated surfaces are included in the diff.

```mermaid
flowchart TD
  CWD[--cwd target] --> R[resolveSessionPaths]
  R --> L[repo-local ledger/config/research/export fallbacks]
  R --> D[live/export/read helpers]
  G[Git repo] --> P[.git/autoresearch recovery paths]
  P -. preserved .-> D
```

## Verification

Post-rebase on `origin/dev`:

- `npm run typecheck:node` - passed
- `npm run build:node` - passed
- `node --test dist\\tests\\session-control-plane.test.mjs` - passed, 24/24
- `node --test --test-name-pattern 'next writes a reusable last-run packet and log can consume it|last-run packet does not dirty git worktrees before discard logging|clear dry-run previews deletion targets without removing files|static export does not call a same-process registry a live dashboard without HTTP health' dist\\tests\\autoresearch-cli.test.mjs` - passed, 4/4
- `git diff --check origin/dev...HEAD` - passed
- `npm run check` - started post-rebase and had passed lint, format check, node/dashboard typecheck, build:node, source hygiene, dashboard build/normalization/parity, demo trust, product/perfection benchmark, command-surface map, help checks, and several compiled CLI shards when coordinator requested immediate PR publication

Before the final rebase, the same diff also completed a full `npm run check` successfully, including compiled CLI/dashboard/finalize/core tests plus package artifact and runtime smoke.

## Risk

- Behavior should remain repo-local by construction; external session storage is intentionally deferred.
- Some consumers still carry user-facing literal names or source-hygiene/finalization artifact classification strings; those are not storage routing points for this slice.
- The post-rebase full `npm run check` was interrupted for immediate PR publication after the already-passing stages listed above; rerun it in CI or locally before undrafting.
