### PR TITLE
Hydrate dashboard assets with source runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 ### Fixed
 
 - Redacted benchmark-contract command text, checks command text, option-file paths, and env-file labels from persisted last-run packet storage.
+- Source-shaped plugin runtime hydration now copies packaged dashboard build assets so `export` and `serve` keep working after `assets/dashboard-build/` became ignored/generated.
 
 ## 2.4.0 - 2026-06-18
 

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -12,6 +12,7 @@ const LOCK_TIMEOUT_MS = 120_000;
 const LOCK_RETRY_MS = 250;
 const PACKAGE_NAME = "codex-autoresearch";
 const RELEASE_VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+const DASHBOARD_BUILD_ASSETS = ["dashboard-app.js", "dashboard-app.css"];
 
 export async function ensureRuntime(entrypoint, importerUrl, options = {}) {
   const { install = true } = options;
@@ -20,18 +21,42 @@ export async function ensureRuntime(entrypoint, importerUrl, options = {}) {
   const target = path.join(pluginRoot, "dist", "scripts", entrypoint);
 
   await rebuildStaleSourceRuntime(pluginRoot, target);
-  if (await fileExists(target)) return pathToFileURL(target).href;
+  if ((await fileExists(target)) && (await dashboardRuntimeReady(pluginRoot))) {
+    return pathToFileURL(target).href;
+  }
   if (!install) throw missingRuntimeError(pluginRoot, target);
 
   await withRuntimeInstallLock(pluginRoot, async () => {
-    if (await fileExists(target)) return;
+    if ((await fileExists(target)) && (await dashboardRuntimeReady(pluginRoot))) return;
     await installRuntimeFromRelease(pluginRoot, options);
     if (!(await fileExists(target))) {
       throw new Error(`Release runtime did not provide ${path.relative(pluginRoot, target)}.`);
     }
+    if (!(await dashboardBuildReady(pluginRoot))) {
+      throw new Error("Release runtime did not provide assets/dashboard-build/.");
+    }
   });
 
   return pathToFileURL(target).href;
+}
+
+async function dashboardRuntimeReady(pluginRoot) {
+  if (await dashboardBuildReady(pluginRoot)) return true;
+  return await isSourceDevelopmentCheckout(pluginRoot);
+}
+
+async function dashboardBuildReady(pluginRoot) {
+  const buildDir = path.join(pluginRoot, "assets", "dashboard-build");
+  return (
+    await Promise.all(DASHBOARD_BUILD_ASSETS.map((asset) => fileExists(path.join(buildDir, asset))))
+  ).every(Boolean);
+}
+
+async function isSourceDevelopmentCheckout(pluginRoot) {
+  return (
+    (await fileExists(path.join(pluginRoot, "scripts", "autoresearch.ts"))) &&
+    (await fileExists(path.join(pluginRoot, "tsdown.config.ts")))
+  );
 }
 
 async function rebuildStaleSourceRuntime(pluginRoot, target) {
@@ -98,14 +123,29 @@ async function installRuntimeFromRelease(pluginRoot, options = {}) {
     await fs.mkdir(extractDir, { recursive: true });
     await run("tar", ["-xzf", tarballPath, "-C", extractDir]);
 
-    const extractedDist = path.join(extractDir, "package", "dist");
+    const extractedPackage = path.join(extractDir, "package");
+    const extractedDist = path.join(extractedPackage, "dist");
     if (!(await fileExists(extractedDist))) {
       throw new Error(`Release tarball ${artifacts.tarballName} does not contain dist/.`);
     }
-    await verifyReleasePackageManifest(path.join(extractDir, "package"), version);
+    const extractedDashboardBuild = path.join(extractedPackage, "assets", "dashboard-build");
+    if (!(await dashboardBuildReady(extractedPackage))) {
+      throw new Error(
+        `Release tarball ${artifacts.tarballName} does not contain assets/dashboard-build/.`,
+      );
+    }
+    await verifyReleasePackageManifest(extractedPackage, version);
 
     await fs.rm(path.join(pluginRoot, "dist"), { recursive: true, force: true });
     await fs.cp(extractedDist, path.join(pluginRoot, "dist"), { recursive: true });
+    await fs.rm(path.join(pluginRoot, "assets", "dashboard-build"), {
+      recursive: true,
+      force: true,
+    });
+    await fs.mkdir(path.join(pluginRoot, "assets"), { recursive: true });
+    await fs.cp(extractedDashboardBuild, path.join(pluginRoot, "assets", "dashboard-build"), {
+      recursive: true,
+    });
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -9851,6 +9851,72 @@ test("source launcher hydrates runtime only after release checksum verification"
   });
 });
 
