### PR TITLE
Document Git-private session snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ### Changed
 
+- Clarified Git-private active last-run/progress storage and non-Git fallback cleanup guidance across docs and the Codex skill.
 - Clarified first-run docs after install, the first successful packet ladder, package-root versus target `--cwd`, and command-index ownership.
 - Clarified demo-session dashboard docs so current review uses the live server or ignored generated exports instead of the checked-in legacy HTML fixture.
 - Changed the product gate to generate an ignored demo dashboard export during checks, preserving version/showcase/read-only/leak/asset-parity trust checks without requiring committed demo HTML churn in routine dashboard UI PRs.

--- a/plugins/codex-autoresearch/docs/concepts.md
+++ b/plugins/codex-autoresearch/docs/concepts.md
@@ -106,8 +106,12 @@ The durable state files written into the target project:
 | `autoresearch.sh` / `.ps1` | Repeatable benchmark entrypoint |
 | `autoresearch.checks.sh` / `.ps1` | Optional correctness gate |
 | `autoresearch.ideas.md` | Deferred hypotheses, rejected lanes, next-action notes |
-| `autoresearch.last-run.json` | Fallback last-packet record |
+| `.git/autoresearch/last-run.json` | Git-private active last-packet record written by `next`. |
+| `.git/autoresearch/progress.json` | Git-private active progress snapshot for slow packets. |
+| `autoresearch.last-run.json` | Non-Git fallback last-packet record. |
+| `autoresearch.progress.json` | Non-Git fallback progress snapshot. |
 | `autoresearch.research/<slug>/` | Deep-research and quality-gap scratchpad for evidence-backed qualitative work. |
