### PR TITLE
[codex] add release provenance smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ### Changed
 
+- Added a maintainer release-provenance smoke command that combines strict
+  tarball/checksum/release-asset digest checks with `gh attestation verify`
+  JSON certificate policy checks, without changing runtime hydration.
 - Clarified Git-private active last-run/progress storage and non-Git fallback cleanup guidance across docs and the Codex skill.
 - Clarified first-run docs after install, the first successful packet ladder, package-root versus target `--cwd`, and command-index ownership.
 - Clarified demo-session dashboard docs so current review uses the live server or ignored generated exports instead of the checked-in legacy HTML fixture.

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -120,6 +120,36 @@ package dashboard export smoke.
 
 Do not push release tags by hand. After a synchronized version bump lands on `main`, the `Auto Release` GitHub Actions workflow compares the previous and current package versions and calls the reusable `Release` workflow when the package version changed. The release workflow still runs the checks, lets `prepack` build the tarball, smoke-tests the extracted tarball with the package check helper, refuses pre-existing tags, and only then creates the GitHub release/tag with the tarball asset attached. Use manual `Release` dispatch only as an explicit recovery path with the package version. This keeps update clients on the previous release until the new install artifact exists.
 
+Release provenance is a maintainer/operator gate, not runtime bootstrap. Source
+runtime hydration stays on the adjacent SHA-256 checksum and packaged
+name/version checks so first-run installs do not depend on GitHub CLI,
+attestation APIs, or Sigstore network state. After downloading a published
+tarball and adjacent checksum, use:
+
+```bash
+npm run smoke:release-provenance -- --tarball codex-autoresearch-<version>.tgz --checksum codex-autoresearch-<version>.tgz.sha256 --tag v<version>
+```
+
+The smoke fetches release metadata with `gh api`, runs
+`gh attestation verify <tarball> --repo TheGreenCedar/codex-autoresearch --signer-workflow TheGreenCedar/codex-autoresearch/.github/workflows/release.yml --format json`,
+and then checks the JSON certificate fields instead of relying on
+`--source-ref` or `--source-digest`. It requires the SLSA subject digest,
+tarball SHA-256, release asset digest, and checksum manifest digest to agree,
+then checks the signer SAN, source repository, `refs/heads/main`,
+GitHub-hosted runner, and release target commit.
+
+Check immutable-release status before publishing a release:
+
+```bash
+gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2026-03-10" /repos/TheGreenCedar/codex-autoresearch/immutable-releases
+```
+
+If it returns `{"enabled":false,...}`, a repository admin should enable
+future-release immutability with `PUT /repos/TheGreenCedar/codex-autoresearch/immutable-releases`
+or through the repository Settings > Code security > Releases control. The
+setting applies to future releases; it does not retroactively lock old release
+assets.
+
 ## Skill Progression Map
 
 Use recurring PR and review evidence to choose the next hardening drill. Each drill should leave a product safeguard behind, not just a private note.

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -59,6 +59,7 @@
     "test:core": "run-s build:node test:compiled:core",
     "check:product": "npm run build:node && node scripts/check.mjs",
     "check:source-hygiene": "node scripts/check.mjs --phase source-hygiene",
