### PR TITLE
Keep session storage mode internal

### DIFF
--- a/plugins/codex-autoresearch/lib/session-paths.ts
+++ b/plugins/codex-autoresearch/lib/session-paths.ts
@@ -24,8 +24,6 @@ export const AUTORESEARCH_SESSION_FILES = [
   AUTORESEARCH_PENDING_TRANSACTION_FILE,
 ] as const;
 
-export type SessionStorageMode = "repo";
-
 export interface ResolveSessionPathsInput {
   cwd?: string;
   sessionCwd?: string;
@@ -33,7 +31,7 @@ export interface ResolveSessionPathsInput {
 }
 
 export interface SessionPaths {
-  mode: SessionStorageMode;
+  mode: "repo";
   targetCwd: string;
   sessionCwd: string;
   sessionDir: string;


### PR DESCRIPTION
## Context

Refs #197 under epic #188.

`resolveSessionPaths` only supports repo-local session storage today. The exported `SessionStorageMode = "repo"` alias made that single implementation detail look like a public extension surface before external modes exist.

## What Changed

- Removed the exported `SessionStorageMode` type alias from `plugins/codex-autoresearch/lib/session-paths.ts`.
- Kept `SessionPaths.mode` explicit as the literal `"repo"`, preserving the runtime contract without exporting a premature mode type.

## How To Review

- Review the one-file diff in `plugins/codex-autoresearch/lib/session-paths.ts`.
- Confirm `SessionPaths.mode` still communicates the current serialized/runtime value and `SessionStorageMode` has no remaining references.

## Verification

- Rebased onto `origin/dev` `d759c6a` with no conflicts.
- `npm run typecheck:node`
- `npm run build:node`
- `node --test dist\tests\session-control-plane.test.mjs` (`24` passed)
- `git diff --check`

## Risk

- Compatibility risk is limited to source consumers importing the named `SessionStorageMode` alias directly; no in-repo consumers existed, and the package remains private/plugin-distributed.
- Full `npm run check` was attempted before the `origin/dev` refresh but is not counted as final evidence: three slow compiled CLI shards timed out at the shard wrapper limit after printing passing test lines. The refreshed-base evidence above is the targeted verification for this surface.