### PR TITLE
Fix live dashboard research cache stamp

### DIFF
--- a/plugins/codex-autoresearch/lib/live-server.ts
+++ b/plugins/codex-autoresearch/lib/live-server.ts
@@ -446,15 +446,15 @@ async function liveSessionSnapshot(
 }
 
 async function liveSessionStamp(sessionPaths: SessionPaths): Promise<string> {
-  // TTL-bounded dashboard reuse compares this stamp; a stale stamp can serve briefly
-  // until the next health poll notices ledger/config drift.
+  // TTL-bounded dashboard reuse compares this stamp before reusing the cached
+  // full fingerprint, so include the bounded research tree metadata here too.
   const parts = await Promise.all([
     fingerprintPath(sessionPaths.ledgerPath, "autoresearch.jsonl"),
     fingerprintPath(sessionPaths.configPath, "autoresearch.config.json"),
     fingerprintPath(sessionPaths.lastRunFallbackPath, "autoresearch.last-run.json"),
     fingerprintPath(sessionPaths.notesPath, "autoresearch.md"),
     fingerprintPath(sessionPaths.ideasPath, "autoresearch.ideas.md"),
-    fingerprintPath(sessionPaths.researchRoot, "autoresearch.research"),
+    fingerprintTree(sessionPaths.researchRoot, "autoresearch.research"),
   ]);
   return parts.join("|");
 }

--- a/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
+++ b/plugins/codex-autoresearch/tests/dashboard-verification.test.ts
@@ -4462,6 +4462,68 @@ test("live dashboard view model cache invalidates on wrapper session config chan
   }
 });
 
+test("live dashboard view model cache invalidates on nested research edits within ttl", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "autoresearch-live-research-cache-"));
+  const researchDir = path.join(dir, "autoresearch.research", "project-study");
+  const qualityGapsPath = path.join(researchDir, "quality-gaps.md");
+  const decisionCapsulePath = path.join(researchDir, "decision-capsule.json");
+  let recomputes = 0;
+  const readResearchDigest = async () => {
+    const [qualityGaps, decisionCapsule] = await Promise.all([
+      readFile(qualityGapsPath, "utf8"),
+      readFile(decisionCapsulePath, "utf8"),
+    ]);
+    return `${qualityGaps.trim()}|${decisionCapsule.trim()}`;
+  };
+  const server = await serveAutoresearch({
+    cwd: dir,
+    port: 0,
+    viewModelCacheTtlMs: 60_000,
+    pluginVersion: "0.test",
+    dashboardHtml: async () => "<!doctype html><title>research cache</title>",
+    viewModel: async () => {
+      recomputes += 1;
+      return { researchDigest: await readResearchDigest() };
+    },
+  });
+
+  try {
+    await mkdir(researchDir, { recursive: true });
+    await writeFile(qualityGapsPath, "- [ ] first gap\n", "utf8");
+    await writeFile(decisionCapsulePath, JSON.stringify({ bottleneck: "first" }), "utf8");
+
+    const first = await fetch(`${server.url}view-model.json`).then((res) => res.json());
+    const second = await fetch(`${server.url}view-model.json`).then((res) => res.json());
+
+    assert.match(first.researchDigest, /first gap/);
+    assert.equal(second.researchDigest, first.researchDigest);
+    assert.equal(recomputes, 1);
+
+    await writeFile(qualityGapsPath, "- [x] first gap\n- [ ] second gap\n", "utf8");
+
+    const afterQualityGap = await fetch(`${server.url}view-model.json`).then((res) => res.json());
+
+    assert.match(afterQualityGap.researchDigest, /second gap/);
+    assert.equal(recomputes, 2);
+
+    await writeFile(
+      decisionCapsulePath,
+      JSON.stringify({ bottleneck: "second", next: "inspect cache stamp" }),
+      "utf8",
+    );
+
+    const afterDecisionCapsule = await fetch(`${server.url}view-model.json`).then((res) =>
+      res.json(),
+    );
+
+    assert.match(afterDecisionCapsule.researchDigest, /inspect cache stamp/);
+    assert.equal(recomputes, 3);
+  } finally {
+    server.server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("live dashboard view model cache starts its ttl after slow recomputes finish", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "autoresearch-live-cache-slow-"));
   let recomputes = 0;


### PR DESCRIPTION
## Context

Refs #225

The live dashboard caches /view-model.json behind a TTL. The cache fingerprint already walked autoresearch.research with a bounded traversal, but the faster TTL stamp only statted the top autoresearch.research directory. Nested edits such as quality-gaps.md or decision-capsule.json could therefore keep serving the cached model inside a long TTL.

## What Changed

- Changed the live dashboard cache stamp to use the same bounded autoresearch.research tree metadata as the full fingerprint.
- Added a regression that serves /view-model.json with a 60s TTL, edits autoresearch.research/<slug>/quality-gaps.md, then edits autoresearch.research/<slug>/decision-capsule.json, and verifies each edit forces a recompute.

## How To Review

- Start in plugins/codex-autoresearch/lib/live-server.ts and check liveSessionStamp versus liveSessionSnapshot.
- Then read plugins/codex-autoresearch/tests/dashboard-verification.test.ts for the long-TTL nested research edit regression.

## Verification

- npm ci
- npm run build:node
- node --test --test-name-pattern "nested research edits" dist/tests/dashboard-verification.test.mjs
- npm run test:dashboard
- git diff --check
- npm run check attempted: typecheck, lint, format, product prechecks, dashboard/demo/source checks passed before test:compiled:cli timed out two unrelated CLI shards at the 300s shard limit (autoresearch-cli.test.mjs shards 13/23 and 16/23).

## Risk

- Low behavior risk: traversal stays bounded by existing LIVE_RESEARCH_FINGERPRINT_MAX_ENTRIES and LIVE_RESEARCH_FINGERPRINT_MAX_DEPTH.
- The cheap TTL stamp now does the bounded research tree walk, so very large research folders pay that bounded metadata cost per live view-model request.
