### PR TITLE
Make source-checkout dashboard readiness truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 - Redacted benchmark-contract command text, checks command text, option-file paths, and env-file labels from persisted last-run packet storage.
 - Source-shaped plugin runtime hydration now copies packaged dashboard build assets so `export` and `serve` keep working after `assets/dashboard-build/` became ignored/generated.
+- Source-checkout launcher readiness now requires dashboard build assets before reporting the runtime ready, so missing `assets/dashboard-build/` triggers hydration instead of a later dashboard export failure.
 
 ## 2.4.0 - 2026-06-18
 

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -42,8 +42,7 @@ export async function ensureRuntime(entrypoint, importerUrl, options = {}) {
 }
 
 async function dashboardRuntimeReady(pluginRoot) {
-  if (await dashboardBuildReady(pluginRoot)) return true;
-  return await isSourceDevelopmentCheckout(pluginRoot);
+  return await dashboardBuildReady(pluginRoot);
 }
 
 async function dashboardBuildReady(pluginRoot) {
@@ -53,21 +52,16 @@ async function dashboardBuildReady(pluginRoot) {
   ).every(Boolean);
 }
 
-async function isSourceDevelopmentCheckout(pluginRoot) {
-  return (
-    (await fileExists(path.join(pluginRoot, "scripts", "autoresearch.ts"))) &&
-    (await fileExists(path.join(pluginRoot, "tsdown.config.ts")))
-  );
-}
-
 async function rebuildStaleSourceRuntime(pluginRoot, target) {
   if (!(await fileExists(path.join(pluginRoot, "scripts", "autoresearch.ts")))) return;
   if (!(await fileExists(path.join(pluginRoot, "tsdown.config.ts")))) return;
   if (!(await fileExists(path.join(pluginRoot, "node_modules")))) return;
 
-  if ((await newestSourceMtime(pluginRoot)) < (await fileMtime(target))) return;
+  const dashboardMissing = !(await dashboardBuildReady(pluginRoot));
+  const runtimeStale = (await newestSourceMtime(pluginRoot)) >= (await fileMtime(target));
+  if (!runtimeStale && !dashboardMissing) return;
 
-  const build = npmBuildInvocation();
+  const build = npmBuildInvocation(dashboardMissing ? "build" : "build:node");
   await run(build.command, build.args, { cwd: pluginRoot });
 }
 
@@ -317,11 +311,11 @@ async function newestSourceMtime(pluginRoot) {
   );
 }
 