+test("source launcher hydrates packaged dashboard assets before source-shaped export", async () => {
+  await withTempDir("runtime-hydration-dashboard-export", async (dir) => {
+    const { pluginDir, importerUrl } = await writeFakeSourcePlugin(dir);
+    await mkdir(path.join(pluginDir, "assets"), { recursive: true });
+    await writeFile(
+      path.join(pluginDir, "assets", "template.html"),
+      [
+        "<!doctype html>",
+        '<div id="dashboard-root"></div>',
+        "<style>__AUTORESEARCH_DASHBOARD_CSS__</style>",
+        "<script>__AUTORESEARCH_DASHBOARD_APP__</script>",
+        '<script type="application/json">__AUTORESEARCH_DATA_PAYLOAD__</script>',
+        '<script type="application/json">__AUTORESEARCH_META_PAYLOAD__</script>',
+      ].join("\n"),
+      "utf8",
+    );
+    await assert.rejects(
+      access(path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.js")),
+    );
+
+    const runtimeText = [
+      'import fs from "node:fs";',
+      'import path from "node:path";',
+      'import { fileURLToPath } from "node:url";',
+      "export const hydratedRuntime = true;",
+      "export function exportDashboardHtml(workDir) {",
+      '  const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");',
+      '  const template = fs.readFileSync(path.join(pluginRoot, "assets", "template.html"), "utf8");',
+      '  const app = fs.readFileSync(path.join(pluginRoot, "assets", "dashboard-build", "dashboard-app.js"), "utf8");',
+      '  const css = fs.readFileSync(path.join(pluginRoot, "assets", "dashboard-build", "dashboard-app.css"), "utf8");',
+      "  const html = template",
+      '    .replace("__AUTORESEARCH_DASHBOARD_CSS__", css)',
+      '    .replace("__AUTORESEARCH_DASHBOARD_APP__", app)',
+      '    .replace("__AUTORESEARCH_DATA_PAYLOAD__", JSON.stringify([{ name: "package dashboard smoke" }]))',
+      '    .replace("__AUTORESEARCH_META_PAYLOAD__", JSON.stringify({ deliveryMode: "static-export" }));',
+      '  const outputPath = path.join(workDir, "autoresearch-dashboard.html");',
+      '  fs.writeFileSync(outputPath, html, "utf8");',
+      "  return outputPath;",
+      "}",
+    ].join("\n");
+    const release = await createRuntimeReleaseAsset(dir, {
+      dashboardAppText: 'window.__hydratedDashboardAsset = "release-dashboard-app";\n',
+      dashboardCssText: "#dashboard-root { color: rgb(12, 34, 56); }\n",
+      runtimeText: `${runtimeText}\n`,
+    });
+    const bootstrap = await import(
+      pathToFileURL(path.join(pluginRoot, "scripts", "bootstrap-runtime.mjs")).href
+    );
+
+    await withReleaseServer(release.releaseDir, PLUGIN_VERSION, async (releaseBaseUrl) => {
+      const runtimeHref = await bootstrap.ensureRuntime("autoresearch.mjs", importerUrl, {
+        releaseBaseUrl,
+      });
+      await access(path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.js"));
+      await access(path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.css"));
+
+      const runtime = await import(`${runtimeHref}?dashboard=${Date.now()}`);
+      const outputPath = runtime.exportDashboardHtml(dir);
+      const dashboardHtml = await readFile(outputPath, "utf8");
+      assert.match(dashboardHtml, /release-dashboard-app/);
+      assert.match(dashboardHtml, /rgb\(12, 34, 56\)/);
+      assert.match(dashboardHtml, /package dashboard smoke/);
+    });
+  });
+});
+
 test("source launcher fails closed when release checksum metadata is missing", async () => {
   await withTempDir("runtime-hydration-missing-checksum", async (dir) => {
     const { pluginDir, importerUrl } = await writeFakeSourcePlugin(dir);

--- a/plugins/codex-autoresearch/tests/helpers/runtime-release-fixtures.ts
+++ b/plugins/codex-autoresearch/tests/helpers/runtime-release-fixtures.ts
@@ -52,6 +52,9 @@ export async function createRuntimeReleaseAsset(
     packageName = "codex-autoresearch",
     checksumFileName,
     checksumHash,
+    dashboardAppText = "window.__CODEX_AUTORESEARCH_DASHBOARD_APP__ = true;\n",
+    dashboardCssText = "#dashboard-root { color: rgb(12, 34, 56); }\n",
+    runtimeText = "export const hydratedRuntime = true;\n",
     writeChecksum = true,
   } = {},
 ) {
@@ -72,7 +75,18 @@ export async function createRuntimeReleaseAsset(
   );
   await writeFile(
     path.join(packageDir, "dist", "scripts", "autoresearch.mjs"),
-    "export const hydratedRuntime = true;\n",
+    runtimeText,
+    "utf8",
+  );
+  await mkdir(path.join(packageDir, "assets", "dashboard-build"), { recursive: true });
+  await writeFile(
+    path.join(packageDir, "assets", "dashboard-build", "dashboard-app.js"),
+    dashboardAppText,
+    "utf8",
+  );
+  await writeFile(
+    path.join(packageDir, "assets", "dashboard-build", "dashboard-app.css"),
+    dashboardCssText,
     "utf8",
   );
 


### PR DESCRIPTION
## Context

`assets/dashboard-build/` is now ignored/generated, but source-shaped runtime hydration only copied `dist/` from the release tarball. That left hydrated source-shaped installs with a working CLI runtime and broken dashboard `export`/`serve`, because dashboard HTML still reads packaged JS/CSS from `assets/dashboard-build/`.

Refs #189

## What Changed

- Copy verified release `assets/dashboard-build/` into the source-shaped plugin directory during runtime hydration, alongside `dist/`.
- Keep true source-development behavior intact: source checkouts with local authored runtime still surface the existing `npm run build:dashboard` missing-asset guidance.
- Extend the runtime release fixture with packaged dashboard assets.
- Add a focused regression proving a source-shaped plugin directory with no pre-existing dashboard build assets can hydrate a release runtime and export dashboard HTML using the packaged JS/CSS.
- Add an Unreleased changelog note for the runtime hydration fix.

## How To Review

1. Review `scripts/bootstrap-runtime.mjs` first: the fix stays in release hydration and copies only `assets/dashboard-build/` after checksum/package manifest verification.
2. Review `tests/helpers/runtime-release-fixtures.ts`, then the new regression in `tests/autoresearch-cli.test.ts`.
3. Confirm `lib/dashboard-transport.ts` missing-asset guidance is unchanged.

## Verification

- `npm ci` passed and ran `prepare -> npm run build:node`.
- `node --test --test-name-pattern "source launcher hydrates packaged dashboard assets before source-shaped export" dist/tests/autoresearch-cli.test.mjs` passed: 1/1.
- `node --test --test-name-pattern "source launcher" dist/tests/autoresearch-cli.test.mjs` passed: 9/9.
- `npm run build:dashboard` passed.
- `node --test --test-name-pattern "source checkout reports missing dashboard build assets" dist/tests/dashboard-verification.test.mjs` passed.
- `git diff --check` passed before rebase; `git diff --check origin/dev...HEAD` passed after rebase.
- `npm run test:dashboard` passed: 106/106.
- Manual extracted-package smoke passed after rebase: `ok package-runtime-smoke:dashboard-export codex-autoresearch-2.4.0.tgz`.
- `npm run check` passed typecheck/lint/format/product preflight, then failed in compiled CLI tests because unrelated parallel shards hit the shared 300s timeout. The timed ranges were rerun serially and passed:
  - `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=120:130` passed 10/10.
  - `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=140:150` passed 10/10.
  - `CODEX_AUTORESEARCH_TEST_SHARD_RANGE=150:160` passed 10/10.

## Risk

Low. The change only expands release runtime hydration to copy packaged dashboard build assets that are already part of the package artifact contract. The main residual risk is CI/runtime duration: the full local gate was blocked by existing slow parallel CLI shard timeouts, not by assertion failures in this change.