### PR TITLE
Prove packaged dashboard assets at runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,16 @@ jobs:
           tar -xzf "$tarball" -C "$RUNNER_TEMP/codex-autoresearch-release"
           node "$RUNNER_TEMP/codex-autoresearch-release/package/scripts/autoresearch.mjs" --help
           node "$RUNNER_TEMP/codex-autoresearch-release/package/scripts/finalize-autoresearch.mjs" --help
+          mkdir -p "$RUNNER_TEMP/codex-autoresearch-dashboard-smoke"
+          printf '%s\n' \
+            '{"type":"config","name":"release dashboard smoke","metricName":"quality_gap","metricUnit":"gaps","bestDirection":"lower"}' \
+            '{"type":"run","run":1,"status":"measure","metric":1,"description":"Release dashboard export smoke."}' \
+            > "$RUNNER_TEMP/codex-autoresearch-dashboard-smoke/autoresearch.jsonl"
+          node "$RUNNER_TEMP/codex-autoresearch-release/package/scripts/autoresearch.mjs" export \
+            --cwd "$RUNNER_TEMP/codex-autoresearch-dashboard-smoke" \
+            --output dashboard-smoke.html
+          grep -q 'id="dashboard-root"' "$RUNNER_TEMP/codex-autoresearch-dashboard-smoke/dashboard-smoke.html"
+          grep -q 'release dashboard smoke' "$RUNNER_TEMP/codex-autoresearch-dashboard-smoke/dashboard-smoke.html"
 
       - name: Create GitHub release with tarball
         env:

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -90,6 +90,15 @@ node scripts/autoresearch.mjs export --cwd examples/demo-session --output autore
 
 Before publishing, inspect the package artifact itself. Use dry-run pack output
 for routine review, then create and extract a real tarball for release smoke.
+Dashboard runtime assets are package output. `prepack`, `npm run check`, and
+the release workflow must build `assets/dashboard-build/dashboard-app.js` and
+`assets/dashboard-build/dashboard-app.css` before `npm pack`. The source
+checkout keeps failing clearly if those files are absent: run
+`npm run build:dashboard` from `plugins/codex-autoresearch` before serving or
+exporting dashboards. Package checks must assert both dashboard assets are in
+the tarball and smoke an extracted-package dashboard export, not just launcher
+help.
+
 The shipped `scripts/*.mjs` shims depend on `dist/`, but `dist/` is generated
 and ignored in the Git tree. If a Git marketplace source checkout is missing
 `dist/`, the CLI launcher calls `scripts/bootstrap-runtime.mjs` to download the
@@ -99,7 +108,8 @@ exact tarball, verify the packaged name/version, and only then extract `dist/`
 into the plugin cache before importing the runtime. A publishable release
 tarball must include the built runtime, publish the adjacent checksum asset,
 exclude authored source and tests, ship no MCP launcher/config, and pass
-`node <extracted-package>/scripts/autoresearch.mjs --help`.
+`node <extracted-package>/scripts/autoresearch.mjs --help` plus an extracted
+package dashboard export smoke.
 
 Do not push release tags by hand. After a synchronized version bump lands on `main`, the `Auto Release` GitHub Actions workflow compares the previous and current package versions and calls the reusable `Release` workflow when the package version changed. The release workflow still runs the checks, builds and smoke-tests the tarball, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. Use manual `Release` dispatch only as an explicit recovery path with the package version. This keeps update clients on the previous release until the new install artifact exists.
 

--- a/plugins/codex-autoresearch/lib/dashboard-transport.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-transport.ts
@@ -137,14 +137,19 @@ function boundDashboardStaticExportEntries(entries: LooseObject[]): {
   );
 }
 