-function npmBuildInvocation() {
+function npmBuildInvocation(scriptName = "build:node") {
   if (process.platform === "win32") {
-    return { command: "cmd.exe", args: ["/d", "/s", "/c", "npm run build:node"] };
+    return { command: "cmd.exe", args: ["/d", "/s", "/c", `npm run ${scriptName}`] };
   }
-  return { command: "npm", args: ["run", "build:node"] };
+  return { command: "npm", args: ["run", scriptName] };
 }
 
 function sleep(ms) {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -9793,7 +9793,10 @@ test("source launcher rebuilds local source runtime before use", async () => {
         {
           name: "codex-autoresearch",
           version: PLUGIN_VERSION,
-          scripts: { "build:node": "node scripts/write-runtime.mjs" },
+          scripts: {
+            build: "node scripts/write-runtime.mjs --dashboard",
+            "build:node": "node scripts/write-runtime.mjs",
+          },
         },
         null,
         2,
@@ -9813,8 +9816,14 @@ test("source launcher rebuilds local source runtime before use", async () => {
         'import path from "node:path";',
         'import { fileURLToPath } from "node:url";',
         'const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");',
+        'const includeDashboard = process.argv.includes("--dashboard");',
         'await mkdir(path.join(root, "dist", "scripts"), { recursive: true });',
         'await writeFile(path.join(root, "dist", "scripts", "autoresearch.mjs"), "export const rebuiltRuntime = true;\\n", "utf8");',
+        "if (includeDashboard) {",
+        '  await mkdir(path.join(root, "assets", "dashboard-build"), { recursive: true });',
+        '  await writeFile(path.join(root, "assets", "dashboard-build", "dashboard-app.js"), "window.__rebuiltDashboard = true;\\n", "utf8");',
+        '  await writeFile(path.join(root, "assets", "dashboard-build", "dashboard-app.css"), "#dashboard-root { color: rgb(1, 2, 3); }\\n", "utf8");',
+        "}",
       ].join("\n"),
       "utf8",
     );
@@ -9829,6 +9838,10 @@ test("source launcher rebuilds local source runtime before use", async () => {
     assert.equal(
       await readFile(new URL(runtimeHref), "utf8"),
       "export const rebuiltRuntime = true;\n",
+    );
+    assert.match(
+      await readFile(path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.js"), "utf8"),
+      /rebuiltDashboard/,
     );
   });
 });
@@ -9917,6 +9930,57 @@ test("source launcher hydrates packaged dashboard assets before source-shaped ex
       assert.match(dashboardHtml, /release-dashboard-app/);
       assert.match(dashboardHtml, /rgb\(12, 34, 56\)/);
       assert.match(dashboardHtml, /package dashboard smoke/);
+    });
+  });
+});
+
+test("source launcher does not treat source-shaped runtime as ready without dashboard assets", async () => {
+  await withTempDir("runtime-hydration-existing-runtime-missing-dashboard", async (dir) => {
+    const { pluginDir, importerUrl } = await writeFakeSourcePlugin(dir);
+    await mkdir(path.join(pluginDir, "dist", "scripts"), { recursive: true });
+    await writeFile(
+      path.join(pluginDir, "dist", "scripts", "autoresearch.mjs"),
+      "export const sourceRuntimeWithoutDashboardAssets = true;\n",
+      "utf8",
+    );
+    await writeFile(path.join(pluginDir, "tsdown.config.ts"), "export default {};\n", "utf8");
+    await writeFile(path.join(pluginDir, "scripts", "autoresearch.ts"), "export {};\n", "utf8");
+    await assert.rejects(
+      access(path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.js")),
+    );
+
+    const release = await createRuntimeReleaseAsset(dir, {
+      dashboardAppText: 'window.__hydratedDashboardAsset = "existing-runtime-missing-assets";\n',
+      dashboardCssText: "#dashboard-root { color: rgb(98, 76, 54); }\n",
+      runtimeText: "export const hydratedRuntime = true;\n",
+    });
+    const bootstrap = await import(
+      pathToFileURL(path.join(pluginRoot, "scripts", "bootstrap-runtime.mjs")).href
+    );
+
+    await withReleaseServer(release.releaseDir, PLUGIN_VERSION, async (releaseBaseUrl) => {
+      const runtimeHref = await bootstrap.ensureRuntime("autoresearch.mjs", importerUrl, {
+        releaseBaseUrl,
+      });
+
+      assert.equal(
+        await readFile(new URL(runtimeHref), "utf8"),
+        "export const hydratedRuntime = true;\n",
+      );
+      assert.match(
+        await readFile(
+          path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.js"),
+          "utf8",
+        ),
+        /existing-runtime-missing-assets/,
+      );
+      assert.match(
+        await readFile(
+          path.join(pluginDir, "assets", "dashboard-build", "dashboard-app.css"),
+          "utf8",
+        ),
+        /rgb\(98, 76, 54\)/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Context

Refs #214.

Source-checkout bootstrap could report the runtime ready when `dist/` existed but `assets/dashboard-build/` did not. Dashboard export/serve then failed later when `lib/dashboard-transport.ts` tried to read the missing built JS/CSS assets.

## What Changed

- Made `dashboardRuntimeReady` require the concrete dashboard build assets instead of accepting a source-shaped checkout by itself.
- Updated source checkout rebuild behavior so missing dashboard assets run the full `npm run build`; runtime-only stale rebuilds still use `npm run build:node`.
- Added a regression for an existing source-shaped runtime with missing dashboard assets, proving bootstrap does not report ready and instead hydrates verified release assets.
- Updated the existing source rebuild test to prove the full-build branch creates dashboard assets.
- Added an Unreleased changelog note for the launcher behavior fix.

## How To Review

Start in `plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs`: the readiness predicate and rebuild branch are the product change. Then review the source launcher tests around the runtime hydration cases in `plugins/codex-autoresearch/tests/autoresearch-cli.test.ts`.

## Verification

- `npm ci`
- `npm run build:node`
- `node --test --test-name-pattern 'source launcher does not treat source-shaped runtime as ready without dashboard assets' dist\tests\autoresearch-cli.test.mjs`
- `node --test --test-name-pattern 'source launcher' dist\tests\autoresearch-cli.test.mjs`
- `npm run format:check`
- `git diff --check`
- `npm run check` passed on rerun. The first run in the fresh worktree stopped at `dashboard-asset-parity` after generating ignored `assets/dashboard-build/`; rerunning with those generated assets present passed through package artifact and runtime smoke.

## Risk

Low. This intentionally makes source readiness stricter. Source checkouts without `node_modules` and missing dashboard assets will hydrate from the verified release path when install is allowed, or fail closed instead of claiming readiness.
