### PR TITLE
[codex] Honor session cwd in live dashboard freshness

### DIFF
--- a/plugins/codex-autoresearch/lib/commands/dashboard.ts
+++ b/plugins/codex-autoresearch/lib/commands/dashboard.ts
@@ -9,7 +9,7 @@ import {
 } from "../dashboard-server-registry.js";
 import { compactDashboardTransportViewModel } from "../dashboard-transport.js";
 import { verifyDashboardHealthSummary } from "../dashboard-health.js";
-import type { SessionPaths } from "../session-paths.js";
+import { sessionPathIdentity, type SessionPaths } from "../session-paths.js";
 
 type LooseObject = Record<string, any>;
 type DashboardCommandListOptions = {
@@ -238,6 +238,7 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
     const startedAt = Date.now();
     const startedAtIso = new Date(startedAt).toISOString();
     const { workDir, sessionPaths } = deps.resolveWorkDir(args.working_dir || args.cwd);
+    const expectedSessionPathIdentity = sessionPathIdentity(sessionPaths);
     const debugLedger = deps.boolOption(args.debugLedger ?? args.debug_ledger, false);
     const liveReadCache = deps.createSessionReadCache?.({ invalidateOnLedgerChange: true });
     let liveUrl = "";
@@ -247,6 +248,7 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
         expectedVersion: deps.pluginVersion,
         timeoutMs: 500,
         debugLedger,
+        sessionPaths,
       });
       dashboardServerRegistry = reusableRegistry.available ? reusableRegistry : null;
       if (reusableRegistry.reusable) {
@@ -324,6 +326,8 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
       pid: process.pid,
       port: Number(serveResult.port),
       cwd: workDir,
+      sessionCwd: sessionPaths.sessionCwd,
+      sessionPathIdentity: expectedSessionPathIdentity,
       startedAt: startedAtIso,
       version: deps.pluginVersion,
       healthUrl,
@@ -339,6 +343,8 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
       pid: process.pid,
       registryPath: registryWrite.path,
       cwd: workDir,
+      sessionCwd: sessionPaths.sessionCwd,
+      sessionPathIdentity: expectedSessionPathIdentity,
       version: deps.pluginVersion,
       startedAt: startedAtIso,
       previous: registrySummary,

--- a/plugins/codex-autoresearch/lib/commands/dashboard.ts
+++ b/plugins/codex-autoresearch/lib/commands/dashboard.ts
@@ -9,6 +9,7 @@ import {
 } from "../dashboard-server-registry.js";
 import { compactDashboardTransportViewModel } from "../dashboard-transport.js";
 import { verifyDashboardHealthSummary } from "../dashboard-health.js";
+import type { SessionPaths } from "../session-paths.js";
 
 type LooseObject = Record<string, any>;
 type DashboardCommandListOptions = {
@@ -35,7 +36,12 @@ export interface DashboardCommandDeps {
   pluginVersion: string;
   readJsonl: (workDir: string) => LooseObject[];
   resolveOutputInside: (workDir: string, output?: string) => string;
-  resolveWorkDir: (value: string) => { workDir: string; config: LooseObject; sessionCwd?: string };
+  resolveWorkDir: (value: string) => {
+    workDir: string;
+    config: LooseObject;
+    sessionCwd?: string;
+    sessionPaths: SessionPaths;
+  };
   serveAutoresearch: (options: LooseObject) => Promise<LooseObject>;
   shellQuote: (value: string) => string;
   writeFile: typeof fsp.writeFile;
@@ -231,7 +237,7 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
   async function serveDashboard(args: LooseObject) {
     const startedAt = Date.now();
     const startedAtIso = new Date(startedAt).toISOString();
-    const { workDir } = deps.resolveWorkDir(args.working_dir || args.cwd);
+    const { workDir, sessionPaths } = deps.resolveWorkDir(args.working_dir || args.cwd);
     const debugLedger = deps.boolOption(args.debugLedger ?? args.debug_ledger, false);
     const liveReadCache = deps.createSessionReadCache?.({ invalidateOnLedgerChange: true });
     let liveUrl = "";
@@ -260,6 +266,7 @@ export function createDashboardCommands(deps: DashboardCommandDeps) {
       .catch(unavailableRuntimeDrift);
     const serveResult = await deps.serveAutoresearch({
       cwd: workDir,
+      sessionPaths,
       port: args.port,
       debugLedger,
       pluginVersion: deps.pluginVersion,

--- a/plugins/codex-autoresearch/lib/dashboard-health.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-health.ts
@@ -8,6 +8,8 @@ export interface DashboardHealthInput {
   pid?: unknown;
   registryPath?: unknown;
   cwd?: unknown;
+  sessionCwd?: unknown;
+  sessionPathIdentity?: unknown;
   version?: unknown;
   startedAt?: unknown;
   previous?: unknown;
@@ -21,6 +23,8 @@ export interface DashboardHealthSummary {
   healthUrl: string;
   registryPath: string;
   cwd: string;
+  sessionCwd: string;
+  sessionPathIdentity: string;
   version: string;
   mode: string;
   lastReadAt: string;
@@ -41,6 +45,8 @@ export function buildDashboardHealthSummary(input: DashboardHealthInput): Dashbo
     healthUrl: healthUrlFromUrl(url),
     registryPath: cleanString(input.registryPath),
     cwd: cleanString(input.cwd),
+    sessionCwd: cleanString(input.sessionCwd),
+    sessionPathIdentity: cleanString(input.sessionPathIdentity),
     version: cleanString(input.version),
     mode: "",
     lastReadAt: "",
@@ -132,9 +138,20 @@ function dashboardHealthDetails(payload: unknown): { mode: string; lastReadAt: s
 function dashboardMatchesSummary(dashboard: unknown, summary: DashboardHealthSummary): boolean {
   const port = recordValue(dashboard, "port");
   const cwd = cleanString(recordValue(dashboard, "cwd"));
+  const sessionCwd = cleanString(recordValue(dashboard, "sessionCwd"));
+  const sessionPathIdentity = cleanString(recordValue(dashboard, "sessionPathIdentity"));
   const version = cleanString(recordValue(dashboard, "version"));
   if (summary.port !== null && port !== summary.port) return false;
   if (summary.cwd && (!cwd || !samePathText(cwd, summary.cwd))) return false;
+  if (
+    summary.sessionPathIdentity &&
+    (!sessionPathIdentity || sessionPathIdentity !== summary.sessionPathIdentity)
+  ) {
+    return false;
+  }
+  if (summary.sessionCwd && (!sessionCwd || !samePathText(sessionCwd, summary.sessionCwd))) {
+    return false;
+  }
   if (summary.version && (!version || version !== summary.version)) return false;
   return true;
 }

--- a/plugins/codex-autoresearch/lib/dashboard-server-registry.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-server-registry.ts
@@ -2,10 +2,11 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { type DashboardHealthSummary, verifyDashboardHealthSummary } from "./dashboard-health.js";
-import { resolveSessionPaths } from "./session-paths.js";
+import { resolveSessionPaths, sessionPathIdentity, type SessionPaths } from "./session-paths.js";
 
 type Liveness = "alive" | "dead" | "unknown";
 type CwdRelation = "same-cwd" | "different-cwd" | "unknown";
+type SessionRelation = "same-session" | "different-session" | "unknown";
 
 export interface DashboardServeRegistryRecord {
   pid: number;
@@ -15,6 +16,8 @@ export interface DashboardServeRegistryRecord {
   version: string;
   healthUrl: string;
   debugLedger?: boolean;
+  sessionCwd?: string;
+  sessionPathIdentity?: string;
   previous?: DashboardServeRegistrySummary | null;
 }
 
@@ -23,6 +26,8 @@ export interface DashboardServeRegistrySummary {
   stale: boolean | null;
   sameCwd: boolean | null;
   cwdRelation: CwdRelation;
+  sameSession: boolean | null;
+  sessionRelation: SessionRelation;
   liveness: Liveness;
   currentProcess: boolean | null;
   message: string;
@@ -35,6 +40,8 @@ export interface DashboardServeRegistryHealthInput {
   pid?: number;
   registryPath: string;
   cwd: string;
+  sessionCwd: string;
+  sessionPathIdentity: string;
   version?: string;
   startedAt?: string;
   previous: DashboardServeRegistrySummary;
@@ -110,7 +117,12 @@ export async function writeServeRegistry(
 
 export function summarizeServeRegistry(
   record: DashboardServeRegistryRecord | null,
-  options: { currentPid?: number; currentCwd?: string } = {},
+  options: {
+    currentPid?: number;
+    currentCwd?: string;
+    sessionCwd?: string;
+    sessionPathIdentity?: string;
+  } = {},
 ): DashboardServeRegistrySummary {
   if (!record) {
     return {
@@ -118,6 +130,8 @@ export function summarizeServeRegistry(
       stale: null,
       sameCwd: null,
       cwdRelation: "unknown",
+      sameSession: null,
+      sessionRelation: "unknown",
       liveness: "unknown",
       currentProcess: null,
       message: "No dashboard serve registry record is available.",
@@ -131,10 +145,13 @@ export function summarizeServeRegistry(
   const sameCwd = currentCwd && normalized.cwd ? samePath(normalized.cwd, currentCwd) : null;
   const cwdRelation: CwdRelation =
     sameCwd == null ? "unknown" : sameCwd ? "same-cwd" : "different-cwd";
+  const sameSession = registrySessionMatches(normalized, options);
+  const sessionRelation: SessionRelation =
+    sameSession == null ? "unknown" : sameSession ? "same-session" : "different-session";
   const liveness = inspectProcessLiveness(normalized.pid);
   const currentProcess = currentPid == null ? null : normalized.pid === currentPid;
   const stale =
-    sameCwd === false
+    sameCwd === false || sameSession === false
       ? true
       : liveness === "dead"
         ? true
@@ -149,9 +166,18 @@ export function summarizeServeRegistry(
     stale,
     sameCwd,
     cwdRelation,
+    sameSession,
+    sessionRelation,
     liveness,
     currentProcess,
-    message: registryMessage({ record: normalized, stale, cwdRelation, liveness, currentProcess }),
+    message: registryMessage({
+      record: normalized,
+      stale,
+      cwdRelation,
+      sessionRelation,
+      liveness,
+      currentProcess,
+    }),
     record: normalized,
   };
 }
@@ -159,17 +185,29 @@ export function summarizeServeRegistry(
 export function buildServeRegistryHealthInput(
   workDir: string,
   record: DashboardServeRegistryRecord | null,
-  options: { expectedVersion?: string; timeoutMs?: number } = {},
+  options: {
+    expectedVersion?: string;
+    timeoutMs?: number;
+    sessionCwd?: string;
+    sessionPathIdentity?: string;
+  } = {},
 ): DashboardServeRegistryHealthInput {
   const requestedCwd = path.resolve(workDir);
   const normalized = record ? normalizeRecord(record) : null;
-  const previous = summarizeServeRegistry(normalized, { currentCwd: requestedCwd });
+  const previous = summarizeServeRegistry(normalized, {
+    currentCwd: requestedCwd,
+    sessionCwd: options.sessionCwd,
+    sessionPathIdentity: options.sessionPathIdentity,
+  });
   return {
     url: normalized?.port ? `http://127.0.0.1:${normalized.port}/` : "",
     port: normalized?.port,
     pid: normalized?.pid,
     registryPath: registryPathForWorkDir(requestedCwd),
     cwd: requestedCwd,
+    sessionCwd: cleanString(options.sessionCwd) || normalized?.sessionCwd || "",
+    sessionPathIdentity:
+      cleanString(options.sessionPathIdentity) || normalized?.sessionPathIdentity || "",
     version: cleanString(options.expectedVersion) || normalized?.version,
     startedAt: normalized?.startedAt,
     previous,
@@ -179,11 +217,24 @@ export function buildServeRegistryHealthInput(
 
 export async function findReusableServeRegistry(
   workDir: string,
-  options: { expectedVersion?: string; timeoutMs?: number; debugLedger?: boolean } = {},
+  options: {
+    expectedVersion?: string;
+    timeoutMs?: number;
+    debugLedger?: boolean;
+    sessionPaths?: SessionPaths;
+  } = {},
 ): Promise<DashboardServeRegistryLookup> {
   const requestedCwd = path.resolve(workDir);
+  const expectedSessionCwd = options.sessionPaths?.sessionCwd || "";
+  const expectedSessionPathIdentity = options.sessionPaths
+    ? sessionPathIdentity(options.sessionPaths)
+    : "";
   const record = await readServeRegistry(requestedCwd);
-  const previous = summarizeServeRegistry(record, { currentCwd: requestedCwd });
+  const previous = summarizeServeRegistry(record, {
+    currentCwd: requestedCwd,
+    sessionCwd: expectedSessionCwd,
+    sessionPathIdentity: expectedSessionPathIdentity,
+  });
   const registryPath = registryPathForWorkDir(requestedCwd);
   const recoveryCommand = serveRecoveryCommand(requestedCwd);
   if (!record) {
@@ -213,6 +264,8 @@ export async function findReusableServeRegistry(
     buildServeRegistryHealthInput(requestedCwd, record, {
       expectedVersion: options.expectedVersion,
       timeoutMs: options.timeoutMs,
+      sessionCwd: expectedSessionCwd,
+      sessionPathIdentity: expectedSessionPathIdentity,
     }),
   );
   const reusable =
@@ -303,6 +356,8 @@ function normalizeRecord(record: unknown): DashboardServeRegistryRecord {
     version: cleanString(source.version),
     healthUrl: cleanString(source.healthUrl),
     debugLedger: source.debugLedger === true,
+    sessionCwd: cleanString(source.sessionCwd),
+    sessionPathIdentity: cleanString(source.sessionPathIdentity),
   };
 }
 
@@ -312,6 +367,8 @@ function compactSummary(summary: DashboardServeRegistrySummary): DashboardServeR
     stale: summary.stale,
     sameCwd: summary.sameCwd,
     cwdRelation: summary.cwdRelation,
+    sameSession: summary.sameSession,
+    sessionRelation: summary.sessionRelation,
     liveness: summary.liveness,
     currentProcess: summary.currentProcess,
     message: summary.message,
@@ -336,22 +393,40 @@ function registryMessage({
   record,
   stale,
   cwdRelation,
+  sessionRelation,
   liveness,
   currentProcess,
 }: {
   record: DashboardServeRegistryRecord;
   stale: boolean | null;
   cwdRelation: CwdRelation;
+  sessionRelation: SessionRelation;
   liveness: Liveness;
   currentProcess: boolean | null;
 }): string {
-  if (currentProcess) return "Dashboard serve registry matches this process.";
   if (cwdRelation === "different-cwd") {
     return `Dashboard registry points at a different cwd: ${record.cwd}.`;
   }
+  if (sessionRelation === "different-session") {
+    return "Dashboard registry points at a different session path contract.";
+  }
+  if (currentProcess) return "Dashboard serve registry matches this process.";
   if (liveness === "dead") return `Dashboard registry pid ${record.pid} is not running.`;
   if (stale === false) return "Dashboard registry points at a live same-cwd server.";
   return "Dashboard registry liveness could not be fully inspected.";
+}
+
+function registrySessionMatches(
+  record: DashboardServeRegistryRecord,
+  options: { sessionCwd?: string; sessionPathIdentity?: string },
+): boolean | null {
+  const expectedIdentity = cleanString(options.sessionPathIdentity);
+  if (expectedIdentity) return cleanString(record.sessionPathIdentity) === expectedIdentity;
+  const expectedSessionCwd = cleanString(options.sessionCwd);
+  if (expectedSessionCwd) {
+    return record.sessionCwd ? samePath(record.sessionCwd, expectedSessionCwd) : false;
+  }
+  return null;
 }
 
 function finitePositiveInteger(value: unknown): number | null {

--- a/plugins/codex-autoresearch/lib/live-server.ts
+++ b/plugins/codex-autoresearch/lib/live-server.ts
@@ -7,7 +7,7 @@ import { createInterface } from "node:readline";
 import type { DashboardLedgerBounds } from "./dashboard-ledger-bounds.js";
 import { compactDashboardTransportViewModel } from "./dashboard-transport.js";
 import { redactEvidenceObject, redactEvidenceText } from "./evidence-redaction.js";
-import { resolveSessionPaths } from "./session-paths.js";
+import { resolveSessionPaths, type SessionPaths } from "./session-paths.js";
 
 type LooseObject = Record<string, unknown>;
 
@@ -46,6 +46,11 @@ interface LiveSessionSnapshot {
   stamp: string;
 }
 
+interface LiveSessionContext {
+  workDir: string;
+  sessionPaths: SessionPaths;
+}
+
 interface LedgerReadout {
   entries: LooseObject[];
   ledgerBounds: DashboardLedgerBounds;
@@ -56,7 +61,8 @@ interface BoundedLedgerLines extends DashboardLedgerBounds {
 }
 
 export async function serveAutoresearch(args: LooseObject) {
-  const workDir = path.resolve(String(args.working_dir || args.cwd || process.cwd()));
+  const sessionContext = resolveLiveSessionContext(args);
+  const { workDir, sessionPaths } = sessionContext;
   const port = Number(args.port || 0);
   const dashboardHtml = args.dashboardHtml as (context?: LooseObject) => Promise<string>;
   const viewModel = args.viewModel as () => Promise<LooseObject>;
@@ -94,9 +100,7 @@ export async function serveAutoresearch(args: LooseObject) {
           );
           return;
         }
-        const ledgerLines = await readBoundedLedgerLines(
-          resolveSessionPaths({ workDir }).ledgerPath,
-        );
+        const ledgerLines = await readBoundedLedgerLines(sessionPaths.ledgerPath);
         send(
           res,
           200,
@@ -108,6 +112,7 @@ export async function serveAutoresearch(args: LooseObject) {
       if (req.method === "GET" && url.pathname === "/view-model.json") {
         const payload = await readCachedLiveViewModel({
           workDir,
+          sessionPaths,
           viewModel,
           nowMs: Date.now(),
           ttlMs: viewModelCacheTtlMs,
@@ -222,19 +227,22 @@ function redactLedgerLines(lines: string[], context: LooseObject): string {
 
 async function readCachedLiveViewModel({
   workDir,
+  sessionPaths,
   viewModel,
   nowMs,
   ttlMs,
   cache,
 }: {
   workDir: string;
+  sessionPaths: SessionPaths;
   viewModel: () => Promise<LooseObject>;
   nowMs: number;
   ttlMs: number;
   cache: LiveViewModelCacheState;
 }): Promise<LiveViewModelResult> {
   const cached = cache.current;
-  const snapshot = await liveSessionSnapshot(workDir, {
+  const sessionContext = { workDir, sessionPaths };
+  const snapshot = await liveSessionSnapshot(sessionContext, {
     cached,
     nowMs,
     ttlMs,
@@ -248,7 +256,12 @@ async function readCachedLiveViewModel({
   }
   const pending: LiveViewModelRefresh = {
     fingerprint,
-    promise: buildLiveViewModelRefresh({ workDir, viewModel, ttlMs, fingerprint }),
+    promise: buildLiveViewModelRefresh({
+      sessionContext,
+      viewModel,
+      ttlMs,
+      fingerprint,
+    }),
   };
   cache.pending = pending;
   try {
@@ -261,19 +274,19 @@ async function readCachedLiveViewModel({
 }
 
 async function buildLiveViewModelRefresh({
-  workDir,
+  sessionContext,
   viewModel,
   ttlMs,
   fingerprint,
 }: {
-  workDir: string;
+  sessionContext: LiveSessionContext;
   viewModel: () => Promise<LooseObject>;
   ttlMs: number;
   fingerprint: string;
 }): Promise<LiveViewModelResult> {
   let expectedFingerprint = fingerprint;
   for (let attempt = 0; ; attempt += 1) {
-    const refresh = await buildLiveViewModelBody({ workDir, viewModel });
+    const refresh = await buildLiveViewModelBody({ sessionContext, viewModel });
     if (refresh.completedSnapshot.fingerprint === expectedFingerprint) {
       return liveViewModelResult({
         body: refresh.body,
@@ -296,17 +309,18 @@ async function buildLiveViewModelRefresh({
 }
 
 async function buildLiveViewModelBody({
-  workDir,
+  sessionContext,
   viewModel,
 }: {
-  workDir: string;
+  sessionContext: LiveSessionContext;
   viewModel: () => Promise<LooseObject>;
 }): Promise<{
   body: LooseObject;
   completedAt: number;
   completedSnapshot: LiveSessionSnapshot;
 }> {
-  const ledgerReadout = await readRedactedLedgerEntries(workDir, { workDir });
+  const { workDir, sessionPaths } = sessionContext;
+  const ledgerReadout = await readRedactedLedgerEntries(sessionPaths, { workDir });
   const body = redactEvidenceObject(
     {
       ...compactDashboardTransportViewModel(await viewModel()),
@@ -316,7 +330,7 @@ async function buildLiveViewModelBody({
     { workDir },
   );
   const completedAt = Date.now();
-  const completedSnapshot = await liveSessionSnapshot(workDir, {
+  const completedSnapshot = await liveSessionSnapshot(sessionContext, {
     cached: null,
     nowMs: completedAt,
     ttlMs: 0,
@@ -387,20 +401,29 @@ export async function liveSessionFingerprint(
     cached: LiveViewModelCache | null;
     nowMs: number;
     ttlMs: number;
+    sessionPaths?: SessionPaths;
   },
 ): Promise<string> {
-  return (await liveSessionSnapshot(workDir, options)).fingerprint;
+  return (
+    await liveSessionSnapshot(
+      {
+        workDir: path.resolve(workDir),
+        sessionPaths: options.sessionPaths || resolveSessionPaths({ workDir }),
+      },
+      options,
+    )
+  ).fingerprint;
 }
 
 async function liveSessionSnapshot(
-  workDir: string,
+  sessionContext: LiveSessionContext,
   options: {
     cached: LiveViewModelCache | null;
     nowMs: number;
     ttlMs: number;
   },
 ): Promise<LiveSessionSnapshot> {
-  const stamp = await liveSessionStamp(workDir);
+  const stamp = await liveSessionStamp(sessionContext.sessionPaths);
   if (
     options.cached &&
     options.cached.fingerprintStamp === stamp &&
@@ -408,7 +431,7 @@ async function liveSessionSnapshot(
   ) {
     return { fingerprint: options.cached.fingerprint, stamp };
   }
-  const sessionPaths = resolveSessionPaths({ workDir });
+  const { sessionPaths } = sessionContext;
   const parts = await Promise.all([
     fingerprintPath(sessionPaths.ledgerPath, "autoresearch.jsonl"),
     fingerprintPath(sessionPaths.configPath, "autoresearch.config.json"),
@@ -420,10 +443,9 @@ async function liveSessionSnapshot(
   return { fingerprint: parts.join("|"), stamp };
 }
 
-async function liveSessionStamp(workDir: string): Promise<string> {
+async function liveSessionStamp(sessionPaths: SessionPaths): Promise<string> {
   // TTL-bounded dashboard reuse compares this stamp; a stale stamp can serve briefly
   // until the next health poll notices ledger/config drift.
-  const sessionPaths = resolveSessionPaths({ workDir });
   const parts = await Promise.all([
     fingerprintPath(sessionPaths.ledgerPath, "autoresearch.jsonl"),
     fingerprintPath(sessionPaths.configPath, "autoresearch.config.json"),
@@ -490,10 +512,10 @@ function normalizeCacheTtlMs(value: unknown): number {
 }
 
 async function readRedactedLedgerEntries(
-  workDir: string,
+  sessionPaths: SessionPaths,
   context: LooseObject,
 ): Promise<LedgerReadout> {
-  const boundedLines = await readBoundedLedgerLines(resolveSessionPaths({ workDir }).ledgerPath);
+  const boundedLines = await readBoundedLedgerLines(sessionPaths.ledgerPath);
   const parsedEntries = boundedLines.lines.flatMap((line) => {
     try {
       const entry = redactEvidenceObject(JSON.parse(line), context);
@@ -619,4 +641,34 @@ function isFileNotFound(error: unknown): boolean {
 
 function isLooseObject(value: unknown): value is LooseObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveLiveSessionContext(args: LooseObject): LiveSessionContext {
+  const rawSessionPaths = args.sessionPaths;
+  if (isSessionPaths(rawSessionPaths)) {
+    const workDir = path.resolve(
+      String(args.working_dir || rawSessionPaths.targetCwd || args.cwd || process.cwd()),
+    );
+    return { workDir, sessionPaths: rawSessionPaths };
+  }
+  const workDir = path.resolve(String(args.working_dir || args.cwd || process.cwd()));
+  const rawSessionCwd = args.sessionCwd ?? args.session_cwd;
+  return {
+    workDir,
+    sessionPaths: resolveSessionPaths({
+      sessionCwd: rawSessionCwd ? String(rawSessionCwd) : undefined,
+      workDir,
+    }),
+  };
+}
+
+function isSessionPaths(value: unknown): value is SessionPaths {
+  if (!isLooseObject(value)) return false;
+  return (
+    typeof value.targetCwd === "string" &&
+    typeof value.sessionCwd === "string" &&
+    typeof value.ledgerPath === "string" &&
+    typeof value.configPath === "string" &&
+    typeof value.researchRoot === "string"
+  );
 }

--- a/plugins/codex-autoresearch/lib/live-server.ts
+++ b/plugins/codex-autoresearch/lib/live-server.ts
@@ -7,7 +7,7 @@ import { createInterface } from "node:readline";
 import type { DashboardLedgerBounds } from "./dashboard-ledger-bounds.js";
 import { compactDashboardTransportViewModel } from "./dashboard-transport.js";
 import { redactEvidenceObject, redactEvidenceText } from "./evidence-redaction.js";
-import { resolveSessionPaths, type SessionPaths } from "./session-paths.js";
+import { resolveSessionPaths, sessionPathIdentity, type SessionPaths } from "./session-paths.js";
 
 type LooseObject = Record<string, unknown>;
 
@@ -127,6 +127,8 @@ export async function serveAutoresearch(args: LooseObject) {
           workDir,
           dashboard: {
             cwd: workDir,
+            sessionCwd: sessionPaths.sessionCwd,
+            sessionPathIdentity: sessionPathIdentity(sessionPaths),
             liveness: "alive",
             mode: "live-server",
             pid: process.pid,

--- a/plugins/codex-autoresearch/lib/session-paths.ts
+++ b/plugins/codex-autoresearch/lib/session-paths.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 
 export const AUTORESEARCH_LEDGER_FILE = "autoresearch.jsonl";
@@ -79,4 +80,23 @@ export function resolveSessionPaths(input: ResolveSessionPathsInput = {}): Sessi
 
 export function researchDirPathForSession(workDir: string, slug: string): string {
   return path.join(resolveSessionPaths({ workDir }).researchRoot, slug);
+}
+
+export function sessionPathIdentity(sessionPaths: SessionPaths): string {
+  const identity = {
+    targetCwd: normalizeIdentityPath(sessionPaths.targetCwd),
+    sessionCwd: normalizeIdentityPath(sessionPaths.sessionCwd),
+    ledgerPath: normalizeIdentityPath(sessionPaths.ledgerPath),
+    configPath: normalizeIdentityPath(sessionPaths.configPath),
+    notesPath: normalizeIdentityPath(sessionPaths.notesPath),
+    ideasPath: normalizeIdentityPath(sessionPaths.ideasPath),
+    lastRunFallbackPath: normalizeIdentityPath(sessionPaths.lastRunFallbackPath),
+    researchRoot: normalizeIdentityPath(sessionPaths.researchRoot),
+  };
+  return createHash("sha256").update(JSON.stringify(identity)).digest("hex");
+}
+
+function normalizeIdentityPath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }

--- a/plugins/codex-autoresearch/tests/dashboard-server-registry.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-server-registry.test.ts
@@ -20,6 +20,7 @@ import {
   summarizeServeRegistry,
   writeServeRegistry,
 } from "../lib/dashboard-server-registry.js";
+import { resolveSessionPaths, sessionPathIdentity } from "../lib/session-paths.js";
 import { withTempDir } from "./helpers/process.js";
 
 async function requestText(url: string, headers: Record<string, string> = {}) {
@@ -44,8 +45,10 @@ async function requestText(url: string, headers: Record<string, string> = {}) {
 test("serve dashboard command reuses a healthy registry instead of starting another server", async () => {
   await withTempDir("autoresearch", "serve-registry-reuse", async (dir) => {
     const startedAt = "2026-06-08T00:00:00.000Z";
+    const sessionPaths = resolveSessionPaths({ workDir: dir });
     const existing = await serveAutoresearch({
       cwd: dir,
+      sessionPaths,
       port: 0,
       pluginVersion: PLUGIN_VERSION,
       startedAt,
@@ -61,6 +64,8 @@ test("serve dashboard command reuses a healthy registry instead of starting anot
         startedAt,
         version: PLUGIN_VERSION,
         healthUrl: new URL("health", existing.url).toString(),
+        sessionCwd: sessionPaths.sessionCwd,
+        sessionPathIdentity: sessionPathIdentity(sessionPaths),
       });
 
       let serveAttempts = 0;
@@ -78,7 +83,7 @@ test("serve dashboard command reuses a healthy registry instead of starting anot
         pluginVersion: PLUGIN_VERSION,
         readJsonl: () => [],
         resolveOutputInside: () => "",
-        resolveWorkDir: () => ({ workDir: dir, config: {} }),
+        resolveWorkDir: () => ({ workDir: dir, config: {}, sessionPaths }),
         serveAutoresearch: async () => {
           serveAttempts += 1;
           throw new Error("healthy registry should be reused");
@@ -99,6 +104,86 @@ test("serve dashboard command reuses a healthy registry instead of starting anot
       assert.equal(result.healthUrl, new URL("health", existing.url).toString());
       assert.equal(result.pid, process.pid);
       assert.match(result.recoveryCommand, /node scripts\/autoresearch\.mjs serve --cwd /);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        existing.server.close((error: Error | undefined) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});
+
+test("serve dashboard command does not reuse target-cwd registry for wrapper session cwd", async () => {
+  await withTempDir("autoresearch", "serve-registry-wrapper-session", async (root) => {
+    const wrapper = path.join(root, "wrapper");
+    const target = path.join(root, "target");
+    await mkdir(wrapper, { recursive: true });
+    await mkdir(target, { recursive: true });
+    const targetSessionPaths = resolveSessionPaths({ workDir: target });
+    const wrapperSessionPaths = resolveSessionPaths({ sessionCwd: wrapper, workDir: target });
+    const startedAt = "2026-06-08T00:00:00.000Z";
+    const existing = await serveAutoresearch({
+      cwd: target,
+      sessionPaths: targetSessionPaths,
+      port: 0,
+      pluginVersion: PLUGIN_VERSION,
+      startedAt,
+      dashboardHtml: async () => "<!doctype html><title>target session</title>",
+      viewModel: async () => ({ ok: true }),
+    });
+    const fakeServer = {
+      on() {
+        return fakeServer;
+      },
+    };
+
+    try {
+      await writeServeRegistry(target, {
+        pid: existing.pid,
+        port: existing.port,
+        cwd: target,
+        startedAt,
+        version: PLUGIN_VERSION,
+        healthUrl: new URL("health", existing.url).toString(),
+        sessionCwd: targetSessionPaths.sessionCwd,
+        sessionPathIdentity: sessionPathIdentity(targetSessionPaths),
+      });
+
+      let serveAttempts = 0;
+      const { serveDashboard } = createDashboardCommands({
+        boolOption: (value, fallback) => (typeof value === "boolean" ? value : fallback),
+        buildDriftReport: async () => ({ ok: true }),
+        dashboardCommands: () => [],
+        dashboardHtml: () => "",
+        dashboardSettings: () => ({}),
+        dashboardViewModel: async () => ({}),
+        operationProgress: (options) => options,
+        pluginRoot: process.cwd(),
+        pluginVersion: PLUGIN_VERSION,
+        readJsonl: () => [],
+        resolveOutputInside: () => "",
+        resolveWorkDir: () => ({ workDir: target, config: {}, sessionPaths: wrapperSessionPaths }),
+        serveAutoresearch: async () => {
+          serveAttempts += 1;
+          return {
+            debugLedger: false,
+            port: 9,
+            server: fakeServer,
+            url: "http://127.0.0.1:9/",
+            workDir: target,
+          };
+        },
+        shellQuote: JSON.stringify,
+        writeFile: async () => {},
+      });
+
+      const result = await serveDashboard({ cwd: wrapper });
+
+      assert.equal(serveAttempts, 1);
+      assert.equal(result.registryReused, false);
+      assert.equal(result.url, "http://127.0.0.1:9/");
+      const record = await readServeRegistry(target);
+      assert.equal(record?.sessionCwd, path.resolve(wrapper));
+      assert.equal(record?.sessionPathIdentity, sessionPathIdentity(wrapperSessionPaths));
     } finally {
       await new Promise<void>((resolve, reject) => {
         existing.server.close((error: Error | undefined) => (error ? reject(error) : resolve()));
@@ -131,6 +216,7 @@ test("serve dashboard resolves config fresh for deferred live view model", async
       resolveWorkDir: () => ({
         workDir: dir,
         config: { dashboardRefreshSeconds: 1, version: configVersion },
+        sessionPaths: resolveSessionPaths({ workDir: dir }),
       }),
       serveAutoresearch: async (options) => {
         capturedViewModel = options.viewModel;

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -35,6 +35,7 @@ import {
 import { PLUGIN_VERSION } from "../lib/plugin-version.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 import { LIVE_LEDGER_MAX_ENTRIES, serveAutoresearch } from "../lib/live-server.js";
+import { resolveSessionPaths } from "../lib/session-paths.js";
 import {
   createDashboardHarness,
   dashboardConfigEntry,
@@ -4391,6 +4392,73 @@ test("live dashboard view model cache invalidates on session state changes", asy
   } finally {
     server.server.close();
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("live dashboard view model cache invalidates on wrapper session config changes", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "autoresearch-live-wrapper-cache-"));
+  const wrapper = path.join(root, "wrapper");
+  const target = path.join(root, "target");
+  await mkdir(wrapper, { recursive: true });
+  await mkdir(target, { recursive: true });
+  let recomputes = 0;
+  const readWrapperRefreshSeconds = async () => {
+    const config = JSON.parse(
+      await readFile(path.join(wrapper, "autoresearch.config.json"), "utf8"),
+    );
+    return Number(config.dashboardRefreshSeconds);
+  };
+  const server = await serveAutoresearch({
+    cwd: wrapper,
+    sessionPaths: resolveSessionPaths({ sessionCwd: wrapper, workDir: target }),
+    port: 0,
+    viewModelCacheTtlMs: 60_000,
+    pluginVersion: "0.test",
+    dashboardHtml: async () => "<!doctype html><title>wrapper cache</title>",
+    viewModel: async () => {
+      recomputes += 1;
+      return { summary: { runs: await readWrapperRefreshSeconds() } };
+    },
+  });
+
+  try {
+    await writeFile(
+      path.join(wrapper, "autoresearch.config.json"),
+      JSON.stringify({ workingDir: "../target", dashboardRefreshSeconds: 5 }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(target, "autoresearch.jsonl"),
+      [
+        JSON.stringify({ type: "config", name: "wrapper cache", metricName: "seconds" }),
+        JSON.stringify({ type: "run", run: 1, status: "keep", metric: 1 }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const first = await fetch(`${server.url}view-model.json`).then((res) => res.json());
+    const second = await fetch(`${server.url}view-model.json`).then((res) => res.json());
+
+    assert.equal(server.workDir, path.resolve(target));
+    assert.equal(first.summary.runs, 5);
+    assert.equal(second.summary.runs, 5);
+    assert.equal(recomputes, 1);
+
+    await writeFile(
+      path.join(wrapper, "autoresearch.config.json"),
+      JSON.stringify({ workingDir: "../target", dashboardRefreshSeconds: 9 }),
+      "utf8",
+    );
+
+    const third = await fetch(`${server.url}view-model.json`).then((res) => res.json());
+
+    assert.equal(third.summary.runs, 9);
+    assert.equal(third.ledgerEntries.length, 2);
+    assert.equal(recomputes, 2);
+  } finally {
+    server.server.close();
+    await rm(root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Context

Refs #213.

Live dashboard freshness could split the wrapper session cwd from the target work dir. `resolveSessionPaths` already supports wrapper config at `sessionCwd` with ledger/session files under `workDir`, but the live server and reusable dashboard registry were still target-cwd centered. That meant wrapper `autoresearch.config.json` edits could change render settings without changing the live `/view-model.json` cache fingerprint, and the default `serve` path could reuse an older target-cwd server for a wrapper session.

## What Changed

- Passed precomputed `sessionPaths` from the dashboard `serve` command into `serveAutoresearch`.
- Added a stable session-path identity and carried it through live-server `/health`, registry writes, registry reuse checks, and health verification.
- Made live view-model freshness, redacted ledger reads, debug-ledger reads, and reuse checks consume the same resolved session path contract.
- Added regressions for wrapper config cache invalidation and command-level live-server reuse with wrapper `sessionCwd`.

## How To Review

- Start in `plugins/codex-autoresearch/lib/commands/dashboard.ts` to see CLI path resolution, reuse lookup, and live-server startup using one session identity.
- Review `plugins/codex-autoresearch/lib/dashboard-server-registry.ts`, `dashboard-health.ts`, and `live-server.ts` for registry/health identity matching.
- Check `plugins/codex-autoresearch/tests/dashboard-server-registry.test.ts` and `dashboard-verification.test.ts` for the wrapper reuse/freshness regressions.

## Verification

- `npm ci`
- `npm run build:dashboard`
- `npm run build:node`
- Focused registry/live tests: 7 passed
- Full `dist/tests/dashboard-server-registry.test.mjs`: 13 passed
- Existing wrapper view-model freshness regression: 1 passed
- `node --test --test-name-pattern "live dashboard view model cache invalidates|live dashboard validates Host|live dashboard keeps debug ledger" dist\tests\dashboard-verification.test.mjs dist\tests\dashboard-server-registry.test.mjs`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- GitHub CI and CodeQL passed on head `12846936132d65606040f9a575317d7f2b4954e9`.
- Read-only follow-up review found no remaining blocker after the session-identity fix.

## Risk

Low. Old registry records without session identity are treated as stale for wrapper-aware reuse, which is intentional to avoid reusing a live server that reads the wrong session paths. Dashboard remains read-only; host validation and defensive headers are unchanged; raw ledger access still requires `--debug-ledger`.