+| `autoresearch.pending-transaction.json` | Non-Git fallback receipt for an interrupted log mutation. |
 | `.git/autoresearch/pending-log-*.json` | Git-private pending log receipts that block unsafe continuation after interrupted keep/discard automation. |
 
 See [Start](start.md#session-files).

--- a/plugins/codex-autoresearch/docs/hooks.md
+++ b/plugins/codex-autoresearch/docs/hooks.md
@@ -38,7 +38,7 @@ Goal-aware reminders:
 
 `Stop`:
 
-- warn when `autoresearch.last-run.json` exists
+- warn when an active last-run packet exists under `.git/autoresearch/` or the non-Git fallback `autoresearch.last-run.json`
 - warn when continuation says the loop is still active
 - suggest `state --compact` before final reporting
 - suggest `codex-goal-brief --cwd <project>` before reporting goal completion

--- a/plugins/codex-autoresearch/docs/privacy.md
+++ b/plugins/codex-autoresearch/docs/privacy.md
@@ -4,17 +4,18 @@ Codex Autoresearch is a local Codex plugin workflow. It does not run a hosted se
 
 ## What stays local
 
-Autoresearch writes session state into the target working directory:
+Autoresearch writes durable session state into the target working directory:
 
 - `autoresearch.md`
 - `autoresearch.jsonl`
 - `autoresearch.config.json`
 - `autoresearch.ideas.md`
-- `autoresearch.last-run.json`
 - `autoresearch.research/<slug>/`
 - dashboard exports such as `autoresearch-dashboard.html`
 
-The served dashboard is a local readout from the same files. Static exports are portable HTML snapshots. Both can contain command names, relative paths, metric values, benchmark output tails, ASI notes, artifact names, and summaries of what Codex tried.
+In Git repositories, active packet snapshots are Git-private files under `.git/autoresearch/`: `last-run.json`, `progress.json`, and pending log receipts such as `pending-log-*.json`. Outside Git, the same transient state falls back to worktree files: `autoresearch.last-run.json`, `autoresearch.progress.json`, and `autoresearch.pending-transaction.json`.
+
+The served dashboard is a local readout from the same state. Static exports are portable HTML snapshots. Snapshots, ledgers, pending receipts, and dashboard exports can contain command names, relative paths, metric values, benchmark output tails, ASI notes, artifact names, and summaries of what Codex tried.
 
 ## Command and evidence boundary
 
@@ -41,12 +42,12 @@ Before running packets, logging keeps/discards, exporting dashboards, or sharing
 - inspect Git state and scope `commitPaths` / `revertPaths`
 - review benchmark and checks commands before execution
 - keep secrets out of command lines, output, ASI, and artifacts
-- treat dashboard exports and ledgers as potentially sensitive project records
+- treat dashboard exports, ledgers, last-run packets, progress snapshots, and pending transaction receipts as potentially sensitive project records
 - verify active runtime provenance when installed behavior might differ from source
 
 ## Deleting local data
 
-Session data lives in local project files. Remove or archive them when you no longer need them. In Git repos, also check whether session files were committed, stashed, or copied into review branches.
+Session data lives in local project files and, for Git repos, under `.git/autoresearch/`. Remove or archive both locations when you no longer need them. Also check whether session files, dashboard exports, pending receipts, or copied snapshots were committed, stashed, attached, or moved into review branches.
 
 ---
 

--- a/plugins/codex-autoresearch/docs/start.md
+++ b/plugins/codex-autoresearch/docs/start.md
@@ -39,7 +39,7 @@ Start with one baseline packet. Do not optimize yet.
 | 2 | Run read-only planning only if those essentials are unclear. | `setup-plan` or `prompt-plan` returns a setup path without creating session files. |
 | 3 | Set up the session. | `autoresearch.md`, `autoresearch.jsonl`, and config files exist in the target project. |
 | 4 | Run `doctor --check-benchmark --explain`. | The benchmark emits the primary `METRIC` and trust blockers are visible. |
-| 5 | Run one packet with `next`. | `autoresearch.last-run.json` records fresh packet evidence. |
+| 5 | Run one packet with `next`. | A fresh last-run packet is stored under `.git/autoresearch/` in Git repos, or as a worktree fallback file outside Git. |
 | 6 | Log the packet as `measure`. | Baseline evidence is saved without claiming a keep. |
 | 7 | Read `state --report` or `recommend-next --compact`. | The next action and blockers are explicit before spending another packet. |
 
@@ -141,12 +141,15 @@ Use `state --report` for a compact terminal readout (`report.text` and `report.j
 | `autoresearch.sh` or `autoresearch.ps1` | Repeatable benchmark entrypoint. |
 | `autoresearch.checks.sh` or `autoresearch.checks.ps1` | Optional correctness checks. |
 | `autoresearch.ideas.md` | Deferred hypotheses, avoided lanes, and next-action notes. |
-| `autoresearch.last-run.json` | Fallback last-packet record. |
+| `.git/autoresearch/last-run.json` | Git-private active last-packet record written by `next`. |
+| `.git/autoresearch/progress.json` | Git-private active progress snapshot for slow packets. |
+| `autoresearch.last-run.json` | Non-Git fallback last-packet record. |
+| `autoresearch.progress.json` | Non-Git fallback progress snapshot. |
 | `autoresearch.research/<slug>/` | Deep-research and quality-gap scratchpad. |
 | `autoresearch.pending-transaction.json` | Non-Git fallback receipt for an interrupted log mutation. |
 | `.git/autoresearch/pending-log-*.json` | Git-private pending log receipts that block unsafe continuation. |
 
-In Git repositories, the pending log-mutation receipt lives under `.git/autoresearch/` instead of the worktree.
+In Git repositories, active last-run packets, progress snapshots, and pending log-mutation receipts live under `.git/autoresearch/` instead of the worktree. The `autoresearch.last-run.json`, `autoresearch.progress.json`, and `autoresearch.pending-transaction.json` files are fallback paths for sessions outside Git.
 
 ## First packet
 

--- a/plugins/codex-autoresearch/docs/trust.md
+++ b/plugins/codex-autoresearch/docs/trust.md
@@ -181,7 +181,7 @@ Partial-result salvage reads only in-workdir artifacts. Oversized or malformed a
 
 ## Privacy and local data
 
-Autoresearch has no hosted backend. Session files, dashboard exports, ASI, packet evidence, and artifact indexes are local project records unless your commands, Git workflow, or external services move them elsewhere.
+Autoresearch has no hosted backend. Session files, dashboard exports, ASI, packet evidence, progress snapshots, pending transaction receipts, and artifact indexes are local project records unless your commands, Git workflow, or external services move them elsewhere. In Git repos, active last-run and progress snapshots live under `.git/autoresearch/`; outside Git, they fall back to `autoresearch.last-run.json` and `autoresearch.progress.json` in the worktree.
 
 See [Privacy](privacy.md) and [Terms](terms.md) for the user-facing policy surfaces.
 

--- a/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
+++ b/plugins/codex-autoresearch/skills/codex-autoresearch/SKILL.md
@@ -21,7 +21,7 @@ The job: make one measured improvement loop trustworthy enough that a human can 
 - For qualitative or deep-research improvement loops, start with `research-start --cwd <project> --slug <slug> --goal "<goal>"`. It creates the scratchpad, configures `quality_gap`, validates the command, and records the first baseline as `measure` unless `--no-baseline-log` is passed.
 - Use advanced diagnostics only when needed. Check `node scripts/autoresearch.mjs --help --all` from the package root before naming a less common command.
 - Use `new-segment` when the active segment is maxed, stale, phase-changing, or no longer comparable.
-- Prefer CLI JSON and durable session files over chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.ideas.md`, `autoresearch.last-run.json`, and `autoresearch.research/<slug>/`.
+- Prefer CLI JSON and durable session state over chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.ideas.md`, active last-run/progress snapshots under `.git/autoresearch/` in Git repos, fallback `autoresearch.last-run.json` / `autoresearch.progress.json` outside Git, and `autoresearch.research/<slug>/`.
 - Keep every packet decision recoverable through `METRIC name=value`, packet evidence, ASI, continuation data, promotion labels, and the ledger.
 - Before another packet, read `recommend-next --compact` or `state --compact`; obey blockers. Compact-state field names: `docs/concepts.md#state-fields`.
 - `benchmark-lint` must prove the primary `METRIC` contract before product packets are trusted.


### PR DESCRIPTION
## Context
Refs #216

The active packet snapshot docs still pointed readers at worktree fallback files, while the CLI now stores active last-run and progress snapshots under `.git/autoresearch/` for Git repos.

## What Changed
- Clarified Git-private active last-run/progress storage in Start and Concepts.
- Updated Privacy and Trust cleanup/share guidance to include progress snapshots and pending transaction receipts.
- Updated the hook reminder and Codex skill guidance so operators check Git-private snapshots plus non-Git fallbacks.
- Added one Unreleased changelog note.

## How To Review
- Read the changed docs as a storage-truth update, not a behavior change.
- Compare the wording against `resolveLastRunPath`, `resolveProgressPath`, `pendingLogTransactionPath`, `resolveSessionPaths`, and `clearSession` in `scripts/autoresearch.ts` / `lib/session-paths.ts`.

## Verification
- `rg -n "autoresearch\.last-run\.json exists|autoresearch\.last-run\.json records|records fresh packet evidence|Autoresearch writes session state into the target working directory|Session data lives in local project files\.|pending log-mutation receipt lives under \.git/autoresearch" plugins\codex-autoresearch\docs plugins\codex-autoresearch\skills\codex-autoresearch\SKILL.md README.md CHANGELOG.md` returned no matches.
- `rg -n "\.git/autoresearch/last-run\.json|\.git/autoresearch/progress\.json|autoresearch\.progress\.json|autoresearch\.pending-transaction\.json|pending-log-\*\.json" plugins\codex-autoresearch\docs plugins\codex-autoresearch\skills\codex-autoresearch\SKILL.md CHANGELOG.md` found the updated truth surfaces.
- `git diff --check` passed.

## Risk
Docs-only. The main risk is that future storage behavior changes again without updating the same docs/skill surfaces.