-function readDashboardBuildAsset(fileName: string) {
-  const filePath = path.join(DASHBOARD_BUILD_DIR, fileName);
+export function readDashboardBuildAsset(
+  fileName: string,
+  options: { buildDir?: string; pluginRoot?: string } = {},
+) {
+  const buildDir = options.buildDir || DASHBOARD_BUILD_DIR;
+  const pluginRoot = options.pluginRoot || PLUGIN_ROOT;
+  const filePath = path.join(buildDir, fileName);
   try {
     return fs.readFileSync(filePath, "utf8");
   } catch (error) {
     if (error && typeof error === "object" && (error as { code?: unknown }).code === "ENOENT") {
       throw new Error(
-        `Dashboard build asset is missing: ${filePath}. Run npm run build:dashboard from ${PLUGIN_ROOT}.`,
+        `Dashboard build asset is missing: ${filePath}. Run npm run build:dashboard from ${pluginRoot}.`,
       );
     }
     throw error;

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -45,6 +45,7 @@
     "format": "oxfmt --write --no-error-on-unmatched-pattern dashboard/src lib scripts tests vite.dashboard.config.ts tsconfig.json tsconfig.node.json tsconfig.dashboard.json tsdown.config.ts package.json",
     "format:check": "oxfmt --check --no-error-on-unmatched-pattern dashboard/src lib scripts tests vite.dashboard.config.ts tsconfig.json tsconfig.node.json tsconfig.dashboard.json tsdown.config.ts package.json",
     "prepare": "npm run build:node",
+    "prepack": "npm run build",
     "test": "run-s build:node test:compiled",
     "test:compiled": "run-s test:compiled:cli test:compiled:dashboard test:compiled:finalize test:compiled:core",
     "test:compiled:cli": "node dist/scripts/run-test-shards.mjs --jobs 4 dist/tests/autoresearch-cli.test.mjs 24 dist/tests/full-product.test.mjs 4 dist/tests/perfection-benchmark.test.mjs 1",

--- a/plugins/codex-autoresearch/scripts/check.ts
+++ b/plugins/codex-autoresearch/scripts/check.ts
@@ -287,6 +287,7 @@ async function runPackageArtifactCheck() {
     const requiredPaths = [
       ".codex-plugin/plugin.json",
       "assets/dashboard-build/dashboard-app.js",
+      "assets/dashboard-build/dashboard-app.css",
       "docs/index.md",
       "dist/lib/runtime-paths.mjs",
       "dist/lib/tool-schemas.mjs",
@@ -972,6 +973,7 @@ async function runPackedRuntimeSmokeCheck(packInfo: PackageManifest | undefined,
 }
 
 async function runPackageSmokeCommands(extractDir: string) {
+  const packageDir = path.join(extractDir, "package");
   const commands = [
     {
       label: "autoresearch",
@@ -991,7 +993,7 @@ async function runPackageSmokeCommands(extractDir: string) {
     const result = await runCommand([
       `package-runtime-smoke:${command.label}`,
       node,
-      [path.join(extractDir, "package", "scripts", command.script), ...command.args],
+      [path.join(packageDir, "scripts", command.script), ...command.args],
     ]);
     if (result.code !== 0) {
       const output = `${result.stdout}${result.stderr}`.trim();
@@ -1006,7 +1008,84 @@ async function runPackageSmokeCommands(extractDir: string) {
     }
   }
 
+  const dashboardSmoke = await runExtractedPackageDashboardExportSmoke(packageDir, extractDir);
+  if (!dashboardSmoke.ok) return dashboardSmoke;
+
   return { ok: true, error: "" };
+}
+
+async function runExtractedPackageDashboardExportSmoke(packageDir: string, extractDir: string) {
+  const smokeDir = path.join(extractDir, "dashboard-smoke");
+  const outputName = "dashboard-smoke.html";
+  const outputPath = path.join(smokeDir, outputName);
+  await fsp.mkdir(smokeDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(smokeDir, "autoresearch.jsonl"),
+    [
+      JSON.stringify({
+        type: "config",
+        name: "package dashboard smoke",
+        metricName: "quality_gap",
+        metricUnit: "gaps",
+        bestDirection: "lower",
+      }),
+      JSON.stringify({
+        type: "run",
+        run: 1,
+        status: "measure",
+        metric: 1,
+        description: "Packaged dashboard export smoke.",
+      }),
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runCommand([
+    "package-runtime-smoke:dashboard-export",
+    node,
+    [
+      path.join(packageDir, "scripts", "autoresearch.mjs"),
+      "export",
+      "--cwd",
+      smokeDir,
+      "--output",
+      outputName,
+    ],
+  ]);
+  if (result.code !== 0) {
+    const output = `${result.stdout}${result.stderr}`.trim();
+    return { ok: false, error: output || "dashboard export smoke failed." };
+  }
+
+  let html = "";
+  try {
+    html = await fsp.readFile(outputPath, "utf8");
+  } catch (error) {
+    return { ok: false, error: `dashboard export smoke did not write ${outputPath}: ${error}` };
+  }
+
+  const assets = await readPackageDashboardExportAssets(packageDir);
+  const assetIssues = dashboardExportAssetIssues(html, assets);
+  const markerIssues = [
+    html.includes("package dashboard smoke") ? "" : "dashboard export missed smoke session data",
+    html.includes('id="dashboard-root"') ? "" : "dashboard export missed dashboard root",
+  ].filter(Boolean);
+  if (assetIssues.length || markerIssues.length) {
+    return { ok: false, error: [...assetIssues, ...markerIssues].join("\n") };
+  }
+
+  return { ok: true, error: "" };
+}
+
+async function readPackageDashboardExportAssets(
+  packageDir: string,
+): Promise<DashboardExportAssets> {
+  const [app, css] = await Promise.all([
+    fsp.readFile(path.join(packageDir, "assets/dashboard-build/dashboard-app.js"), "utf8"),
+    fsp.readFile(path.join(packageDir, "assets/dashboard-build/dashboard-app.css"), "utf8"),
+  ]);
+  return { app, css };
 }
 
 async function runDogfoodHealthCheck() {

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -18,6 +18,7 @@ import {
   DASHBOARD_TRANSPORT_ARRAY_LIMIT,
   DASHBOARD_TRANSPORT_MEMORY_LIST_LIMIT,
   compactDashboardTransportViewModel,
+  readDashboardBuildAsset,
 } from "../lib/dashboard-transport.js";
 import { boundDashboardLedgerEntries } from "../lib/dashboard-ledger-bounds.js";
 import {
@@ -578,6 +579,20 @@ test("dashboard transport view model caps large memory arrays", () => {
   assert.equal(viewModel.decisionEnvelope.state.current[0].run, 6);
   assert.equal(viewModel.decisionEnvelope.workflowFriction.length, DASHBOARD_TRANSPORT_ARRAY_LIMIT);
   assert.equal(viewModel.decisionEnvelope.workflowFriction[0].id, 0);
+});
+
+test("source checkout reports missing dashboard build assets with build guidance", async () => {
+  const missingBuildDir = await mkdtemp(path.join(tmpdir(), "autoresearch-missing-dashboard-"));
+  await rm(missingBuildDir, { recursive: true, force: true });
+
+  assert.throws(
+    () =>
+      readDashboardBuildAsset("dashboard-app.js", {
+        buildDir: missingBuildDir,
+        pluginRoot: "C:\\repo\\plugins\\codex-autoresearch",
+      }),
+    /Dashboard build asset is missing: .* Run npm run build:dashboard from C:\\repo\\plugins\\codex-autoresearch\./,
+  );
 });
 
 test("dashboard ledger bounder preserves governing config when there is room for a run", () => {


### PR DESCRIPTION
## Context

`assets/dashboard-build/*` is still tracked, but issue #179 needs proof that dashboard assets can safely become package-time output. This PR hardens the package boundary first: package creation builds the dashboard, package checks assert both assets, and runtime smoke proves an extracted package can export embedded dashboard HTML without authored source.

Refs #179

## What Changed

- Added `prepack` so manual `npm pack` runs `npm run build`, including `build:dashboard`.
- Extended package artifact checks to require both `assets/dashboard-build/dashboard-app.js` and `assets/dashboard-build/dashboard-app.css`.
- Extended extracted-package runtime smoke to run `autoresearch export` against a temporary ledger and compare embedded JS/CSS with the packaged dashboard assets.
- Kept source-checkout missing-asset behavior explicit: `dashboardHtml` fails with guidance to run `npm run build:dashboard`.
- Added a regression test for the missing dashboard asset guidance.
- Added release workflow dashboard export smoke after extracting the tarball.
- Updated maintainer docs for the package-time dashboard asset contract.

```mermaid
flowchart LR
  Build[build:dashboard] --> Pack[npm pack]
  Pack --> Assert[artifact asserts js + css]
  Assert --> Extract[extract tarball]
  Extract --> Export[package autoresearch export]
  Export --> Embed[HTML embeds packaged js + css]
```

## How To Review

- Start with `plugins/codex-autoresearch/scripts/check.ts` for the artifact and extracted-package smoke changes.
- Check `plugins/codex-autoresearch/package.json` for the `prepack` lifecycle hook.
- Check `.github/workflows/release.yml` for CI release-smoke parity.
- Check `plugins/codex-autoresearch/lib/dashboard-transport.ts` and `tests/dashboard-verification.test.ts` for source-checkout missing-asset behavior.
- Check `plugins/codex-autoresearch/docs/maintainers.md` for maintainer-facing package contract docs.

## Verification

- `npm run build:node` passed.
- `node --test dist\tests\check-runner.test.mjs dist\tests\dashboard-verification.test.mjs` passed: 116/116.
- `npm run check` passed, including `ok package-artifact` and `ok package-runtime-smoke`.
- `npm pack --dry-run --json` passed and showed `prepack -> npm run build -> build:node + build:dashboard`; dry-run manifest included both `assets/dashboard-build/dashboard-app.js` and `assets/dashboard-build/dashboard-app.css`.
- `git diff --check` passed.

## Risk

- `assets/dashboard-build/*` remains tracked in this PR. That is intentional: this PR proves package/runtime replacement first and leaves untracking/ignore cleanup for a follow-up after reviewers accept the package-time contract.
- Release workflow export smoke is shell-only CI coverage; local proof comes from `npm run check` extracted-package smoke on Windows.