### PR TITLE
Tighten dashboard chart and status accessibility

### DIFF
--- a/plugins/codex-autoresearch/dashboard/src/components/SideRail.tsx
+++ b/plugins/codex-autoresearch/dashboard/src/components/SideRail.tsx
@@ -8,20 +8,23 @@ const NAV_ITEMS = [
 export function SideRail({ live, showcase }: { live: boolean; showcase: boolean }) {
   const status = showcase ? "Demo" : live ? "Live" : "Static";
   const detail = showcase ? "Snapshot" : live ? "Readout" : "Snapshot";
+  const markerClassName = live ? "live-dot" : "status-dot";
   return (
     <aside className="side-rail" aria-label="Dashboard sections">
       <div className="rail-mark">AR</div>
       <nav className="side-nav">
         {NAV_ITEMS.map(([href, index, label]) => (
-          <a href={href} key={href}>
-            <span className="nav-icon">{index}</span>
+          <a href={href} key={href} aria-label={`Dashboard section: ${label}`}>
+            <span className="nav-icon" aria-hidden="true">
+              {index}
+            </span>
             <span>{label}</span>
           </a>
         ))}
       </nav>
       <div className="side-status">
         <span>
-          <span className="live-dot" aria-hidden="true" />
+          <span className={markerClassName} aria-hidden="true" />
           {status}
         </span>
         <strong id="side-mode-detail">{detail}</strong>

--- a/plugins/codex-autoresearch/dashboard/src/components/trend/TrendChartFigure.tsx
+++ b/plugins/codex-autoresearch/dashboard/src/components/trend/TrendChartFigure.tsx
@@ -343,7 +343,8 @@ function ChartDot({
         type="button"
         className="chart-point-button"
         aria-haspopup="dialog"
-        aria-describedby="trend-chart-selected chart-keyboard-help"
+        aria-current={payload.runNumber === selectedRunNumber ? "true" : undefined}
+        aria-describedby="chart-keyboard-help"
         aria-label={chartPointAriaLabel(payload)}
         data-chart-run={payload.runNumber}
         tabIndex={tabbable ? 0 : -1}

--- a/plugins/codex-autoresearch/dashboard/src/styles.css
+++ b/plugins/codex-autoresearch/dashboard/src/styles.css
@@ -241,16 +241,24 @@ a:focus-visible {
   font-size: 12px;
 }
 
-.live-dot {
+.live-dot,
+.status-dot {
   display: inline-block;
   width: 8px;
   height: 8px;
   margin-right: 6px;
   border-radius: 50%;
   background: var(--teal);
+  vertical-align: middle;
+}
+
+.live-dot {
   box-shadow: 0 0 0 4px rgba(28, 181, 173, 0.2);
   animation: pulse-glow 2s infinite ease-in-out;
-  vertical-align: middle;
+}
+
+.status-dot {
+  box-shadow: 0 0 0 1px var(--teal-dark);
 }
 
 @keyframes pulse-glow {

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -963,11 +963,71 @@ test("dashboard chart does not place interactive point buttons under an image ro
     /arrow keys move through history/i,
   );
   assert.match(chartSource, /className="chart-point-button"/);
+  assert.match(chartSource, /aria-current=\{payload\.runNumber === selectedRunNumber/);
+  assert.doesNotMatch(chartSource, /aria-describedby="trend-chart-selected chart-keyboard-help"/);
   for (const button of buttons) {
     assert.equal(button.closest('[role="img"]'), null);
-    assert.match(button.getAttribute("aria-describedby") || "", /chart-keyboard-help/);
+    assert.equal(button.getAttribute("aria-describedby"), "chart-keyboard-help");
+    assert.doesNotMatch(button.getAttribute("aria-describedby") || "", /trend-chart-selected/);
+    assert.match(button.getAttribute("aria-label") || "", /Open details for run/);
   }
+  assert.match(getById("trend-chart-selected").textContent || "", /Selected chart point:/);
   dom.window.close();
+});
+
+test("dashboard side rail distinguishes live and static status affordances", async () => {
+  const entries = [
+    dashboardConfigEntry({ name: "side rail status", metricName: "seconds", metricUnit: "s" }),
+    { type: "run", run: 1, metric: 5, status: "keep", description: "Baseline", confidence: 1 },
+  ];
+
+  const staticDashboard = await runDashboard(entries, {
+    deliveryMode: "static-export",
+    liveActionsAvailable: false,
+  });
+  assert.ok(staticDashboard.dom.window.document.querySelector(".side-status .status-dot"));
+  assert.equal(staticDashboard.dom.window.document.querySelector(".side-status .live-dot"), null);
+  assert.match(
+    staticDashboard.dom.window.document.querySelector(".side-status")?.textContent || "",
+    /Static/,
+  );
+  staticDashboard.dom.window.close();
+
+  const demoDashboard = await runDashboard(entries, {
+    deliveryMode: "static-export",
+    liveActionsAvailable: false,
+    showcaseMode: true,
+  });
+  assert.ok(demoDashboard.dom.window.document.querySelector(".side-status .status-dot"));
+  assert.equal(demoDashboard.dom.window.document.querySelector(".side-status .live-dot"), null);
+  assert.match(
+    demoDashboard.dom.window.document.querySelector(".side-status")?.textContent || "",
+    /Demo/,
+  );
+  demoDashboard.dom.window.close();
+
+  const liveDashboard = await runDashboard(entries, {
+    deliveryMode: "live-server",
+    liveRefreshAvailable: true,
+    liveActionsAvailable: false,
+  });
+  assert.ok(liveDashboard.dom.window.document.querySelector(".side-status .live-dot"));
+  assert.equal(liveDashboard.dom.window.document.querySelector(".side-status .status-dot"), null);
+  assert.match(
+    liveDashboard.dom.window.document.querySelector(".side-status")?.textContent || "",
+    /Live/,
+  );
+  liveDashboard.dom.window.close();
+});
+
+test("dashboard static status marker does not inherit live animation", () => {
+  const css = readFileSync(
+    path.join(resolvePackageRoot(import.meta.url), "dashboard", "src", "styles.css"),
+    "utf8",
+  );
+
+  assert.match(css, /\.live-dot\s*\{[^}]*animation:\s*pulse-glow/s);
+  assert.doesNotMatch(extractCssBlock(css, ".status-dot"), /animation:/);
 });
 
 test("dashboard styles latest rejected evidence as rejected, not kept", async () => {
@@ -3681,6 +3741,21 @@ test("dashboard exposes keyboard skip path through primary surfaces", async () =
     item.textContent?.trim(),
   );
   assert.deepEqual(sideLabels, ["1Metric", "2Move", "3Brief", "4Ledger"]);
+  const sideAriaLabels = [...dom.window.document.querySelectorAll(".side-nav a")].map((item) =>
+    item.getAttribute("aria-label"),
+  );
+  assert.deepEqual(sideAriaLabels, [
+    "Dashboard section: Metric",
+    "Dashboard section: Move",
+    "Dashboard section: Brief",
+    "Dashboard section: Ledger",
+  ]);
+  assert.equal(
+    [...dom.window.document.querySelectorAll(".side-nav .nav-icon")].every(
+      (item) => item.getAttribute("aria-hidden") === "true",
+    ),
+    true,
+  );
   assert.ok(dom.window.document.getElementById("dashboard-toolbar"));
   assert.equal(dom.window.document.querySelector(".masthead"), null);
   const decisionRail = dom.window.document.getElementById("decision-rail");


### PR DESCRIPTION
## Context

Refs #195
Parent epic: #188

Dashboard accessibility review found two small but user-visible defects:

- chart point buttons described themselves with the global selected-point live text, so non-selected tabbable points could announce stale selected-run context
- static/demo mode reused the animated `.live-dot`, making snapshots look live
- side-nav ordinal text was visible in link text without being marked decorative for assistive tech

## What Changed

- Chart point buttons now describe only their own run context plus keyboard help, while selected state is exposed separately with `aria-current`.
- Static and demo side-rail modes now use a non-pulsing `status-dot`; live mode keeps the animated `live-dot`.
- Side-nav links now have explicit accessible names and hide ordinal icons from assistive tech.
- Dashboard DOM/a11y tests cover chart descriptions, live/static/demo status markers, non-animated static CSS, and side-nav labels.

## How To Review

- Review `dashboard/src/components/trend/TrendChartFigure.tsx` for chart point announcement wiring.
- Review `dashboard/src/components/SideRail.tsx` and `dashboard/src/styles.css` for live vs static marker behavior.
- Review `tests/dashboard-verification.test.ts` for the focused DOM assertions.
- For visual evidence, open the generated showcase export from the child worktree: `examples/demo-session/tmp/issue-195-dashboard-review.html`.

## Verification

- `npm ci` in the isolated worktree, to hydrate package tools.
- `CODEX_AUTORESEARCH_TEST_REBUILD_DASHBOARD=1 npm run test:dashboard` -> passed, 108/108.
- `npm run test:dashboard` after rebase onto current `origin/dev` -> passed, 108/108.
- `git diff --check` -> passed.
- Dashboard export evidence: `node scripts/autoresearch.mjs export --cwd examples/demo-session --output tmp/issue-195-dashboard-review.html --showcase` -> wrote `examples/demo-session/tmp/issue-195-dashboard-review.html`; generated bundle contains `status-dot` and explicit side-nav labels.
- Visual evidence boundary: no screenshot or manual screen-reader pass was captured in this lane; evidence is DOM/a11y tests plus the generated dashboard export.

`npm run check` did not complete cleanly: product/check phases reached compiled tests and all visible dashboard/finalize/core assertions passed, but broad `autoresearch-cli.test.mjs` shards timed out at the 300s shard limit (`13/22`, then direct `npm run test:compiled` reproduced timeouts in `13/22` and `15/22`). I did not find a dashboard assertion failure in the full gate output.

## Risk

Low implementation risk: this is scoped to dashboard semantics and marker styling. Remaining risk is assistive-technology runtime nuance beyond jsdom; NVDA/JAWS/VoiceOver manual validation was not run in this lane.