### PR TITLE
Reuse session path constants for artifacts

### DIFF
--- a/plugins/codex-autoresearch/lib/session-artifacts.ts
+++ b/plugins/codex-autoresearch/lib/session-artifacts.ts
@@ -1,21 +1,16 @@
+import {
+  AUTORESEARCH_DASHBOARD_FILE,
+  AUTORESEARCH_RESEARCH_DIR,
+  AUTORESEARCH_SESSION_FILES,
+} from "./session-paths.js";
+
 export type SessionArtifactMode = "finalization" | "dirty-tree" | "source-checkout";
 export type SessionArtifactPolicy = { mode: SessionArtifactMode };
 
-const SESSION_FILES = new Set([
-  "autoresearch.jsonl",
-  "autoresearch.md",
-  "autoresearch.ideas.md",
-  "autoresearch.config.json",
-  "autoresearch.last-run.json",
-  "autoresearch-dashboard.html",
-  "autoresearch.sh",
-  "autoresearch.ps1",
-  "autoresearch.checks.sh",
-  "autoresearch.checks.ps1",
-]);
+const SESSION_FILES = new Set([...AUTORESEARCH_SESSION_FILES, AUTORESEARCH_DASHBOARD_FILE]);
 
-const RESEARCH_DIR = "autoresearch.research";
-const RESEARCH_DIR_PREFIX = "autoresearch.research/";
+const RESEARCH_DIR = AUTORESEARCH_RESEARCH_DIR;
+const RESEARCH_DIR_PREFIX = `${AUTORESEARCH_RESEARCH_DIR}/`;
 export const REPORT_DIRNAME = "autoresearch-finalize";
 export const CLEANUP_SESSION_PATHS = [RESEARCH_DIR, ...SESSION_FILES].sort((a, b) =>
   a.localeCompare(b),

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -6,6 +6,7 @@ import { finalizationPlanFingerprint, readAutoresearchLedger } from "../lib/fina
 import { finalizePreview } from "../lib/finalize-preview.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 import { isAutoresearchSessionArtifact } from "../lib/session-artifacts.js";
+import { AUTORESEARCH_DASHBOARD_FILE, AUTORESEARCH_SESSION_FILES } from "../lib/session-paths.js";
 import { testGitArgs, withTempDir as withNamedTempDir } from "./helpers/process.js";
 import test from "./helpers/sharded-test.js";
 
@@ -84,6 +85,16 @@ test("session artifact modes preserve finalization, dirty tree, and source check
     assert.equal(
       isAutoresearchSessionArtifact(file, "source-checkout"),
       sourceCheckout,
+      `${file} source-checkout`,
+    );
+  }
+
+  for (const file of [...AUTORESEARCH_SESSION_FILES, AUTORESEARCH_DASHBOARD_FILE]) {
+    assert.equal(isAutoresearchSessionArtifact(file, "finalization"), true, `${file} constant`);
+    assert.equal(isAutoresearchSessionArtifact(file, "dirty-tree"), true, `${file} dirty-tree`);
+    assert.equal(
+      isAutoresearchSessionArtifact(file, "source-checkout"),
+      true,
       `${file} source-checkout`,
     );
   }


### PR DESCRIPTION
## Context

Refs #197.

This draft addresses only the #197 session-artifact constants checklist item: `session-artifacts.ts` had its own hard-coded session file set while `session-paths.ts` already owns the canonical session file constants.

Non-claims:
- This does not broaden into the rest of #197.
- This does not touch #193's likely files.
- No CodeStory context path was used; direct source reads were enough for this slice.

## What Changed

- Reused `AUTORESEARCH_SESSION_FILES`, `AUTORESEARCH_DASHBOARD_FILE`, and `AUTORESEARCH_RESEARCH_DIR` from `lib/session-paths.ts` inside `lib/session-artifacts.ts`.
- Added a focused finalization test assertion that every resolver-owned session file constant is classified as a session artifact across finalization, dirty-tree, and source-checkout modes.

## How To Review

- Start with `plugins/codex-autoresearch/lib/session-artifacts.ts` and confirm the local duplicate session file list is gone.
- Then read the small assertion added to `plugins/codex-autoresearch/tests/finalize-report.test.ts`.

## Verification

- `npm ci` passed and hydrated the isolated worktree dependencies.
- `npm run test:finalize` passed: all `finalize-report.test.mjs` shards completed in 122.6s.
- `git diff --check` passed.
- `npm run check` attempted. It passed typecheck, lint, format, build, syntax, source hygiene, dashboard build/parity, demo checks, product checks, and reported `METRIC quality_gap=0`; it did not complete because `autoresearch-cli.test.mjs` shard 5 timed out after 300s during the compiled test bundle. I stopped the draining run after the timeout so this narrow lane could publish with the exact caveat.

## Risk

Low. The production change replaces duplicated literals with existing exported constants. The only behavior expansion is that any future file added to `AUTORESEARCH_SESSION_FILES` is automatically treated as a session artifact here, which is the intended contract for this cleanup item.