### PR TITLE
Split dashboard view-model builders

### DIFF
--- a/plugins/codex-autoresearch/lib/dashboard-view-model.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.ts
@@ -1,6 +1,8 @@
 import { STATUS_VALUES, buildDecisionEnvelope, finiteMetric } from "./session-core.js";
 import { redactEvidenceObject } from "./evidence-redaction.js";
 import { acceptedCurrentRuns, buildEvidenceRegistry } from "./evidence-registry.js";
+import { buildAiSummary } from "./dashboard-view-model/ai-summary.js";
+import { buildWatchdogSummary } from "./dashboard-view-model/watchdog-summary.js";
 import {
   actionMetadataForKind,
   fallbackCommandForKind,
@@ -12,6 +14,9 @@ import {
   stripDashboardGuidanceCommandFields,
 } from "./dashboard-command-safety.js";
 import type { DashboardContext } from "../dashboard/src/types.js";
+
+export { buildAiSummary } from "./dashboard-view-model/ai-summary.js";
+export { buildWatchdogSummary } from "./dashboard-view-model/watchdog-summary.js";
 
 type LooseObject = Record<string, any>;
 type Direction = "lower" | "higher" | string;
@@ -900,121 +905,6 @@ function summarizeRuntimeDrift(drift: LooseObject | null | undefined) {
     installedAvailable:
       typeof drift.installed?.available === "boolean" ? drift.installed.available : null,
   };
-}
-
-export function buildWatchdogSummary({
-  state,
-  settings = {},
-  current = [],
-  parallelLanes = [],
-  fanoutPlan = null,
-}: LooseObject) {
-  const thresholdSeconds = watchdogThresholdSeconds(settings, state?.config);
-  const thresholdHours = round(thresholdSeconds / 3600);
-  const nowMs = timestampMs(settings.now || settings.generatedAt) || Date.now();
-  const cutoffMs = nowMs - thresholdSeconds * 1000;
-  const currentRuns = Array.isArray(current) ? current : [];
-  const completedLanes = Array.isArray(parallelLanes)
-    ? parallelLanes.filter((lane: LooseObject) => laneCompleted(lane))
-    : [];
-  const progressEvents = [
-    ...metricMovementEvents(currentRuns, state?.config?.bestDirection || "lower"),
-    ...currentRuns.filter(watchdogDecisionRun).map((run: LooseObject) => ({
-      kind: "decision",
-      at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
-      label: `Logged run #${run.run ?? "?"} as ${run.status || "decision"}.`,
-    })),
-    ...currentRuns
-      .filter((run: LooseObject) => run.status === "keep" && cleanText(run.commit))
-      .map((run: LooseObject) => ({
-        kind: "kept_commit",
-        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
-        label: `Kept commit ${String(run.commit).slice(0, 12)} from run #${run.run ?? "?"}.`,
-      })),
-    ...completedLanes.map((lane: LooseObject) => ({
-      kind: "completed_lane",
-      at: timestampMs(lane.completedAt || lane.finishedAt || lane.updatedAt || lane.timestamp),
-      label: `Lane ${lane.title || lane.id || "unknown"} completed.`,
-    })),
-  ].filter((event) => event.at != null) as Array<{ kind: string; at: number; label: string }>;
-  const recentEvents = progressEvents.filter((event) => event.at >= cutoffMs);
-  const latestEvent = progressEvents.sort((a, b) => b.at - a.at)[0] || null;
-  const quietHours = latestEvent ? round((nowMs - latestEvent.at) / 3600000) : null;
-  const stale = currentRuns.length > 0 && recentEvents.length === 0 && quietHours != null;
-  const reasons = stale
-    ? [
-        `No metric movement, logged decision, kept commit, or completed lane in ${thresholdHours}h.`,
-        latestEvent
-          ? `Last progress signal: ${latestEvent.label}`
-          : "No dated progress signal found.",
-      ]
-    : recentEvents.length
-      ? [
-          `${recentEvents.length} progress signal${recentEvents.length === 1 ? "" : "s"} inside the watchdog window.`,
-        ]
-      : currentRuns.length
-        ? ["Run history has no dated progress signal; watchdog cannot prove a quiet window."]
-        : ["No run history yet; capture a baseline before watchdog pressure applies."];
-  const recommendation = stale
-    ? "Intervene before running more packets: inspect the active process, finalize kept work, or rescope the segment."
-    : currentRuns.length
-      ? "Continue from the decision envelope; watchdog has no stale no-progress window."
-      : "Run and log the baseline so the watchdog can compare future progress.";
-  return {
-    status: stale ? "stale" : currentRuns.length ? "tracking" : "idle",
-    stale,
-    thresholdSeconds,
-    thresholdHours,
-    quietHours,
-    latestProgressAt: latestEvent ? new Date(latestEvent.at).toISOString() : null,
-    recentProgressCount: recentEvents.length,
-    progressEventCount: progressEvents.length,
-    fanoutPlanId: cleanText(fanoutPlan?.id) || null,
-    completedLaneCount: completedLanes.length,
-    reasons,
-    recommendation,
-  };
-}
-
-function watchdogThresholdSeconds(settings: LooseObject, config: LooseObject = {}) {
-  const direct =
-    settings.watchdogNoProgressSeconds ??
-    settings.watchdogThresholdSeconds ??
-    config.watchdogNoProgressSeconds ??
-    config.watchdogThresholdSeconds;
-  const hours = settings.watchdogNoProgressHours ?? config.watchdogNoProgressHours;
-  const raw = direct ?? (hours != null ? Number(hours) * 3600 : 8 * 3600);
-  const value = Number(raw);
-  return Number.isFinite(value) && value > 0 ? value : 8 * 3600;
-}
-
-function metricMovementEvents(current: LooseObject[], direction: Direction) {
-  const events = [];
-  let previous: number | null = null;
-  for (const run of current) {
-    const metric = finiteMetric(run.metric);
-    if (metric == null) continue;
-    if (previous != null && metric !== previous) {
-      events.push({
-        kind: "metric_movement",
-        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
-        label: `Metric moved on run #${run.run ?? "?"} (${previous} -> ${metric}; ${direction}).`,
-      });
-    }
-    previous = metric;
-  }
-  return events;
-}
-
-function laneCompleted(lane: LooseObject) {
-  const status = String(lane.status || lane.state || lane.evidenceStatus || "").toLowerCase();
-  return ["complete", "completed", "done", "kept", "accepted", "finished"].includes(status);
-}
-
-function watchdogDecisionRun(run: LooseObject) {
-  if (run?.type === "lane_result") return false;
-  const status = String(run?.status || "").toLowerCase();
-  return ["keep", "discard", "crash", "checks_failed", "measure"].includes(status);
 }
 
 function timestampMs(value: unknown): number | null {
@@ -2618,133 +2508,6 @@ function warningMessage(warning: unknown): string {
     return String(payload.message || payload.code || "Warning");
   }
   return String(warning || "");
-}
-
-export function buildAiSummary({
-  state,
-  current,
-  kept,
-  failures,
-  bestKept,
-  latestFailure,
-  nextAction,
-  nextTitle,
-  qualityGap,
-  finalizePreview,
-  experimentMemory,
-  warnings,
-}: LooseObject) {
-  const context = summaryMetricContext({ state, current });
-  const metricName = state.config.metricName || "metric";
-  const blockers = [
-    ...(Array.isArray(warnings) ? warnings.map((warning: unknown) => warningMessage(warning)) : []),
-    ...(Array.isArray(finalizePreview?.warnings) ? finalizePreview.warnings : []),
-  ].filter(Boolean);
-
-  return {
-    title: current.length ? "Next move is ready." : "Run a baseline.",
-    subtitle: nextTitle || "Ledger, ASI, gap state, and finalization preview.",
-    happened: buildSummaryHappened({ current, kept, failures, metricName, ...context }).slice(0, 3),
-    plan: unique(
-      buildSummaryPlan({ bestKept, latestFailure, qualityGap, nextAction, finalizePreview }),
-    ).slice(0, 3),
-    blockers: blockers.slice(0, 2),
-    generatedFrom: {
-      runs: current.length,
-      latestRun: context.latest?.run || null,
-      latestActionHint: experimentMemory?.latestNextAction || "",
-    },
-  };
-}
-
-function summaryMetricContext({ state, current }: LooseObject) {
-  const baseline = finiteMetric(state.baseline);
-  const bestMetric = finiteMetric(state.best);
-  const latest = current.at(-1) || null;
-  return {
-    unit: state.config.metricUnit ? ` ${state.config.metricUnit}` : "",
-    direction: state.config.bestDirection === "higher" ? "higher is better" : "lower is better",
-    baseline,
-    bestMetric,
-    latest,
-    latestMetric: finiteMetric(latest?.metric),
-    delta:
-      baseline != null && bestMetric != null
-        ? percentChange(bestMetric, baseline, state.config.bestDirection)
-        : null,
-  };
-}
-
-function buildSummaryHappened({
-  current,
-  kept,
-  failures,
-  metricName,
-  unit,
-  direction,
-  baseline,
-  bestMetric,
-  latest,
-  latestMetric,
-  delta,
-}: LooseObject) {
-  if (!current.length) {
-    return ["No experiments have been logged yet; the loop needs a measured baseline."];
-  }
-  const happened = [
-    `${current.length} run${current.length === 1 ? "" : "s"} logged: ${kept.length} kept and ${failures.length} rejected or failed.`,
-  ];
-  if (baseline != null && bestMetric != null) {
-    const movement = delta == null ? "" : ` (${delta >= 0 ? "+" : ""}${round(delta)}%)`;
-    happened.push(
-      `The best ${metricName} is ${formatSummaryMetric(bestMetric, unit)} against a ${formatSummaryMetric(baseline, unit)} baseline${movement}; ${direction}.`,
-    );
-  }
-  if (latest) {
-    happened.push(
-      `Most recent run #${latest.run} was ${latest.status}${latestMetric == null ? "" : ` at ${formatSummaryMetric(latestMetric, unit)}`}.`,
-    );
-  }
-  return happened;
-}
-
-function buildSummaryPlan({
-  bestKept,
-  latestFailure,
-  qualityGap,
-  nextAction,
-  finalizePreview,
-}: LooseObject) {
-  const plan = [];
-  if (bestKept) {
-    plan.push(
-      `Use kept run #${bestKept.run} as the comparison anchor unless the next packet beats it.`,
-    );
-  }
-  if (latestFailure) {
-    plan.push(
-      `Avoid repeating #${latestFailure.run}: ${latestFailure.asi?.rollback_reason || latestFailure.description || "it did not improve the primary metric"}.`,
-    );
-  }
-  if (qualityGap) {
-    plan.push(
-      qualityGap.open > 0
-        ? `Work the next accepted gap in ${qualityGap.slug}; ${qualityGap.open} remain open.`
-        : `Treat ${qualityGap.slug} as closed unless a fresh gap pass finds credible new work.`,
-    );
-  }
-  if (nextAction) {
-    plan.push(nextAction);
-  }
-  if (finalizePreview?.ready) {
-    plan.push("Preview finalization and package the kept evidence for review.");
-  }
-  if (!plan.length) {
-    plan.push(
-      "Capture a clean baseline, then log the decision with ASI before the next experiment.",
-    );
-  }
-  return plan;
 }
 
 function percentChange(best: number, baseline: number, direction: Direction): number | null {

--- a/plugins/codex-autoresearch/lib/dashboard-view-model/ai-summary.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model/ai-summary.ts
@@ -1,0 +1,207 @@
+import { finiteMetric } from "../session-core.js";
+import type { UnknownRecord } from "../types/json.js";
+
+type Direction = "lower" | "higher" | string;
+
+export function buildAiSummary(input: UnknownRecord) {
+  const state = recordValue(input.state);
+  const current = recordArray(input.current);
+  const kept = recordArray(input.kept);
+  const failures = recordArray(input.failures);
+  const bestKept = recordOrNull(input.bestKept);
+  const latestFailure = recordOrNull(input.latestFailure);
+  const qualityGap = recordOrNull(input.qualityGap);
+  const finalizePreview = recordOrNull(input.finalizePreview);
+  const experimentMemory = recordOrNull(input.experimentMemory);
+  const warnings = Array.isArray(input.warnings) ? input.warnings : [];
+  const nextAction = input.nextAction;
+  const nextTitle = cleanText(input.nextTitle);
+  const context = summaryMetricContext({ state, current });
+  const metricName = recordValue(state.config).metricName || "metric";
+  const blockers = [
+    ...warnings.map((warning: unknown) => warningMessage(warning)),
+    ...(Array.isArray(finalizePreview?.warnings) ? finalizePreview.warnings : []),
+  ].filter(Boolean);
+
+  return {
+    title: current.length ? "Next move is ready." : "Run a baseline.",
+    subtitle: nextTitle || "Ledger, ASI, gap state, and finalization preview.",
+    happened: buildSummaryHappened({ current, kept, failures, metricName, ...context }).slice(0, 3),
+    plan: unique(
+      buildSummaryPlan({ bestKept, latestFailure, qualityGap, nextAction, finalizePreview }),
+    ).slice(0, 3),
+    blockers: blockers.slice(0, 2),
+    generatedFrom: {
+      runs: current.length,
+      latestRun: context.latest?.run || null,
+      latestActionHint: experimentMemory?.latestNextAction || "",
+    },
+  };
+}
+
+function summaryMetricContext({
+  state,
+  current,
+}: {
+  state: UnknownRecord;
+  current: UnknownRecord[];
+}) {
+  const config = recordValue(state.config);
+  const baseline = finiteMetric(state.baseline);
+  const bestMetric = finiteMetric(state.best);
+  const latest = current.at(-1) || null;
+  return {
+    unit: config.metricUnit ? ` ${config.metricUnit}` : "",
+    direction: config.bestDirection === "higher" ? "higher is better" : "lower is better",
+    baseline,
+    bestMetric,
+    latest,
+    latestMetric: finiteMetric(latest?.metric),
+    delta:
+      baseline != null && bestMetric != null
+        ? percentChange(bestMetric, baseline, String(config.bestDirection || "lower"))
+        : null,
+  };
+}
+
+function buildSummaryHappened({
+  current,
+  kept,
+  failures,
+  metricName,
+  unit,
+  direction,
+  baseline,
+  bestMetric,
+  latest,
+  latestMetric,
+  delta,
+}: UnknownRecord) {
+  const currentRuns = Array.isArray(current) ? current : [];
+  const keptRuns = Array.isArray(kept) ? kept : [];
+  const failedRuns = Array.isArray(failures) ? failures : [];
+  const baselineMetric = numberOrNull(baseline);
+  const bestMetricValue = numberOrNull(bestMetric);
+  const deltaValue = numberOrNull(delta);
+  const latestRecord = recordOrNull(latest);
+  const latestMetricValue = numberOrNull(latestMetric);
+  const metricUnit = cleanText(unit);
+  if (!currentRuns.length) {
+    return ["No experiments have been logged yet; the loop needs a measured baseline."];
+  }
+  const happened = [
+    `${currentRuns.length} run${currentRuns.length === 1 ? "" : "s"} logged: ${keptRuns.length} kept and ${failedRuns.length} rejected or failed.`,
+  ];
+  if (baselineMetric != null && bestMetricValue != null) {
+    const movement =
+      deltaValue == null ? "" : ` (${deltaValue >= 0 ? "+" : ""}${round(deltaValue)}%)`;
+    happened.push(
+      `The best ${metricName} is ${formatSummaryMetric(bestMetricValue, metricUnit)} against a ${formatSummaryMetric(baselineMetric, metricUnit)} baseline${movement}; ${direction}.`,
+    );
+  }
+  if (latestRecord) {
+    happened.push(
+      `Most recent run #${latestRecord.run} was ${latestRecord.status}${latestMetricValue == null ? "" : ` at ${formatSummaryMetric(latestMetricValue, metricUnit)}`}.`,
+    );
+  }
+  return happened;
+}
+
+function buildSummaryPlan({
+  bestKept,
+  latestFailure,
+  qualityGap,
+  nextAction,
+  finalizePreview,
+}: UnknownRecord) {
+  const plan = [];
+  const bestKeptRecord = recordOrNull(bestKept);
+  const latestFailureRecord = recordOrNull(latestFailure);
+  const qualityGapRecord = recordOrNull(qualityGap);
+  const finalizePreviewRecord = recordOrNull(finalizePreview);
+  if (bestKeptRecord) {
+    plan.push(
+      `Use kept run #${bestKeptRecord.run} as the comparison anchor unless the next packet beats it.`,
+    );
+  }
+  if (latestFailureRecord) {
+    plan.push(
+      `Avoid repeating #${latestFailureRecord.run}: ${recordValue(latestFailureRecord.asi).rollback_reason || latestFailureRecord.description || "it did not improve the primary metric"}.`,
+    );
+  }
+  if (qualityGapRecord) {
+    plan.push(
+      Number(qualityGapRecord.open) > 0
+        ? `Work the next accepted gap in ${qualityGapRecord.slug}; ${qualityGapRecord.open} remain open.`
+        : `Treat ${qualityGapRecord.slug} as closed unless a fresh gap pass finds credible new work.`,
+    );
+  }
+  if (nextAction) {
+    plan.push(nextAction);
+  }
+  if (finalizePreviewRecord?.ready) {
+    plan.push("Preview finalization and package the kept evidence for review.");
+  }
+  if (!plan.length) {
+    plan.push(
+      "Capture a clean baseline, then log the decision with ASI before the next experiment.",
+    );
+  }
+  return plan;
+}
+
+function percentChange(best: number, baseline: number, direction: Direction): number | null {
+  if (!Number.isFinite(best) || !Number.isFinite(baseline)) return null;
+  if (baseline === 0) return null;
+  const raw = ((best - baseline) / Math.abs(baseline)) * 100;
+  return direction === "higher" ? raw : -raw;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function formatSummaryMetric(value: number, unit: string): string {
+  return `${round(value)}${unit}`;
+}
+
+function unique<T>(items: T[]): T[] {
+  const seen = new Set<string>();
+  return items.filter((item: T) => {
+    const key = String(item || "");
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function warningMessage(warning: unknown): string {
+  if (warning && typeof warning === "object") {
+    const payload = warning as UnknownRecord;
+    return String(payload.message || payload.code || "Warning");
+  }
+  return String(warning || "");
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function cleanText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function recordArray(value: unknown): UnknownRecord[] {
+  return Array.isArray(value) ? value.map(recordValue) : [];
+}
+
+function recordValue(value: unknown): UnknownRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function recordOrNull(value: unknown): UnknownRecord | null {
+  const record = recordValue(value);
+  return Object.keys(record).length ? record : null;
+}

--- a/plugins/codex-autoresearch/lib/dashboard-view-model/watchdog-summary.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model/watchdog-summary.ts
@@ -1,0 +1,142 @@
+import { finiteMetric } from "../session-core.js";
+import type { UnknownRecord } from "../types/json.js";
+
+type Direction = "lower" | "higher" | string;
+
+export function buildWatchdogSummary(input: UnknownRecord) {
+  const state = recordValue(input.state);
+  const settings = recordValue(input.settings);
+  const current = Array.isArray(input.current) ? input.current : [];
+  const parallelLanes = Array.isArray(input.parallelLanes) ? input.parallelLanes : [];
+  const fanoutPlan = recordValue(input.fanoutPlan);
+  const thresholdSeconds = watchdogThresholdSeconds(settings, recordValue(state.config));
+  const thresholdHours = round(thresholdSeconds / 3600);
+  const nowMs = timestampMs(settings.now || settings.generatedAt) || Date.now();
+  const cutoffMs = nowMs - thresholdSeconds * 1000;
+  const currentRuns = current.map(recordValue);
+  const completedLanes = parallelLanes.map(recordValue).filter(laneCompleted);
+  const progressEvents = [
+    ...metricMovementEvents(
+      currentRuns,
+      String(recordValue(state.config).bestDirection || "lower"),
+    ),
+    ...currentRuns.filter(watchdogDecisionRun).map((run: UnknownRecord) => ({
+      kind: "decision",
+      at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
+      label: `Logged run #${run.run ?? "?"} as ${run.status || "decision"}.`,
+    })),
+    ...currentRuns
+      .filter((run: UnknownRecord) => run.status === "keep" && cleanText(run.commit))
+      .map((run: UnknownRecord) => ({
+        kind: "kept_commit",
+        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
+        label: `Kept commit ${String(run.commit).slice(0, 12)} from run #${run.run ?? "?"}.`,
+      })),
+    ...completedLanes.map((lane: UnknownRecord) => ({
+      kind: "completed_lane",
+      at: timestampMs(lane.completedAt || lane.finishedAt || lane.updatedAt || lane.timestamp),
+      label: `Lane ${lane.title || lane.id || "unknown"} completed.`,
+    })),
+  ].filter((event) => event.at != null) as Array<{ kind: string; at: number; label: string }>;
+  const recentEvents = progressEvents.filter((event) => event.at >= cutoffMs);
+  const latestEvent = progressEvents.sort((a, b) => b.at - a.at)[0] || null;
+  const quietHours = latestEvent ? round((nowMs - latestEvent.at) / 3600000) : null;
+  const stale = currentRuns.length > 0 && recentEvents.length === 0 && quietHours != null;
+  const reasons = stale
+    ? [
+        `No metric movement, logged decision, kept commit, or completed lane in ${thresholdHours}h.`,
+        latestEvent
+          ? `Last progress signal: ${latestEvent.label}`
+          : "No dated progress signal found.",
+      ]
+    : recentEvents.length
+      ? [
+          `${recentEvents.length} progress signal${recentEvents.length === 1 ? "" : "s"} inside the watchdog window.`,
+        ]
+      : currentRuns.length
+        ? ["Run history has no dated progress signal; watchdog cannot prove a quiet window."]
+        : ["No run history yet; capture a baseline before watchdog pressure applies."];
+  const recommendation = stale
+    ? "Intervene before running more packets: inspect the active process, finalize kept work, or rescope the segment."
+    : currentRuns.length
+      ? "Continue from the decision envelope; watchdog has no stale no-progress window."
+      : "Run and log the baseline so the watchdog can compare future progress.";
+  return {
+    status: stale ? "stale" : currentRuns.length ? "tracking" : "idle",
+    stale,
+    thresholdSeconds,
+    thresholdHours,
+    quietHours,
+    latestProgressAt: latestEvent ? new Date(latestEvent.at).toISOString() : null,
+    recentProgressCount: recentEvents.length,
+    progressEventCount: progressEvents.length,
+    fanoutPlanId: cleanText(fanoutPlan.id) || null,
+    completedLaneCount: completedLanes.length,
+    reasons,
+    recommendation,
+  };
+}
+
+function watchdogThresholdSeconds(settings: UnknownRecord, config: UnknownRecord = {}) {
+  const direct =
+    settings.watchdogNoProgressSeconds ??
+    settings.watchdogThresholdSeconds ??
+    config.watchdogNoProgressSeconds ??
+    config.watchdogThresholdSeconds;
+  const hours = settings.watchdogNoProgressHours ?? config.watchdogNoProgressHours;
+  const raw = direct ?? (hours != null ? Number(hours) * 3600 : 8 * 3600);
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : 8 * 3600;
+}
+
+function metricMovementEvents(current: UnknownRecord[], direction: Direction) {
+  const events = [];
+  let previous: number | null = null;
+  for (const run of current) {
+    const metric = finiteMetric(run.metric);
+    if (metric == null) continue;
+    if (previous != null && metric !== previous) {
+      events.push({
+        kind: "metric_movement",
+        at: timestampMs(run.timestamp || run.loggedAt || run.createdAt),
+        label: `Metric moved on run #${run.run ?? "?"} (${previous} -> ${metric}; ${direction}).`,
+      });
+    }
+    previous = metric;
+  }
+  return events;
+}
+
+function laneCompleted(lane: UnknownRecord) {
+  const status = String(lane.status || lane.state || lane.evidenceStatus || "").toLowerCase();
+  return ["complete", "completed", "done", "kept", "accepted", "finished"].includes(status);
+}
+
+function watchdogDecisionRun(run: UnknownRecord) {
+  if (run?.type === "lane_result") return false;
+  const status = String(run?.status || "").toLowerCase();
+  return ["keep", "discard", "crash", "checks_failed", "measure"].includes(status);
+}
+
+function timestampMs(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) return number;
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function cleanText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function recordValue(value: unknown): UnknownRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}


### PR DESCRIPTION
## Context
Refs #224

Parent epic: #231

`buildDashboardViewModel` is still the single dashboard model entrypoint, but two pure readout builders were embedded in the large `lib/dashboard-view-model.ts` file. This PR keeps behavior and copy stable while moving those builder groups behind the same public import surface.

## What Changed
- Moved AI summary shaping into `lib/dashboard-view-model/ai-summary.ts`.
- Moved watchdog summary shaping into `lib/dashboard-view-model/watchdog-summary.ts`.
- Kept `lib/dashboard-view-model.ts` as the orchestration entrypoint and re-exported the moved helpers so existing imports/tests remain stable.
- Rebasing included current `origin/dev` at `6540231` from #233; no live dashboard cache files or behavior were changed by this PR.

## How To Review
- Start with `plugins/codex-autoresearch/lib/dashboard-view-model.ts` and verify the public entrypoint still assembles the same read-only model.
- Then review the two new builder modules as moved pure logic, with `UnknownRecord` conversions added to satisfy source hygiene.
- Confirm there are no React UI, live-server/cache, package script, mutation route, or display copy changes.

## Verification
- PASS: `npm run test:dashboard` after rebase, 112/112 tests.
- PASS: `npm run test:core` after rebase, 280/280 tests.
- PASS: `git diff --check` after rebase.
- PARTIAL: `npm run check` after rebase passed typecheck, lint, format, source hygiene, dashboard build/parity, demo export, dogfood quality gate, command surface map, and perfection benchmark (`quality_gap=0`) before coordinator interruption during compiled CLI shards.
- Earlier before the rebase, `npm run check` reached compiled tests but failed the shard runner timeout on CLI shard ranges 120:130 and 150:160. Both timed-out ranges were rerun directly and passed 10/10 each.

## Risk
- Low behavior risk: this is a module split of pure readout builders, and dashboard/core regression tests passed after rebasing onto current `dev`.
- Residual risk: full `npm run check` did not complete in one uninterrupted run in this lane because the compiled CLI shard phase exceeded/ran into operator time constraints. The targeted failed shard ranges passed directly.