+    "smoke:release-provenance": "node scripts/check.mjs --phase release-provenance-smoke",
     "check": "run-p typecheck lint format:check && npm run check:product"
   },
   "devDependencies": {

--- a/plugins/codex-autoresearch/scripts/check.ts
+++ b/plugins/codex-autoresearch/scripts/check.ts
@@ -129,6 +129,9 @@ export async function runCheckMain(
     if (selectedPhase.phase === "release-package-smoke") {
       return (await runReleasePackageSmokePhase(selectedPhase.args)) ? 0 : 1;
     }
+    if (selectedPhase.phase === "release-provenance-smoke") {
+      return (await runReleaseProvenanceSmokePhase(selectedPhase.args)) ? 0 : 1;
+    }
     return reportUnknownPhase(selectedPhase.phase) ? 0 : 1;
   }
 
@@ -184,14 +187,16 @@ function parseSelectedPhase(args: string[]): PhaseSelection {
 function reportPhaseUsageError(message: string): false {
   console.error(message);
   console.error(
-    "Usage: node scripts/check.mjs [--phase source-hygiene|release-package-smoke --tarball <file> [--checksum <file>]]",
+    "Usage: node scripts/check.mjs [--phase source-hygiene|release-package-smoke|release-provenance-smoke --tarball <file> [--checksum <file>]]",
   );
   return false;
 }
 
 function reportUnknownPhase(phase: string): false {
   console.error(`Unknown check phase: ${phase}`);
-  console.error("Available phases: source-hygiene, release-package-smoke");
+  console.error(
+    "Available phases: source-hygiene, release-package-smoke, release-provenance-smoke",
+  );
   return false;
 }
 
@@ -407,6 +412,91 @@ async function runReleasePackageSmokePhase(args: string[]): Promise<boolean> {
   } finally {
     await fsp.rm(smokeDir, { recursive: true, force: true }).catch(() => {});
   }
+}
+
+async function runReleaseProvenanceSmokePhase(args: string[]): Promise<boolean> {
+  console.log("\n== release provenance smoke ==");
+  const tarballArg = optionValue(args, "--tarball");
+  const checksumArg = optionValue(args, "--checksum");
+  if (!tarballArg || !checksumArg) {
+    console.log("fail release-provenance-smoke");
+    console.log(indent("Missing --tarball <file> or --checksum <file>."));
+    return false;
+  }
+
+  const repo = optionValue(args, "--repo") || "TheGreenCedar/codex-autoresearch";
+  const signerWorkflow =
+    optionValue(args, "--signer-workflow") ||
+    "TheGreenCedar/codex-autoresearch/.github/workflows/release.yml";
+  const tag = optionValue(args, "--tag");
+  const tarball = path.resolve(process.cwd(), tarballArg);
+  const checksumPath = path.resolve(process.cwd(), checksumArg);
+  const releaseJsonPath = optionValue(args, "--release-json");
+  const attestationJsonPath = optionValue(args, "--attestation-json");
+  const targetCommit = optionValue(args, "--target-commit");
+
+  let releaseJson = "";
+  if (releaseJsonPath) {
+    releaseJson = await fsp.readFile(path.resolve(process.cwd(), releaseJsonPath), "utf8");
+  } else {
+    if (!tag) {
+      console.log("fail release-provenance-smoke");
+      console.log(indent("Missing --tag <vX.Y.Z> when --release-json is not provided."));
+      return false;
+    }
+    const release = await runCommand([
+      "release-provenance:release-json",
+      "gh",
+      ["api", `repos/${repo}/releases/tags/${tag}`],
+    ]);
+    if (release.code !== 0) {
+      console.log("fail release-provenance-smoke");
+      const output = `${release.stdout}${release.stderr}`.trim();
+      if (output) console.log(indent(output));
+      return false;
+    }
+    releaseJson = release.stdout;
+  }
+
+  let attestationJson = "";
+  if (attestationJsonPath) {
+    attestationJson = await fsp.readFile(path.resolve(process.cwd(), attestationJsonPath), "utf8");
+  } else {
+    const attestation = await runCommand([
+      "release-provenance:attestation",
+      "gh",
+      releaseProvenanceGhVerifyArgs(tarball, { repo, signerWorkflow }),
+    ]);
+    if (attestation.code !== 0) {
+      console.log("fail release-provenance-smoke");
+      const output = `${attestation.stdout}${attestation.stderr}`.trim();
+      if (output) console.log(indent(output));
+      return false;
+    }
+    attestationJson = attestation.stdout;
+  }
+
+  let issue = "";
+  try {
+    issue = await releaseProvenanceIssue({
+      attestationJson,
+      checksumPath,
+      releaseJson,
+      repo,
+      signerWorkflow,
+      targetCommit,
+      tarball,
+    });
+  } catch (error) {
+    issue = errorMessage(error);
+  }
+  if (issue) {
+    console.log("fail release-provenance-smoke");
+    console.log(indent(issue));
+    return false;
+  }
+  console.log("ok release-provenance-smoke");
+  return true;
 }
 
 async function runSourceHygieneCheck(
@@ -1086,6 +1176,148 @@ export async function releaseChecksumIssue(tarball: string, checksumPath: string
   return "";
 }
 
+export interface ReleaseProvenanceOptions {
+  attestationJson: string;
+  checksumPath: string;
+  releaseJson: string;
+  repo?: string;
+  signerWorkflow?: string;
+  targetCommit?: string;
+  tarball: string;
+}
+
+export function releaseProvenanceGhVerifyArgs(
+  tarball: string,
+  options: { repo?: string; signerWorkflow?: string } = {},
+): string[] {
+  return [
+    "attestation",
+    "verify",
+    tarball,
+    "--repo",
+    options.repo || "TheGreenCedar/codex-autoresearch",
+    "--signer-workflow",
+    options.signerWorkflow || "TheGreenCedar/codex-autoresearch/.github/workflows/release.yml",
+    "--format",
+    "json",
+  ];
+}
+
+export async function releaseProvenanceIssue(options: ReleaseProvenanceOptions): Promise<string> {
+  const repo = options.repo || "TheGreenCedar/codex-autoresearch";
+  const signerWorkflow =
+    options.signerWorkflow || "TheGreenCedar/codex-autoresearch/.github/workflows/release.yml";
+  const tarballName = path.basename(options.tarball);
+  const checksumName = path.basename(options.checksumPath);
+  const checksumText = await fsp.readFile(options.checksumPath, "utf8");
+  const expectedHash = await parseStrictSha256Manifest(checksumText, tarballName);
+  const tarballHash = await fileSha256(options.tarball);
+  if (tarballHash !== expectedHash) {
+    return `Checksum mismatch for ${tarballName}: expected ${expectedHash}, got ${tarballHash}.`;
+  }
+
+  const release = parseJsonObject(options.releaseJson, "release JSON");
+  const targetCommit = options.targetCommit || stringField(release, "target_commitish");
+  if (!/^[a-f0-9]{40}$/i.test(targetCommit)) {
+    return `Release target commit must be a full 40-character SHA, got ${JSON.stringify(
+      targetCommit,
+    )}.`;
+  }
+
+  const tarballAsset = releaseAsset(release, tarballName);
+  if (!tarballAsset) return `Release asset ${tarballName} was not found.`;
+  const releaseDigest = assetSha256(tarballAsset);
+  if (releaseDigest !== tarballHash) {
+    return `Release asset digest for ${tarballName} expected ${tarballHash}, got ${releaseDigest || "missing"}.`;
+  }
+
+  const checksumAsset = releaseAsset(release, checksumName);
+  if (!checksumAsset) return `Release checksum asset ${checksumName} was not found.`;
+  const checksumAssetDigest = assetSha256(checksumAsset);
+  const checksumFileHash = await fileSha256(options.checksumPath);
+  if (checksumAssetDigest !== checksumFileHash) {
+    return `Release asset digest for ${checksumName} expected ${checksumFileHash}, got ${
+      checksumAssetDigest || "missing"
+    }.`;
+  }
+
+  const attestations = parseJsonArray(options.attestationJson, "attestation JSON");
+  const matching = attestations
+    .map((entry) => attestationPolicyView(entry))
+    .filter((entry) =>
+      entry.subjects.some(
+        (subject) => subject.name === tarballName && subject.sha256 === tarballHash,
+      ),
+    );
+  if (!matching.length) {
+    return `Attestation subject ${tarballName} with SHA-256 ${tarballHash} was not found.`;
+  }
+
+  const expectedSan = `https://github.com/${signerWorkflow}@refs/heads/main`;
+  const expectedRepoUri = `https://github.com/${repo}`;
+  const expectedWorkflowPath = signerWorkflow.slice(`${repo}/`.length);
+  const expectedBuilderUri = `https://github.com/${signerWorkflow}@refs/heads/main`;
+  for (const entry of matching) {
+    const issues = [
+      requireEqual(
+        "certificate subjectAlternativeName",
+        entry.certificate.subjectAlternativeName,
+        expectedSan,
+      ),
+      requireEqual(
+        "certificate githubWorkflowRepository",
+        entry.certificate.githubWorkflowRepository,
+        repo,
+      ),
+      requireEqual(
+        "certificate sourceRepositoryURI",
+        entry.certificate.sourceRepositoryURI,
+        expectedRepoUri,
+      ),
+      requireEqual(
+        "certificate sourceRepositoryRef",
+        entry.certificate.sourceRepositoryRef,
+        "refs/heads/main",
+      ),
+      requireEqual(
+        "certificate runnerEnvironment",
+        entry.certificate.runnerEnvironment,
+        "github-hosted",
+      ),
+      requireEqual(
+        "certificate sourceRepositoryDigest",
+        entry.certificate.sourceRepositoryDigest,
+        targetCommit,
+      ),
+      requireEqual(
+        "certificate githubWorkflowSHA",
+        entry.certificate.githubWorkflowSHA,
+        targetCommit,
+      ),
+      requireEqual("workflow repository", entry.workflow.repository, expectedRepoUri),
+      requireEqual("workflow ref", entry.workflow.ref, "refs/heads/main"),
+      requireEqual("workflow path", entry.workflow.path, expectedWorkflowPath),
+      requireEqual("predicate runner_environment", entry.runnerEnvironment, "github-hosted"),
+      requireEqual("builder id", entry.builderId, expectedBuilderUri),
+    ].filter(Boolean);
+    const dependencyOk = entry.resolvedDependencies.some(
+      (dependency) =>
+        dependency.uri === `git+${expectedRepoUri}@refs/heads/main` &&
+        dependency.gitCommit === targetCommit,
+    );
+    if (!dependencyOk) {
+      issues.push(
+        `resolvedDependencies must include git+${expectedRepoUri}@refs/heads/main at ${targetCommit}.`,
+      );
+    }
+    if (!issues.length) return "";
+  }
+
+  return `No matching attestation satisfied release provenance policy:\n${matching
+    .map((entry) => entry.summary)
+    .join("\n")}`;
+}
+
 async function parseStrictSha256Manifest(text: string, expectedFileName: string): Promise<string> {
   const releaseIntegrity = (await import(
     pathToFileURL(path.join(ROOT, "scripts", "release-integrity.mjs")).href
@@ -1093,6 +1325,124 @@ async function parseStrictSha256Manifest(text: string, expectedFileName: string)
     parseSha256Manifest: (text: string, expectedFileName: string) => string;
   };
   return releaseIntegrity.parseSha256Manifest(text, expectedFileName);
+}
+
+async function fileSha256(file: string): Promise<string> {
+  return createHash("sha256")
+    .update(await fsp.readFile(file))
+    .digest("hex");
+}
+
+function parseJsonObject(text: string, label: string): Record<string, unknown> {
+  const value = JSON.parse(text) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseJsonArray(text: string, label: string): unknown[] {
+  const value = JSON.parse(text) as unknown;
+  if (!Array.isArray(value)) throw new Error(`${label} must be a JSON array.`);
+  return value;
+}
+
+function releaseAsset(
+  release: Record<string, unknown>,
+  name: string,
+): Record<string, unknown> | null {
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  for (const asset of assets) {
+    if (asset && typeof asset === "object" && !Array.isArray(asset)) {
+      const record = asset as Record<string, unknown>;
+      if (record.name === name) return record;
+    }
+  }
+  return null;
+}
+
+function assetSha256(asset: Record<string, unknown>): string {
+  const digest = String(asset.digest || "");
+  const match = digest.match(/^sha256:([a-f0-9]{64})$/i);
+  return match ? match[1].toLowerCase() : "";
+}
+
+function attestationPolicyView(entry: unknown) {
+  const root = record(entry);
+  const result = record(root.verificationResult);
+  const statement = record(result.statement);
+  const predicate = record(statement.predicate);
+  const buildDefinition = record(predicate.buildDefinition);
+  const externalParameters = record(buildDefinition.externalParameters);
+  const workflow = record(externalParameters.workflow);
+  const internalParameters = record(buildDefinition.internalParameters);
+  const github = record(internalParameters.github);
+  const runDetails = record(predicate.runDetails);
+  const builder = record(runDetails.builder);
+  const signature = record(result.signature);
+  const certificate = record(signature.certificate);
+  const subjects = (Array.isArray(statement.subject) ? statement.subject : []).map((subject) => {
+    const subjectRecord = record(subject);
+    return {
+      name: stringField(subjectRecord, "name"),
+      sha256: stringField(record(subjectRecord.digest), "sha256").toLowerCase(),
+    };
+  });
+  const resolvedDependencies = (
+    Array.isArray(buildDefinition.resolvedDependencies) ? buildDefinition.resolvedDependencies : []
+  ).map((dependency) => {
+    const dependencyRecord = record(dependency);
+    return {
+      gitCommit: stringField(record(dependencyRecord.digest), "gitCommit"),
+      uri: stringField(dependencyRecord, "uri"),
+    };
+  });
+  return {
+    builderId: stringField(builder, "id"),
+    certificate: {
+      githubWorkflowRepository: stringField(certificate, "githubWorkflowRepository"),
+      githubWorkflowSHA: stringField(certificate, "githubWorkflowSHA"),
+      runnerEnvironment: stringField(certificate, "runnerEnvironment"),
+      sourceRepositoryDigest: stringField(certificate, "sourceRepositoryDigest"),
+      sourceRepositoryRef: stringField(certificate, "sourceRepositoryRef"),
+      sourceRepositoryURI: stringField(certificate, "sourceRepositoryURI"),
+      subjectAlternativeName: stringField(certificate, "subjectAlternativeName"),
+    },
+    resolvedDependencies,
+    runnerEnvironment: stringField(github, "runner_environment"),
+    subjects,
+    summary: JSON.stringify({
+      certificate: {
+        githubWorkflowRepository: stringField(certificate, "githubWorkflowRepository"),
+        sourceRepositoryDigest: stringField(certificate, "sourceRepositoryDigest"),
+        sourceRepositoryRef: stringField(certificate, "sourceRepositoryRef"),
+        subjectAlternativeName: stringField(certificate, "subjectAlternativeName"),
+      },
+      subjects,
+    }),
+    workflow: {
+      path: stringField(workflow, "path"),
+      ref: stringField(workflow, "ref"),
+      repository: stringField(workflow, "repository"),
+    },
+  };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringField(recordValue: Record<string, unknown>, field: string): string {
+  const value = recordValue[field];
+  return typeof value === "string" ? value : "";
+}
+
+function requireEqual(label: string, actual: string, expected: string): string {
+  return actual === expected
+    ? ""
+    : `${label} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}.`;
 }
 
 async function runPackageSmokeCommands(extractDir: string) {

--- a/plugins/codex-autoresearch/tests/check-runner.test.ts
+++ b/plugins/codex-autoresearch/tests/check-runner.test.ts
@@ -11,6 +11,8 @@ import {
   dashboardGeneratedDemoExport,
   demoDashboardExportCommand,
   releaseChecksumIssue,
+  releaseProvenanceGhVerifyArgs,
+  releaseProvenanceIssue,
   resolveNpmCommand,
 } from "../scripts/check.js";
 
@@ -213,6 +215,81 @@ test("release package smoke rejects unnamed checksum manifests", async () => {
   });
 });
 
+test("release provenance smoke builds gh attestation verification without flaky source flags", () => {
+  const args = releaseProvenanceGhVerifyArgs("codex-autoresearch-2.4.0.tgz", {
+    repo: "TheGreenCedar/codex-autoresearch",
+    signerWorkflow: "TheGreenCedar/codex-autoresearch/.github/workflows/release.yml",
+  });
+
+  assert.deepEqual(args, [
+    "attestation",
+    "verify",
+    "codex-autoresearch-2.4.0.tgz",
+    "--repo",
+    "TheGreenCedar/codex-autoresearch",
+    "--signer-workflow",
+    "TheGreenCedar/codex-autoresearch/.github/workflows/release.yml",
+    "--format",
+    "json",
+  ]);
+  assert.equal(args.includes("--source-ref"), false);
+  assert.equal(args.includes("--source-digest"), false);
+});
+
+test("release provenance smoke accepts matching checksum, release asset, and certificate policy", async () => {
+  await withTempDir("release-provenance-ok-", async (dir) => {
+    const fixture = await writeReleaseProvenanceFixture(dir);
+
+    assert.equal(
+      await releaseProvenanceIssue({
+        attestationJson: JSON.stringify(fixture.attestations),
+        checksumPath: fixture.checksum,
+        releaseJson: JSON.stringify(fixture.release),
+        targetCommit: fixture.commit,
+        tarball: fixture.tarball,
+      }),
+      "",
+    );
+  });
+});
+
+test("release provenance smoke rejects certificate policy drift", async () => {
+  await withTempDir("release-provenance-ref-", async (dir) => {
+    const fixture = await writeReleaseProvenanceFixture(dir);
+    const attestations = structuredClone(fixture.attestations);
+    attestations[0].verificationResult.signature.certificate.sourceRepositoryRef = "refs/heads/dev";
+
+    assert.match(
+      await releaseProvenanceIssue({
+        attestationJson: JSON.stringify(attestations),
+        checksumPath: fixture.checksum,
+        releaseJson: JSON.stringify(fixture.release),
+        targetCommit: fixture.commit,
+        tarball: fixture.tarball,
+      }),
+      /No matching attestation satisfied release provenance policy/,
+    );
+  });
+});
+
+test("release provenance smoke rejects release asset digest drift", async () => {
+  await withTempDir("release-provenance-asset-", async (dir) => {
+    const fixture = await writeReleaseProvenanceFixture(dir);
+    fixture.release.assets[0].digest = `sha256:${"0".repeat(64)}`;
+
+    assert.match(
+      await releaseProvenanceIssue({
+        attestationJson: JSON.stringify(fixture.attestations),
+        checksumPath: fixture.checksum,
+        releaseJson: JSON.stringify(fixture.release),
+        targetCommit: fixture.commit,
+        tarball: fixture.tarball,
+      }),
+      /Release asset digest for codex-autoresearch-2\.4\.0\.tgz expected/,
+    );
+  });
+});
+
 async function withTempDir(prefix: string, fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
   try {
@@ -220,4 +297,84 @@ async function withTempDir(prefix: string, fn: (dir: string) => Promise<void>): 
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+}
+
+async function writeReleaseProvenanceFixture(dir: string) {
+  const repo = "TheGreenCedar/codex-autoresearch";
+  const workflowPath = ".github/workflows/release.yml";
+  const workflow = `${repo}/${workflowPath}`;
+  const commit = "622959562359e2c608f2bfa8e6fa91340751d7af";
+  const tarballName = "codex-autoresearch-2.4.0.tgz";
+  const checksumName = `${tarballName}.sha256`;
+  const tarball = path.join(dir, tarballName);
+  const checksum = path.join(dir, checksumName);
+  const bytes = "release tarball";
+  const tarballHash = createHash("sha256").update(bytes).digest("hex");
+  const checksumText = `${tarballHash}  ${tarballName}\n`;
+  const checksumHash = createHash("sha256").update(checksumText).digest("hex");
+
+  await writeFile(tarball, bytes, "utf8");
+  await writeFile(checksum, checksumText, "utf8");
+
+  const release = {
+    assets: [
+      { digest: `sha256:${tarballHash}`, name: tarballName },
+      { digest: `sha256:${checksumHash}`, name: checksumName },
+    ],
+    target_commitish: commit,
+  };
+  const attestations = [
+    {
+      verificationResult: {
+        signature: {
+          certificate: {
+            githubWorkflowRepository: repo,
+            githubWorkflowSHA: commit,
+            runnerEnvironment: "github-hosted",
+            sourceRepositoryDigest: commit,
+            sourceRepositoryRef: "refs/heads/main",
+            sourceRepositoryURI: `https://github.com/${repo}`,
+            subjectAlternativeName: `https://github.com/${workflow}@refs/heads/main`,
+          },
+        },
+        statement: {
+          predicate: {
+            buildDefinition: {
+              externalParameters: {
+                workflow: {
+                  path: workflowPath,
+                  ref: "refs/heads/main",
+                  repository: `https://github.com/${repo}`,
+                },
+              },
+              internalParameters: {
+                github: {
+                  runner_environment: "github-hosted",
+                },
+              },
+              resolvedDependencies: [
+                {
+                  digest: { gitCommit: commit },
+                  uri: `git+https://github.com/${repo}@refs/heads/main`,
+                },
+              ],
+            },
+            runDetails: {
+              builder: {
+                id: `https://github.com/${workflow}@refs/heads/main`,
+              },
+            },
+          },
+          subject: [
+            {
+              digest: { sha256: tarballHash },
+              name: tarballName,
+            },
+          ],
+        },
+      },
+    },
+  ];
+
+  return { attestations, checksum, commit, release, tarball };
 }


### PR DESCRIPTION
## Context

Refs #232

#230 kept source runtime hydration on the adjacent SHA-256 gate. This PR keeps that runtime path unchanged and adds the smallest maintainer/operator smoke for release provenance after a release artifact exists.

Immutable release status was checked with:

```bash
gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2026-03-10' /repos/TheGreenCedar/codex-autoresearch/immutable-releases
```

Result: `{"enabled":false,"enforced_by_owner":false}`. The org-level settings endpoint for `TheGreenCedar` returned 404 with the current token, so the concrete owner action is to enable repository immutable releases for future releases via repo settings or `PUT /repos/TheGreenCedar/codex-autoresearch/immutable-releases`.

## What Changed

- Added `release-provenance-smoke` to `scripts/check.ts` and `npm run smoke:release-provenance`.
- The smoke verifies the strict adjacent checksum, release asset digests, and `gh attestation verify ... --signer-workflow ... --format json` output.
- The policy checks JSON/certificate fields for signer SAN, source repository, `refs/heads/main`, GitHub-hosted runner, release target commit, and subject digest agreement.
- Documented the maintainer/operator gate and immutable-release owner action in `docs/maintainers.md`.
- Added focused offline tests for checksum/provenance success and drift failures.

## How To Review

- Start with `plugins/codex-autoresearch/scripts/check.ts` around `releaseProvenanceIssue` and `releaseProvenanceGhVerifyArgs`.
- Confirm the command does not use flaky `--source-ref` or `--source-digest` flags.
- Confirm `scripts/bootstrap-runtime.mjs` and runtime hydration behavior are unchanged.
- Review `plugins/codex-autoresearch/docs/maintainers.md` for the maintainer command and immutable-release action.

## Verification

- `gh api ... /repos/TheGreenCedar/codex-autoresearch/immutable-releases` -> `{"enabled":false,"enforced_by_owner":false}`
- `gh release view --repo TheGreenCedar/codex-autoresearch --json tagName,targetCommitish,isImmutable,assets,url,publishedAt` -> latest `v2.4.0`, target `622959562359e2c608f2bfa8e6fa91340751d7af`, `isImmutable:false`
- `gh attestation verify C:\Users\alber\AppData\Local\Temp\codex-autoresearch-provenance-sample\codex-autoresearch-2.4.0.tgz --repo TheGreenCedar/codex-autoresearch --signer-workflow TheGreenCedar/codex-autoresearch/.github/workflows/release.yml --format json` -> exit 0
- `node --test --test-name-pattern "release (package smoke|provenance smoke)" dist\tests\check-runner.test.mjs` -> 6/6 pass
- `npm run smoke:release-provenance -- --tarball C:\Users\alber\AppData\Local\Temp\codex-autoresearch-provenance-sample\codex-autoresearch-2.4.0.tgz --checksum C:\Users\alber\AppData\Local\Temp\codex-autoresearch-provenance-sample\codex-autoresearch-2.4.0.tgz.sha256 --tag v2.4.0 --target-commit 622959562359e2c608f2bfa8e6fa91340751d7af` -> `ok release-provenance-smoke`
- `git diff --check origin/dev...HEAD` -> pass
- `npm run check` -> pass before rebasing onto #233
- After rebasing onto `origin/dev` at `65402315ffc2503b154c23e22ed527ef2382ce73`: `git diff --check origin/dev...HEAD` passed and `npm run smoke:release-provenance ...` passed again. A second full `npm run check` was interrupted by coordinator request after typecheck/lint/format/source hygiene/syntax/dashboard parity/demo/source-checkout/dogfood/product benchmark and several compiled shards had passed.

## Risk

Runtime hydration remains non-gating and unchanged. The new command depends on `gh` auth/network and published attestation availability, so it is documented as a maintainer/operator release smoke rather than first-run plugin behavior. Immutable releases are still disabled until a repository admin enables them for future releases.
