### PR TITLE
Refactor safe command resolver

### DIFF
--- a/plugins/codex-autoresearch/lib/action-metadata.ts
+++ b/plugins/codex-autoresearch/lib/action-metadata.ts
@@ -1,4 +1,8 @@
-import { readoutSafeCommand } from "./dashboard-command-safety.js";
+import {
+  createCommandLookup,
+  resolveCommandByKeys,
+  resolveSafeCommand,
+} from "./safe-command-resolver.js";
 
 export interface ActionMetadata {
   label: string;
@@ -274,25 +278,17 @@ export function resolveActionCommand(
   commands: unknown,
   context: { explicitCommand?: unknown } = {},
 ): string {
-  const explicit = concreteCommand(context.explicitCommand);
-  if (explicit) {
-    const command = fallbackCommandForPolicy(kind, explicit);
-    if (command) return command;
-  }
+  const explicit = resolveSafeCommand(context.explicitCommand, fallbackCommandMode(kind));
+  if (explicit) return explicit;
 
   const metadata = actionMetadataForKind(kind);
-  const lookup = commandLookup(commands);
+  const lookup = createCommandLookup(commands);
   if (metadata) {
-    for (const key of metadata.fallbackKeys) {
-      const command = fallbackCommandForPolicy(kind, lookup(key));
-      if (command) return command;
-    }
+    const command = fallbackCommandForPolicy(kind, lookup, metadata.fallbackKeys);
+    if (command) return command;
   }
   if (String(kind || "") === "next-packet") {
-    return (
-      fallbackCommandForPolicy(kind, lookup("next")) ||
-      fallbackCommandForPolicy(kind, lookup("nextRun"))
-    );
+    return fallbackCommandForPolicy(kind, lookup, ["next", "nextRun"]);
   }
   return "";
 }
@@ -303,24 +299,25 @@ export function fallbackCommandForKind(
 ): string {
   const metadata = actionMetadataForKind(kind);
   if (!metadata) return "";
-  for (const key of metadata.fallbackKeys) {
-    const command = fallbackCommandForPolicy(
-      kind,
-      lookup(key) || lookup(spacedKey(key)) || lookup(normalizeActionCommandKey(key)),
-    );
-    if (command) return command;
-  }
-  return "";
+  return fallbackCommandForPolicy(kind, lookup, metadata.fallbackKeys);
 }
 
 export function readoutFallbackCommand(command: unknown): string {
-  return readoutSafeCommand(concreteCommand(command));
+  return resolveSafeCommand(command);
 }
 
-function fallbackCommandForPolicy(kind: unknown, command: unknown): string {
-  const text = concreteCommand(command);
-  if (!text) return "";
-  return operationalFallbackKinds.has(String(kind || "")) ? text : readoutFallbackCommand(text);
+function fallbackCommandForPolicy(
+  kind: unknown,
+  lookup: (key: string) => unknown,
+  keys: Iterable<string>,
+): string {
+  return resolveCommandByKeys(lookup, keys, {
+    mode: fallbackCommandMode(kind),
+  });
+}
+
+function fallbackCommandMode(kind: unknown): "operational" | "readout" {
+  return operationalFallbackKinds.has(String(kind || "")) ? "operational" : "readout";
 }
 
 function actionMetadata({
@@ -335,44 +332,4 @@ function actionMetadata({
   return { label, commandLabel, safeAction, packetBrake, fallbackKeys };
 }
 
-function spacedKey(value: string): string {
-  return value.replace(/[A-Z]/g, (match) => ` ${match.toLowerCase()}`).toLowerCase();
-}
-
-export function normalizeActionCommandKey(value: unknown): string {
-  return String(value || "")
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[^a-z0-9]+/gi, " ")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "");
-}
-
-function commandLookup(commands: unknown): (key: string) => string {
-  const entries = new Map<string, string>();
-  const add = (key: unknown, command: unknown) => {
-    const normalized = normalizeActionCommandKey(key);
-    const text = concreteCommand(command);
-    if (normalized && text && !entries.has(normalized)) entries.set(normalized, text);
-  };
-  if (Array.isArray(commands)) {
-    for (const item of commands) {
-      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-      const record = item as Record<string, unknown>;
-      add(record.key, record.command);
-      add(record.name, record.command);
-      add(record.label, record.command);
-    }
-  } else if (commands && typeof commands === "object") {
-    for (const [key, command] of Object.entries(commands as Record<string, unknown>)) {
-      add(key, command);
-    }
-  }
-  return (key: string) => entries.get(normalizeActionCommandKey(key)) || "";
-}
-
-function concreteCommand(command: unknown): string {
-  const text = typeof command === "string" ? command.trim() : "";
-  if (!text || /<[^>]+>/.test(text)) return "";
-  return text;
-}
+export { normalizeActionCommandKey } from "./safe-command-resolver.js";

--- a/plugins/codex-autoresearch/lib/operator-checklist.ts
+++ b/plugins/codex-autoresearch/lib/operator-checklist.ts
@@ -1,4 +1,5 @@
 import { actionMetadataForKind } from "./action-metadata.js";
+import { firstSafeCommand } from "./safe-command-resolver.js";
 
 type LooseObject = Record<string, unknown>;
 
@@ -80,50 +81,64 @@ function evidenceRoleForAction(kind: string): string {
 }
 
 function inspectCommandForAction(action: LooseObject, context: LooseObject): string {
+  return firstSafeCommand(inspectionCommandCandidatesForAction(action, context), "operational");
+}
+
+function boundedInspectCommandForAction(action: LooseObject, context: LooseObject): string {
+  return firstSafeCommand(
+    boundedInspectionCommandCandidatesForAction(action, context),
+    "operational",
+  );
+}
+
+function inspectionCommandCandidatesForAction(action: LooseObject, context: LooseObject): string[] {
   const workDir = stringValue(context.workDir || context.cwd);
-  if (!workDir) return "";
+  if (!workDir) return [];
   const script = scriptCommand(context);
   const cwd = quoteCommandArg(workDir);
   switch (stringValue(action.kind)) {
     case "context-distillation":
-      return `${script} session-forensics --cwd ${cwd} --dry-run`;
+      return [`${script} session-forensics --cwd ${cwd} --dry-run`];
     case "packet-diagnostic":
-      return `${script} partial-results --cwd ${cwd} --from-last`;
+      return [`${script} partial-results --cwd ${cwd} --from-last`];
     case "gate-quality":
     case "preflight":
     case "runtime-provenance":
-      return `${script} doctor --cwd ${cwd} --check-benchmark --explain`;
+      return [`${script} doctor --cwd ${cwd} --check-benchmark --explain`];
     case "portfolio-trust-blocker":
     case "metric-saturation":
-      return `${script} state --cwd ${cwd} --compact --report`;
+      return [`${script} state --cwd ${cwd} --compact --report`];
     case "current-tree-finalization":
-      return `${script} finalize-preview --cwd ${cwd}`;
+      return [`${script} finalize-preview --cwd ${cwd}`];
     case "finalization":
-      return `${script} finalize-preview --cwd ${cwd} --dry-run`;
+      return [`${script} finalize-preview --cwd ${cwd} --dry-run`];
     case "lane-cleanup":
-      return `${script} state --cwd ${cwd} --compact`;
+      return [`${script} state --cwd ${cwd} --compact`];
     default:
       return actionMetadataForKind(action.kind)?.packetBrake === false
-        ? ""
-        : `${script} state --cwd ${cwd} --compact`;
+        ? []
+        : [`${script} state --cwd ${cwd} --compact`];
   }
 }
 
-function boundedInspectCommandForAction(action: LooseObject, context: LooseObject): string {
+function boundedInspectionCommandCandidatesForAction(
+  action: LooseObject,
+  context: LooseObject,
+): string[] {
   const workDir = stringValue(context.workDir || context.cwd);
-  if (!workDir) return "";
+  if (!workDir) return [];
   const script = scriptCommand(context);
   const cwd = quoteCommandArg(workDir);
   switch (stringValue(action.kind)) {
     case "preflight":
     case "setup":
     case "benchmark-command":
-      return `${script} setup-plan --cwd ${cwd}`;
+      return [`${script} setup-plan --cwd ${cwd}`];
     case "benchmark-mismatch":
     case "gate-quality":
-      return `${script} benchmark-lint --cwd ${cwd}`;
+      return [`${script} benchmark-lint --cwd ${cwd}`];
     default:
-      return `${script} state --cwd ${cwd} --compact`;
+      return [`${script} state --cwd ${cwd} --compact`];
   }
 }
 

--- a/plugins/codex-autoresearch/lib/preflight-audit.ts
+++ b/plugins/codex-autoresearch/lib/preflight-audit.ts
@@ -1,3 +1,5 @@
+import { firstSafeCommand } from "./safe-command-resolver.js";
+
 export type PreflightStatus = "blocked" | "ready" | "unknown";
 
 export interface PreflightAuditInput {
@@ -127,14 +129,17 @@ function nextCommand(input: PreflightAuditInput, blockers: string[], warnings: s
         /No benchmark command|Missing setup|No primary metric/i.test(blocker),
       )
     ) {
-      return setupPlanCommand || benchmarkLintCommand || doctorCommand;
+      return firstSafeCommand(
+        [setupPlanCommand, benchmarkLintCommand, doctorCommand],
+        "operational",
+      );
     }
-    return benchmarkLintCommand || setupPlanCommand || doctorCommand;
+    return firstSafeCommand([benchmarkLintCommand, setupPlanCommand, doctorCommand], "operational");
   }
   if (blockers.length > 0 || warnings.some((warning) => /dirty|runtime|stale/i.test(warning))) {
-    return doctorCommand || benchmarkLintCommand;
+    return firstSafeCommand([doctorCommand, benchmarkLintCommand], "operational");
   }
-  return benchmarkLintCommand || doctorCommand;
+  return firstSafeCommand([benchmarkLintCommand, doctorCommand], "operational");
 }
 
 function scaffoldHealthBlockers(value: unknown): string[] {

--- a/plugins/codex-autoresearch/lib/safe-command-resolver.ts
+++ b/plugins/codex-autoresearch/lib/safe-command-resolver.ts
@@ -1,0 +1,87 @@
+import { readoutSafeCommand } from "./dashboard-command-safety.js";
+
+export type SafeCommandMode = "operational" | "readout";
+
+export interface ResolveCommandOptions {
+  keyVariants?: (key: string) => Iterable<string>;
+  mode?: SafeCommandMode;
+}
+
+export function resolveSafeCommand(command: unknown, mode: SafeCommandMode = "readout"): string {
+  const text = concreteCommand(command);
+  if (!text) return "";
+  return mode === "operational" ? text : readoutSafeCommand(text);
+}
+
+export function firstSafeCommand(
+  commands: Iterable<unknown>,
+  mode: SafeCommandMode = "readout",
+): string {
+  for (const command of commands) {
+    const resolved = resolveSafeCommand(command, mode);
+    if (resolved) return resolved;
+  }
+  return "";
+}
+
+export function resolveCommandByKeys(
+  lookup: (key: string) => unknown,
+  keys: Iterable<string>,
+  options: ResolveCommandOptions = {},
+): string {
+  const mode = options.mode || "readout";
+  const keyVariants = options.keyVariants || defaultCommandKeyVariants;
+  for (const key of keys) {
+    for (const variant of keyVariants(key)) {
+      const command = resolveSafeCommand(lookup(variant), mode);
+      if (command) return command;
+    }
+  }
+  return "";
+}
+
+export function createCommandLookup(commands: unknown): (key: string) => string {
+  const entries = new Map<string, string>();
+  const add = (key: unknown, command: unknown) => {
+    const normalized = normalizeActionCommandKey(key);
+    const text = concreteCommand(command);
+    if (normalized && text && !entries.has(normalized)) entries.set(normalized, text);
+  };
+  if (Array.isArray(commands)) {
+    for (const item of commands) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const record = item as Record<string, unknown>;
+      add(record.key, record.command);
+      add(record.name, record.command);
+      add(record.label, record.command);
+    }
+  } else if (commands && typeof commands === "object") {
+    for (const [key, command] of Object.entries(commands as Record<string, unknown>)) {
+      add(key, command);
+    }
+  }
+  return (key: string) => entries.get(normalizeActionCommandKey(key)) || "";
+}
+
+export function normalizeActionCommandKey(value: unknown): string {
+  return String(value || "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "");
+}
+
+export function defaultCommandKeyVariants(key: string): string[] {
+  return [key, spacedKey(key), normalizeActionCommandKey(key)];
+}
+
+function spacedKey(value: string): string {
+  return value.replace(/[A-Z]/g, (match) => ` ${match.toLowerCase()}`).toLowerCase();
+}
+
+function concreteCommand(command: unknown): string {
+  const text = typeof command === "string" ? command.trim() : "";
+  if (!text || /<[^>]+>/.test(text)) return "";
+  return text;
+}

--- a/plugins/codex-autoresearch/tests/loop-governance.test.ts
+++ b/plugins/codex-autoresearch/tests/loop-governance.test.ts
@@ -13,6 +13,7 @@ import { buildLaneLifecycle } from "../lib/lane-lifecycle.js";
 import { buildBudgetStatus } from "../lib/benchmark/budget-contract.js";
 import { buildLoopContractStatus, canonicalNextActionForLoop } from "../lib/loop-governance.js";
 import { buildOperatorChecklist } from "../lib/operator-checklist.js";
+import { firstSafeCommand, resolveCommandByKeys } from "../lib/safe-command-resolver.js";
 import { buildDecisionEnvelope } from "../lib/session-core.js";
 import {
   buildSessionDecisionCapsule,
@@ -689,6 +690,25 @@ test("readout action fallback skips process-starting fallback commands", () => {
   assert.equal(
     resolveActionCommand("decision-capsule", commands),
     "node scripts/autoresearch.mjs state --cwd C:/repo --compact --report",
+  );
+});
+
+test("shared safe command resolver preserves operational commands but filters readouts", () => {
+  const processStarting = "node scripts/autoresearch.mjs benchmark-lint --cwd C:/repo";
+  const inspectOnly = "node scripts/autoresearch.mjs state --cwd C:/repo --compact";
+  const lookup = new Map([
+    ["benchmarkLint", processStarting],
+    ["placeholder", "node scripts/autoresearch.mjs state --cwd <project>"],
+    ["stateCompact", inspectOnly],
+  ]);
+
+  assert.equal(firstSafeCommand([processStarting, inspectOnly], "operational"), processStarting);
+  assert.equal(firstSafeCommand([processStarting, inspectOnly], "readout"), inspectOnly);
+  assert.equal(
+    resolveCommandByKeys((key) => lookup.get(key), ["placeholder", "stateCompact"], {
+      mode: "readout",
+    }),
+    inspectOnly,
   );
 });
 


### PR DESCRIPTION
## Context

Refs #197.

Issue #197 called out duplicated safe inspection/recommendation command resolution across action metadata, operator checklist, preflight, and dashboard fallbacks. This PR keeps the existing command surfaces intact and extracts only the shared resolver boundary.

## What Changed

- Added `lib/safe-command-resolver.ts` for shared command concretization, key lookup normalization, placeholder rejection, and `readout` vs `operational` safety modes.
- Rewired action metadata fallbacks, operator checklist inspection commands, and preflight next-command selection through the shared resolver.
- Added a focused loop-governance regression covering the operational/readout split and placeholder filtering.

## How To Review

- Start with `lib/safe-command-resolver.ts` to see the shared policy boundary.
- Then compare the call sites in `lib/action-metadata.ts`, `lib/operator-checklist.ts`, and `lib/preflight-audit.ts` for behavior-preserving rewiring.
- Check `tests/loop-governance.test.ts` for the targeted resolver invariant.

## Verification

From `origin/dev` `6a6fa8f` after rebasing with no conflicts:

- `git diff --check origin/dev..HEAD`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:core` - 277 passed, 0 failed

## Risk

Low. This is a small refactor of existing fallback selection policy; dashboard read-only command validation remains in `dashboard-command-safety.ts`, and operational commands continue to be allowed only for existing operational action kinds or terminal preflight/checklist recommendations.