### PR TITLE
Restore compact read startup budget

### DIFF
--- a/plugins/codex-autoresearch/lib/watchdog-summary.ts
+++ b/plugins/codex-autoresearch/lib/watchdog-summary.ts
@@ -1,0 +1,149 @@
+import { finiteMetric } from "./session-core.js";
+import type { UnknownRecord } from "./types/json.js";
+
+type Direction = "lower" | "higher" | string;
+
+export function buildWatchdogSummary({
+  state,
+  settings = {},
+  current = [],
+  parallelLanes = [],
+  fanoutPlan = null,
+}: UnknownRecord) {
+  const stateRecord = asRecord(state);
+  const settingsRecord = asRecord(settings);
+  const config = asRecord(stateRecord.config);
+  const thresholdSeconds = watchdogThresholdSeconds(settingsRecord, config);
+  const thresholdHours = round(thresholdSeconds / 3600);
+  const nowMs = timestampMs(settingsRecord.now || settingsRecord.generatedAt) || Date.now();
+  const cutoffMs = nowMs - thresholdSeconds * 1000;
+  const currentRuns = Array.isArray(current) ? current : [];
+  const completedLanes = Array.isArray(parallelLanes)
+    ? parallelLanes.filter((lane: unknown) => laneCompleted(asRecord(lane)))
+    : [];
+  const progressEvents = [
+    ...metricMovementEvents(currentRuns.map(asRecord), String(config.bestDirection || "lower")),
+    ...currentRuns
+      .map(asRecord)
+      .filter(watchdogDecisionRun)
+      .map((run: UnknownRecord) => ({
+        kind: "decision",
+        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
+        label: `Logged run #${run.run ?? "?"} as ${run.status || "decision"}.`,
+      })),
+    ...currentRuns
+      .map(asRecord)
+      .filter((run: UnknownRecord) => run.status === "keep" && cleanText(run.commit))
+      .map((run: UnknownRecord) => ({
+        kind: "kept_commit",
+        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
+        label: `Kept commit ${String(run.commit).slice(0, 12)} from run #${run.run ?? "?"}.`,
+      })),
+    ...completedLanes.map((lane: UnknownRecord) => ({
+      kind: "completed_lane",
+      at: timestampMs(lane.completedAt || lane.finishedAt || lane.updatedAt || lane.timestamp),
+      label: `Lane ${lane.title || lane.id || "unknown"} completed.`,
+    })),
+  ].filter((event) => event.at != null) as Array<{ kind: string; at: number; label: string }>;
+  const recentEvents = progressEvents.filter((event) => event.at >= cutoffMs);
+  const latestEvent = progressEvents.sort((a, b) => b.at - a.at)[0] || null;
+  const quietHours = latestEvent ? round((nowMs - latestEvent.at) / 3600000) : null;
+  const stale = currentRuns.length > 0 && recentEvents.length === 0 && quietHours != null;
+  const reasons = stale
+    ? [
+        `No metric movement, logged decision, kept commit, or completed lane in ${thresholdHours}h.`,
+        latestEvent
+          ? `Last progress signal: ${latestEvent.label}`
+          : "No dated progress signal found.",
+      ]
+    : recentEvents.length
+      ? [
+          `${recentEvents.length} progress signal${recentEvents.length === 1 ? "" : "s"} inside the watchdog window.`,
+        ]
+      : currentRuns.length
+        ? ["Run history has no dated progress signal; watchdog cannot prove a quiet window."]
+        : ["No run history yet; capture a baseline before watchdog pressure applies."];
+  const recommendation = stale
+    ? "Intervene before running more packets: inspect the active process, finalize kept work, or rescope the segment."
+    : currentRuns.length
+      ? "Continue from the decision envelope; watchdog has no stale no-progress window."
+      : "Run and log the baseline so the watchdog can compare future progress.";
+  return {
+    status: stale ? "stale" : currentRuns.length ? "tracking" : "idle",
+    stale,
+    thresholdSeconds,
+    thresholdHours,
+    quietHours,
+    latestProgressAt: latestEvent ? new Date(latestEvent.at).toISOString() : null,
+    recentProgressCount: recentEvents.length,
+    progressEventCount: progressEvents.length,
+    fanoutPlanId: cleanText(asRecord(fanoutPlan).id) || null,
+    completedLaneCount: completedLanes.length,
+    reasons,
+    recommendation,
+  };
+}
+
+function watchdogThresholdSeconds(settings: UnknownRecord, config: UnknownRecord = {}) {
+  const direct =
+    settings.watchdogNoProgressSeconds ??
+    settings.watchdogThresholdSeconds ??
+    config.watchdogNoProgressSeconds ??
+    config.watchdogThresholdSeconds;
+  const hours = settings.watchdogNoProgressHours ?? config.watchdogNoProgressHours;
+  const raw = direct ?? (hours != null ? Number(hours) * 3600 : 8 * 3600);
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : 8 * 3600;
+}
+
+function metricMovementEvents(current: UnknownRecord[], direction: Direction) {
+  const events = [];
+  let previous: number | null = null;
+  for (const run of current) {
+    const metric = finiteMetric(run.metric);
+    if (metric == null) continue;
+    if (previous != null && metric !== previous) {
+      events.push({
+        kind: "metric_movement",
+        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
+        label: `Metric moved on run #${run.run ?? "?"} (${previous} -> ${metric}; ${direction}).`,
+      });
+    }
+    previous = metric;
+  }
+  return events;
+}
+
+function laneCompleted(lane: UnknownRecord) {
+  const status = String(lane.status || lane.state || lane.evidenceStatus || "").toLowerCase();
+  return ["complete", "completed", "done", "kept", "accepted", "finished"].includes(status);
+}
+
+function watchdogDecisionRun(run: UnknownRecord) {
+  if (run?.type === "lane_result") return false;
+  const status = String(run?.status || "").toLowerCase();
+  return ["keep", "discard", "crash", "checks_failed", "measure"].includes(status);
+}
+
+function timestampMs(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) return number;
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function cleanText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function asRecord(value: unknown): UnknownRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { fileURLToPath } from "node:url";
-import { buildDashboardViewModel, buildWatchdogSummary } from "../lib/dashboard-view-model.js";
+import { buildWatchdogSummary } from "../lib/watchdog-summary.js";
 import { verifyDashboardHealthSummary } from "../lib/dashboard-health.js";
 import { buildDecisionGuidanceContext } from "../lib/decision-guidance.js";
 import {
@@ -101,10 +101,6 @@ import {
 import { isPathInside, resolvePathInsideRootSync } from "../lib/path-containment.js";
 import { buildExperimentMemory } from "../lib/experiment-memory.js";
 import {
-  finalizeCurrentTree as buildFinalizeCurrentTree,
-  finalizePreview as buildFinalizePreview,
-} from "../lib/finalize-preview.js";
-import {
   buildGoalContract,
   buildGoalFrame,
   goalCompletionUnresolvedBlockers,
@@ -116,8 +112,6 @@ import {
   normalizeFixedControlConfig,
   type FixedControlViolation,
 } from "../lib/fixed-control.js";
-import { discoverPartialResultCandidates } from "../lib/partial-results.js";
-import { integrationsCommand } from "../lib/integrations.js";
 import { buildLaneLifecycle } from "../lib/lane-lifecycle.js";
 import { normalizeLaneBrief, summarizeLaneLessons } from "../lib/lane-briefs.js";
 import { buildOperatorChecklist } from "../lib/operator-checklist.js";
@@ -141,7 +135,6 @@ import {
   recommendRecipe,
   revalidateRecipeCatalogProvenance,
 } from "../lib/recipes.js";
-import { serveAutoresearch } from "../lib/live-server.js";
 import {
   parseMetricLines,
   runProcess as runBoundedProcess,
@@ -259,6 +252,79 @@ const COMMAND_EXECUTION_BOUNDARY = {
 };
 const OUTPUT_MAX_LINES = 20;
 const OUTPUT_MAX_BYTES = 8192;
+
+type DashboardViewModelModule = typeof import("../lib/dashboard-view-model.js");
+type FinalizePreviewModule = typeof import("../lib/finalize-preview.js");
+type PartialResultsModule = typeof import("../lib/partial-results.js");
+type IntegrationsModule = typeof import("../lib/integrations.js");
+type LiveServerModule = typeof import("../lib/live-server.js");
+
+let dashboardViewModelModulePromise: Promise<DashboardViewModelModule> | null = null;
+let finalizePreviewModulePromise: Promise<FinalizePreviewModule> | null = null;
+let partialResultsModulePromise: Promise<PartialResultsModule> | null = null;
+let integrationsModulePromise: Promise<IntegrationsModule> | null = null;
+let liveServerModulePromise: Promise<LiveServerModule> | null = null;
+
+function dashboardViewModelModule(): Promise<DashboardViewModelModule> {
+  dashboardViewModelModulePromise ??= import("../lib/dashboard-view-model.js");
+  return dashboardViewModelModulePromise;
+}
+
+function finalizePreviewModule(): Promise<FinalizePreviewModule> {
+  finalizePreviewModulePromise ??= import("../lib/finalize-preview.js");
+  return finalizePreviewModulePromise;
+}
+
+function partialResultsModule(): Promise<PartialResultsModule> {
+  partialResultsModulePromise ??= import("../lib/partial-results.js");
+  return partialResultsModulePromise;
+}
+
+function integrationsModule(): Promise<IntegrationsModule> {
+  integrationsModulePromise ??= import("../lib/integrations.js");
+  return integrationsModulePromise;
+}
+
+function liveServerModule(): Promise<LiveServerModule> {
+  liveServerModulePromise ??= import("../lib/live-server.js");
+  return liveServerModulePromise;
+}
+
+async function buildDashboardViewModelLazy(
+  ...args: Parameters<DashboardViewModelModule["buildDashboardViewModel"]>
+): Promise<ReturnType<DashboardViewModelModule["buildDashboardViewModel"]>> {
+  return (await dashboardViewModelModule()).buildDashboardViewModel(...args);
+}
+
+async function buildFinalizePreview(
+  ...args: Parameters<FinalizePreviewModule["finalizePreview"]>
+): Promise<Awaited<ReturnType<FinalizePreviewModule["finalizePreview"]>>> {
+  return (await finalizePreviewModule()).finalizePreview(...args);
+}
+
+async function buildFinalizeCurrentTree(
+  ...args: Parameters<FinalizePreviewModule["finalizeCurrentTree"]>
+): Promise<Awaited<ReturnType<FinalizePreviewModule["finalizeCurrentTree"]>>> {
+  return (await finalizePreviewModule()).finalizeCurrentTree(...args);
+}
+
+async function discoverPartialResultCandidatesLazy(
+  ...args: Parameters<PartialResultsModule["discoverPartialResultCandidates"]>
+): Promise<Awaited<ReturnType<PartialResultsModule["discoverPartialResultCandidates"]>>> {
+  return (await partialResultsModule()).discoverPartialResultCandidates(...args);
+}
+
+async function integrationsCommandLazy(
+  ...args: Parameters<IntegrationsModule["integrationsCommand"]>
+): Promise<Awaited<ReturnType<IntegrationsModule["integrationsCommand"]>>> {
+  return (await integrationsModule()).integrationsCommand(...args);
+}
+
+async function serveAutoresearchLazy(
+  ...args: Parameters<LiveServerModule["serveAutoresearch"]>
+): Promise<Awaited<ReturnType<LiveServerModule["serveAutoresearch"]>>> {
+  return (await liveServerModule()).serveAutoresearch(...args);
+}
 const MAX_PARSED_METRICS = 512;
 const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
 const REPO_ROOT = resolveRepoRoot(import.meta.url);
@@ -285,7 +351,7 @@ const { exportDashboard, serveDashboard } = createDashboardCommands({
   readJsonl,
   resolveOutputInside,
   resolveWorkDir,
-  serveAutoresearch,
+  serveAutoresearch: serveAutoresearchLazy,
   shellQuote,
   writeFile: fsp.writeFile,
 });
@@ -5427,7 +5493,7 @@ async function dashboardViewModel(workDir: string, config: any, context: LooseOb
     resumeAudit: decisionEnvelope,
     decisionEnvelope,
   };
-  return buildDashboardViewModel({
+  return buildDashboardViewModelLazy({
     state: enrichedState as any,
     settings,
     commands,
@@ -6822,7 +6888,7 @@ async function discoverLastRunPartialResults(
   if (!lastRun || !partialResultEligiblePacket(lastRun)) {
     return { candidates: [], skippedArtifacts: [] };
   }
-  return await discoverPartialResultCandidates({
+  return await discoverPartialResultCandidatesLazy({
     workDir,
     primaryMetricName: state.config?.metricName || "metric",
     lastRunPacket: lastRun,
@@ -10066,7 +10132,7 @@ async function executeAutoresearchCli(
     gapCandidates: buildGapCandidates,
     guidedSetup,
     initExperiment,
-    integrationsCommand,
+    integrationsCommand: integrationsCommandLazy,
     interactiveSetup,
     logExperiment,
     ledgerDoctor,

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -23,9 +23,6 @@ import {
   operationProgress,
 } from "../lib/commands/dashboard.js";
 import { buildContinuationCommands } from "../lib/commands/continuation.js";
-import { createInspectCommands } from "../lib/commands/inspect.js";
-import { createLaneRunnerCommand } from "../lib/commands/lane-runner.js";
-import { createPartialResultsCommand } from "../lib/commands/partial-results.js";
 import { buildNextPacketId } from "../lib/commands/next.js";
 import {
   buildCompactRecommendNextResponse,
@@ -256,12 +253,19 @@ const OUTPUT_MAX_BYTES = 8192;
 type DashboardViewModelModule = typeof import("../lib/dashboard-view-model.js");
 type FinalizePreviewModule = typeof import("../lib/finalize-preview.js");
 type PartialResultsModule = typeof import("../lib/partial-results.js");
+type InspectCommandsModule = typeof import("../lib/commands/inspect.js");
+type LaneRunnerCommandModule = typeof import("../lib/commands/lane-runner.js");
+type PartialResultsCommandModule = typeof import("../lib/commands/partial-results.js");
 type IntegrationsModule = typeof import("../lib/integrations.js");
 type LiveServerModule = typeof import("../lib/live-server.js");
+type InspectCommandHandlers = ReturnType<InspectCommandsModule["createInspectCommands"]>;
 
 let dashboardViewModelModulePromise: Promise<DashboardViewModelModule> | null = null;
 let finalizePreviewModulePromise: Promise<FinalizePreviewModule> | null = null;
 let partialResultsModulePromise: Promise<PartialResultsModule> | null = null;
+let inspectCommandsModulePromise: Promise<InspectCommandsModule> | null = null;
+let laneRunnerCommandModulePromise: Promise<LaneRunnerCommandModule> | null = null;
+let partialResultsCommandModulePromise: Promise<PartialResultsCommandModule> | null = null;
 let integrationsModulePromise: Promise<IntegrationsModule> | null = null;
 let liveServerModulePromise: Promise<LiveServerModule> | null = null;
 
@@ -278,6 +282,21 @@ function finalizePreviewModule(): Promise<FinalizePreviewModule> {
 function partialResultsModule(): Promise<PartialResultsModule> {
   partialResultsModulePromise ??= import("../lib/partial-results.js");
   return partialResultsModulePromise;
+}
+
+function inspectCommandsModule(): Promise<InspectCommandsModule> {
+  inspectCommandsModulePromise ??= import("../lib/commands/inspect.js");
+  return inspectCommandsModulePromise;
+}
+
+function laneRunnerCommandModule(): Promise<LaneRunnerCommandModule> {
+  laneRunnerCommandModulePromise ??= import("../lib/commands/lane-runner.js");
+  return laneRunnerCommandModulePromise;
+}
+
+function partialResultsCommandModule(): Promise<PartialResultsCommandModule> {
+  partialResultsCommandModulePromise ??= import("../lib/commands/partial-results.js");
+  return partialResultsCommandModulePromise;
 }
 
 function integrationsModule(): Promise<IntegrationsModule> {
@@ -356,40 +375,68 @@ const { exportDashboard, serveDashboard } = createDashboardCommands({
   writeFile: fsp.writeFile,
 });
 
-const { benchmarkLint, benchmarkInspect, checksInspect } = createInspectCommands({
-  currentState,
-  defaultBenchmarkCommand,
-  fixedControlBlockForCommand,
-  finiteMetric,
-  headText,
-  metricParseSource,
-  numberOption,
-  parseMetricLines,
-  resolveBenchmarkCommand: async (args: LooseObject, workDir: string, config: LooseObject) =>
-    await resolveBenchmarkCommandSource(args, workDir, {
-      fallbackToDefault: true,
-      requireCommand: false,
-      config,
-    }),
-  resolveWorkDir,
-  runShell,
-  validateMetricName,
-});
+let inspectCommandHandlers: InspectCommandHandlers | null = null;
 
-const partialResultsCommand = createPartialResultsCommand({
-  appendJsonl,
-  assertFreshLastRunPacket,
-  boolOption,
-  computeConfidence,
-  currentState,
-  deleteLastRunPacket,
-  finiteMetric,
-  loopContinuation,
-  readConfig,
-  readLastRunPacket,
-  researchSlugFromArgs,
-  resolveWorkDir,
-});
+async function getInspectCommandHandlers(): Promise<InspectCommandHandlers> {
+  if (!inspectCommandHandlers) {
+    const { createInspectCommands } = await inspectCommandsModule();
+    inspectCommandHandlers = createInspectCommands({
+      currentState,
+      defaultBenchmarkCommand,
+      fixedControlBlockForCommand,
+      finiteMetric,
+      headText,
+      metricParseSource,
+      numberOption,
+      parseMetricLines,
+      resolveBenchmarkCommand: async (args: LooseObject, workDir: string, config: LooseObject) =>
+        await resolveBenchmarkCommandSource(args, workDir, {
+          fallbackToDefault: true,
+          requireCommand: false,
+          config,
+        }),
+      resolveWorkDir,
+      runShell,
+      validateMetricName,
+    });
+  }
+  return inspectCommandHandlers;
+}
+
+async function benchmarkLint(args: LooseObject): Promise<LooseObject> {
+  return await (await getInspectCommandHandlers()).benchmarkLint(args);
+}
+
+async function benchmarkInspect(args: LooseObject): Promise<LooseObject> {
+  return await (await getInspectCommandHandlers()).benchmarkInspect(args);
+}
+
+async function checksInspect(args: LooseObject): Promise<LooseObject> {
+  return await (await getInspectCommandHandlers()).checksInspect(args);
+}
+
+let partialResultsCommandHandler: ((args: LooseObject) => Promise<LooseObject>) | null = null;
+
+async function partialResultsCommand(args: LooseObject): Promise<LooseObject> {
+  if (!partialResultsCommandHandler) {
+    const { createPartialResultsCommand } = await partialResultsCommandModule();
+    partialResultsCommandHandler = createPartialResultsCommand({
+      appendJsonl,
+      assertFreshLastRunPacket,
+      boolOption,
+      computeConfidence,
+      currentState,
+      deleteLastRunPacket,
+      finiteMetric,
+      loopContinuation,
+      readConfig,
+      readLastRunPacket,
+      researchSlugFromArgs,
+      resolveWorkDir,
+    });
+  }
+  return await partialResultsCommandHandler(args);
+}
 
 let sessionForensicsCommand: ((args: LooseObject) => Promise<LooseObject>) | null = null;
 
@@ -407,31 +454,39 @@ async function sessionForensics(args: LooseObject): Promise<LooseObject> {
   return await sessionForensicsCommand(args);
 }
 
-const laneRunner = createLaneRunnerCommand({
-  appendJsonl,
-  assertNoDirtyPathsOutsideWriteScope,
-  assertWriteScopeIntegrity,
-  boolOption,
-  buildParallelOrchestrationContext,
-  commandLooksMutating,
-  commandLooksUnsafeForWriteScope,
-  currentState,
-  dashboardSettings,
-  gitStatusPorcelain,
-  insideGitRepo,
-  latestLaneResults,
-  normalizeLaneMode,
-  normalizeParallelLane,
-  normalizeRelativePaths,
-  positiveIntegerOption,
-  readJsonl,
-  resolveLaneWorktree,
-  resolveWorkDir,
-  runShell,
-  synthesizeLaneDecision,
-  tailText,
-  writeScopeSnapshot,
-});
+let laneRunnerHandler: ((args: LooseObject) => Promise<LooseObject>) | null = null;
+
+async function laneRunner(args: LooseObject): Promise<LooseObject> {
+  if (!laneRunnerHandler) {
+    const { createLaneRunnerCommand } = await laneRunnerCommandModule();
+    laneRunnerHandler = createLaneRunnerCommand({
+      appendJsonl,
+      assertNoDirtyPathsOutsideWriteScope,
+      assertWriteScopeIntegrity,
+      boolOption,
+      buildParallelOrchestrationContext,
+      commandLooksMutating,
+      commandLooksUnsafeForWriteScope,
+      currentState,
+      dashboardSettings,
+      gitStatusPorcelain,
+      insideGitRepo,
+      latestLaneResults,
+      normalizeLaneMode,
+      normalizeParallelLane,
+      normalizeRelativePaths,
+      positiveIntegerOption,
+      readJsonl,
+      resolveLaneWorktree,
+      resolveWorkDir,
+      runShell,
+      synthesizeLaneDecision,
+      tailText,
+      writeScopeSnapshot,
+    });
+  }
+  return await laneRunnerHandler(args);
+}
 
 function usage(options: { all?: boolean } = {}) {
   return renderCliHelp(options);
@@ -2099,7 +2154,12 @@ async function guidedSetup(args: LooseObject): Promise<LooseObject> {
 async function compactGuidedSetup({ workDir, config, readCache }: LooseObject) {
   const state: LooseObject = await publicState({ cwd: workDir, compact: true, readCache });
   const canonicalNextAction = state.canonicalNextAction || null;
-  const lastRun = await readLastRunPacket(workDir).catch((): null => null);
+  const shouldReadLastRun =
+    state.requiresLogDecision === true ||
+    ["log-decision", "stale-packet"].includes(String(canonicalNextAction?.kind || ""));
+  const lastRun = shouldReadLastRun
+    ? await readLastRunPacket(workDir).catch((): null => null)
+    : null;
   const lastRunFingerprint = lastRun ? await lastRunPacketFingerprint(workDir).catch(() => "") : "";
   const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
   const lastRunLogStatus = lastRun
@@ -3729,8 +3789,19 @@ function gitOutput(result: any, fallback: any) {
 }
 
 async function insideGitRepo(cwd: string) {
+  if (!hasGitMarker(cwd)) return false;
   const result = await git(["rev-parse", "--is-inside-work-tree"], cwd);
   return result.code === 0 && result.stdout.trim() === "true";
+}
+
+function hasGitMarker(cwd: string): boolean {
+  let current = path.resolve(cwd);
+  for (;;) {
+    if (fs.existsSync(path.join(current, ".git"))) return true;
+    const parent = path.dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
 }
 
 async function gitPrivatePath(cwd: string, relativePath: string) {
@@ -5566,11 +5637,16 @@ async function operatorWarningsForWorkDir(
   const protectedBenchmarkGuard = await protectedBenchmarkGuardForWorkDir(workDir, config, state);
   const protectedBenchmarkWarning = protectedBenchmarkWarningFromGuard(protectedBenchmarkGuard);
   if (protectedBenchmarkWarning) warnings.push(protectedBenchmarkWarning);
-  warnings.push(...(await benchmarkIntegrityPreflight(workDir, config, state)));
+  warnings.push(...(await benchmarkIntegrityPreflight(workDir, config, state, { inGit })));
   return warnings;
 }
 
-async function benchmarkIntegrityPreflight(workDir: string, config: any, state: any) {
+async function benchmarkIntegrityPreflight(
+  workDir: string,
+  config: any,
+  state: any,
+  options: { inGit?: boolean } = {},
+) {
   const warnings = [];
   const hasIntegrityGuard = Boolean(
     config.benchmarkIntegrityCommand ||
@@ -5598,10 +5674,8 @@ async function benchmarkIntegrityPreflight(workDir: string, config: any, state: 
   for (const relative of ["target/autoresearch", ".autoresearch-cache"]) {
     if (await pathExists(path.join(workDir, relative))) staleArtifactRoots.push(relative);
   }
-  if (
-    (await insideGitRepo(workDir).catch(() => false)) &&
-    (await gitPrivateDirectoryHasBenchmarkArtifacts(workDir, "autoresearch"))
-  ) {
+  const inGit = options.inGit ?? (await insideGitRepo(workDir).catch(() => false));
+  if (inGit && (await gitPrivateDirectoryHasBenchmarkArtifacts(workDir, "autoresearch"))) {
     staleArtifactRoots.push(".git/autoresearch");
   }
   if (staleArtifactRoots.length && !boolOption(config.allowStaleArtifacts, false)) {

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -64,7 +64,9 @@ async function rebuildStaleSourceRuntime(pluginRoot, target) {
   if (!(await fileExists(path.join(pluginRoot, "tsdown.config.ts")))) return;
   if (!(await fileExists(path.join(pluginRoot, "node_modules")))) return;
 
-  if ((await newestSourceMtime(pluginRoot)) < (await fileMtime(target))) return;
+  const targetMtime = await fileMtime(target);
+  if (await sourceRuntimeFreshByGit(pluginRoot, targetMtime)) return;
+  if ((await newestSourceMtime(pluginRoot)) < targetMtime) return;
 
   const build = npmBuildInvocation();
   await run(build.command, build.args, { cwd: pluginRoot });
@@ -319,6 +321,28 @@ function run(command, args, options = {}) {
   });
 }
 
+function runCapture(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
 async function fileExists(file) {
   try {
     await fs.access(file);
@@ -334,6 +358,103 @@ async function fileMtime(file) {
   } catch {
     return 0;
   }
+}
+
+async function sourceRuntimeFreshByGit(pluginRoot, targetMtime) {
+  if (!(targetMtime > 0)) return false;
+  const [metadata, status] = await Promise.all([
+    runCapture(
+      "git",
+      [
+        "rev-parse",
+        "--show-toplevel",
+        "--path-format=absolute",
+        "--git-path",
+        "HEAD",
+        "--git-path",
+        "index",
+      ],
+      {
+        cwd: pluginRoot,
+      },
+    ).catch(() => null),
+    runCapture(
+      "git",
+      ["status", "--porcelain=v1", "-uall", "--", "package.json", "lib", "scripts"],
+      {
+        cwd: pluginRoot,
+      },
+    ).catch(() => null),
+  ]);
+  if (!metadata || metadata.code !== 0 || !status || status.code !== 0) return false;
+
+  const [repoRootText, headPathText, indexPathText] = metadata.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!repoRootText || !headPathText || !indexPathText) return false;
+
+  const dirty = dirtyRuntimeSourcePaths({
+    pluginRoot,
+    repoRoot: repoRootText,
+    stdout: status.stdout,
+  });
+  if (dirty.fullScanRequired) return false;
+
+  const markerMtimes = await Promise.all([
+    fileMtime(headPathText),
+    fileMtime(indexPathText),
+    ...dirty.paths.map((file) => fileMtime(file)),
+  ]);
+  return Math.max(0, ...markerMtimes) < targetMtime;
+}
+
+function dirtyRuntimeSourcePaths({ pluginRoot, repoRoot, stdout }) {
+  const paths = [];
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    if (!rawLine.trim()) continue;
+    const status = rawLine.slice(0, 2);
+    const parsed = parsePorcelainPath(rawLine.slice(3));
+    if (!parsed) continue;
+    if (
+      status.includes("D") ||
+      status.includes("R") ||
+      status.includes("C") ||
+      status.includes("T")
+    ) {
+      return { fullScanRequired: true, paths };
+    }
+    const absolutePath = path.resolve(repoRoot, parsed.replace(/\//g, path.sep));
+    const relativePath = slashPath(path.relative(pluginRoot, absolutePath));
+    if (!isRuntimeSourcePath(relativePath)) continue;
+    paths.push(absolutePath);
+  }
+  return { fullScanRequired: false, paths };
+}
+
+function parsePorcelainPath(text) {
+  const value = String(text || "").trim();
+  if (!value) return "";
+  const renamed = value.lastIndexOf(" -> ");
+  const pathText = renamed >= 0 ? value.slice(renamed + 4) : value;
+  if (!pathText.startsWith('"')) return pathText;
+  try {
+    return JSON.parse(pathText);
+  } catch {
+    return pathText.slice(1, -1);
+  }
+}
+
+function isRuntimeSourcePath(relativePath) {
+  return (
+    relativePath === "package.json" ||
+    ((relativePath.startsWith("lib/") || relativePath.startsWith("scripts/")) &&
+      relativePath.endsWith(".ts"))
+  );
+}
+
+function slashPath(value) {
+  return String(value || "").replace(/\\/g, "/");
 }
 
 async function newestSourceMtime(pluginRoot) {


### PR DESCRIPTION
## Context

Refs #212.

The compact read perf gate was red on a fresh run from `origin/dev`/`e86814f`, and review later reproduced the PR as still over budget on this Windows workstation:

- Review blocker: `CODEX_AUTORESEARCH_RUN_PERF_TESTS=1 node --test --test-name-pattern "compact read commands stay within a warm local startup budget" dist/tests/autoresearch-cli.test.mjs` failed with `state --compact best-of-3 took 3209 ms, budget 1500 ms`.
- Direct `dist` was faster than the source launcher, so the remaining fix needed to include bootstrap/startup path sensitivity.
- CodeStory / `codestory-grounding` was not used for repo context; local repo/issue evidence was enough, and the implementation lane reported no CodeStory friction.

## What Changed

- Deferred heavyweight CLI-only modules until their commands need them:
  - dashboard view-model
  - live server
  - finalization preview/current-tree finalization
  - partial result discovery and the `partial-results` command factory
  - inspect command factory
  - lane-runner command factory
  - integrations
- Moved the watchdog summary used by compact state into a small helper so compact reads do not import the full dashboard view-model just to compute watchdog status.
- Added a Git-aware source-runtime freshness fast path in `scripts/bootstrap-runtime.mjs` so source-launcher compact reads do not recursively scan all source files when the built runtime is already fresh.
- Skipped pointless Git probes for non-git temp sessions and reused the known Git repo result inside compact warning preflight.
- Avoided a redundant compact `guide` last-run read unless compact state says a log/stale-packet decision is pending.
- Kept the existing 1500 ms perf budget unchanged.

## How To Review

1. Start in `plugins/codex-autoresearch/scripts/autoresearch.ts` and check that compact `state`, `recommend-next`, and `guide` still use the same compact state builders and response shapes.
2. Review `plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs` for the source-runtime freshness shortcut; it falls back to the old recursive mtime scan unless Git metadata proves the built runtime is fresh.
3. Review `plugins/codex-autoresearch/lib/watchdog-summary.ts` as the extracted watchdog-only dependency for compact startup.
4. Confirm the lazy wrappers are used only at existing command boundaries and do not change command output shape.

## Verification

- `npm run test:perf` passed with the unchanged 1500 ms budget.
- Exact enforced command passed:
  - `CODEX_AUTORESEARCH_RUN_PERF_TESTS=1 node --test --test-name-pattern "compact read commands stay within a warm local startup budget" dist/tests/autoresearch-cli.test.mjs`
- Final explicit timing probe on a tiny session:
  - source launcher `state --compact`: `times_ms=984,511,532`, `best_ms=511`
  - source launcher `recommend-next --compact`: `times_ms=514,483,994`, `best_ms=483`
  - source launcher `guide --compact`: `times_ms=492,487,920`, `best_ms=487`
  - direct `dist` `state --compact`: `times_ms=394,406,434`, `best_ms=394`
  - direct `dist` `recommend-next --compact`: `times_ms=405,446,433`, `best_ms=405`
  - direct `dist` `guide --compact`: `times_ms=440,577,531`, `best_ms=440`
- Lazy command smoke passed for `partial-results`, `benchmark-lint`, `benchmark-inspect`, `checks-inspect`, `research-fanout`, and `lane-runner`.
- `npm run typecheck:node` passed.
- `npm run lint` passed.
- `npm run format:check` passed.
- `git diff --check` passed.
- `npm run check` passed end to end.
- GitHub CI and CodeQL passed on head `9a9eeffbe3be5a076212f046c09bf25104846eac`.
- Independent read-only performance review found no remaining blocker after the follow-up fix.

## Risk

Low-to-medium. Module loading order changed for non-compact dashboard/finalization/live-server/integrations/inspect/lane-runner/partial-results paths. The bootstrap freshness shortcut is intentionally conservative and falls back when Git/runtime metadata cannot prove freshness. Windows wall-clock perf showed variance during iteration, but the final enforced gate and package perf script both passed without relaxing the budget.