### PR TITLE
Consolidate test process helpers

### DIFF
--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { finalizationPlanFingerprint, readAutoresearchLedger } from "../lib/finalization-plan.js";
@@ -7,7 +6,7 @@ import { finalizePreview } from "../lib/finalize-preview.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 import { isAutoresearchSessionArtifact } from "../lib/session-artifacts.js";
 import { AUTORESEARCH_DASHBOARD_FILE, AUTORESEARCH_SESSION_FILES } from "../lib/session-paths.js";
-import { testGitArgs, withTempDir as withNamedTempDir } from "./helpers/process.js";
+import { runProcess, testGitArgs, withTempDir as withNamedTempDir } from "./helpers/process.js";
 import test from "./helpers/sharded-test.js";
 
 const pluginRoot = resolvePackageRoot(import.meta.url);
@@ -15,25 +14,7 @@ const finalizer = path.join(pluginRoot, "scripts", "finalize-autoresearch.mjs");
 const cli = path.join(pluginRoot, "scripts", "autoresearch.mjs");
 
 async function run(command, args, cwd, allowFailure = false) {
-  const result = await new Promise((resolve) => {
-    const child = spawn(command, args, {
-      cwd,
-      windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.on("error", (error) =>
-      resolve({ code: -1, stdout, stderr: String(error.message || error) }),
-    );
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
+  const result = await runProcess(command, args, cwd);
   if (!allowFailure && result.code !== 0) {
     const commandLine = command + " " + args.join(" ");
     throw new Error(commandLine + " failed:\n" + result.stdout + result.stderr);

--- a/plugins/codex-autoresearch/tests/helpers/process-fixtures.ts
+++ b/plugins/codex-autoresearch/tests/helpers/process-fixtures.ts
@@ -1,30 +1,14 @@
-import { spawn } from "node:child_process";
 import { resolvePackageRoot } from "../../lib/runtime-paths.js";
+import { runProcess } from "./process.js";
 
 const pluginRoot = resolvePackageRoot(import.meta.url);
 
 export async function runNode(args, { cwd = pluginRoot, env = process.env } = {}) {
-  return await new Promise((resolve) => {
-    const childEnv = { ...env };
-    delete childEnv.NODE_TEST_CONTEXT;
-    const child = spawn(process.execPath, args, {
-      cwd,
-      env: childEnv,
-      windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.on("error", (error) =>
-      resolve({ code: -1, stdout, stderr: String(error.message || error) }),
-    );
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  const childEnv = { ...env };
+  delete childEnv.NODE_TEST_CONTEXT;
+  return await runProcess(process.execPath, args, {
+    cwd,
+    env: childEnv,
   });
 }
 
@@ -34,24 +18,8 @@ export async function runShellCommand(command, { cwd = pluginRoot } = {}) {
     process.platform === "win32"
       ? ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command]
       : ["-c", command];
-  return await new Promise((resolve) => {
-    const child = spawn(shell, args, {
-      cwd,
-      env: process.env,
-      windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.on("error", (error) =>
-      resolve({ code: -1, stdout, stderr: String(error.message || error) }),
-    );
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  return await runProcess(shell, args, {
+    cwd,
+    env: process.env,
   });
 }

--- a/plugins/codex-autoresearch/tests/helpers/runtime-release-fixtures.ts
+++ b/plugins/codex-autoresearch/tests/helpers/runtime-release-fixtures.ts
@@ -1,31 +1,13 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { PLUGIN_VERSION } from "../../lib/plugin-version.js";
+import { runProcess } from "./process.js";
 
 async function runTar(args, cwd) {
-  const result = await new Promise((resolve) => {
-    const child = spawn("tar", args, {
-      cwd,
-      windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-    });
-    child.on("error", (error) =>
-      resolve({ code: -1, stdout, stderr: String(error.message || error) }),
-    );
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
+  const result = await runProcess("tar", args, cwd);
   assert.equal(result.code, 0, `tar ${args.join(" ")} failed\n${result.stderr}${result.stdout}`);
 }
 


### PR DESCRIPTION
## Context

Refs #197.

This is the narrow duplicated test process helper cleanup lane under epic #188. It targets plain child-process capture loops that can delegate to the existing `tests/helpers/process.ts` helper without changing assertions or test behavior.

Coordinator overlap note: release-tooling lane `019ee7b4-0ed0-7350-9b03-c33d5feecef0` currently touches `plugins/codex-autoresearch/tests/source-hygiene.test.ts`. This PR intentionally leaves `source-hygiene.test.ts` unchanged.

## What Changed

- `tests/helpers/process-fixtures.ts`: `runNode` and `runShellCommand` now delegate to `runProcess`, preserving `NODE_TEST_CONTEXT` cleanup and shell selection.
- `tests/helpers/runtime-release-fixtures.ts`: tar fixture execution now uses `runProcess` before asserting exit code.
- `tests/finalize-report.test.ts`: the local `run()` helper now uses `runProcess` while preserving `allowFailure` handling.

## How To Review

Review as a behavior-preserving test-helper refactor:

- Confirm removed code is duplicated stdout/stderr/exit-code capture only.
- Confirm no test assertions or production code changed.
- Confirm `source-hygiene.test.ts`, package scripts, release workflow, command-policy modules, and SessionStorageMode files are untouched.

## Verification

- `npm ci` (exit 0; ran prepare/build:node)
- `npm run build:node` (exit 0)
- `node --test --test-name-pattern "session artifact modes preserve finalization|finalize-preview fails on corrupt autoresearch ledger" dist\tests\finalize-report.test.mjs` (exit 0; 2/2 pass)
- `node --test --test-name-pattern "test shard runner validates jobs and fails closed on discovery gaps|stale packet compact state recommends replacement next command|source launcher" dist\tests\autoresearch-cli.test.mjs` (exit 0; 11/11 pass)
- `npm run typecheck:node` (exit 0)
- `npm run lint` (exit 0; 0 warnings/errors)
- `npm run format:check` (exit 0)
- `git diff --check` (exit 0)

Note: I briefly tried consolidating `perfection-benchmark.test.ts`, but its direct test currently fails on an unrelated `dashboard-practical-chart` product benchmark gap (`quality_gap=1`). I removed that optional file change from the final diff.

## Risk

Low: test-only helper consolidation, with focused coverage for normal process completion, failure-code handling, shell command execution, and tarball fixture execution.

Remaining overlap risk: low but explicit. The known release-tooling overlap file, `source-hygiene.test.ts`, is not modified here. This PR still touches shared test helper code used by multiple tests, so reviewers should expect broad helper consumers to be sensitive even though the changed call sites are focused.

CodeStory/codestory-grounding was not used; direct source reads and repo-local tests were sufficient for this narrow lane.
