### PR TITLE
Extract state and doctor command services

### DIFF
--- a/plugins/codex-autoresearch/lib/commands/doctor.ts
+++ b/plugins/codex-autoresearch/lib/commands/doctor.ts
@@ -1,4 +1,6 @@
-type LooseObject = Record<string, any>;
+import type { UnknownRecord } from "../types/json.js";
+
+type CommandRecord = UnknownRecord & Record<string, any>;
 
 export type DoctorCommandServiceDeps = Record<string, any>;
 
@@ -42,9 +44,9 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
   const PLUGIN_ROOT = deps.pluginRoot;
   const PLUGIN_VERSION = deps.pluginVersion;
 
-  async function doctorSession(args: LooseObject): Promise<LooseObject> {
+  async function doctorSession(args: CommandRecord): Promise<CommandRecord> {
     const { sessionCwd, workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
-    const state: LooseObject = await publicState({ ...args, compact: false });
+    const state: CommandRecord = await publicState({ ...args, compact: false });
     const primaryMetricName =
       args.metric_name ||
       args.metricName ||
@@ -130,7 +132,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     });
     const publicCommandAuthority = publicCommandPayload(guidance.commandAuthority);
     const publicPreflight = publicCommandPayload(guidance.preflight);
-    const runtimeAuthority = (guidance.runtimeAuthority || null) as LooseObject | null;
+    const runtimeAuthority = (guidance.runtimeAuthority || null) as CommandRecord | null;
     if (runtimeAuthority?.blocking === true) {
       pushUniqueMessage(issues, runtimeAuthority.blocker);
     }
@@ -160,7 +162,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     );
     for (const blocker of loopAuthority.blockers) pushUniqueMessage(issues, blocker);
 
-    const benchmark: LooseObject = {
+    const benchmark: CommandRecord = {
       checked: false,
       command: args.command || "",
       packetEnvMode: null,
@@ -286,7 +288,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
       command: redactCommandDisplay(benchmark.command),
     };
 
-    const result: LooseObject = {
+    const result: CommandRecord = {
       ok: issues.length === 0,
       workDir,
       config: state.config,
@@ -327,7 +329,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     return result;
   }
 
-  async function catalogTrustCheck(config: LooseObject, sessionCwd: string) {
+  async function catalogTrustCheck(config: CommandRecord, sessionCwd: string) {
     const provenance = config.recipeCatalogProvenance || config.recipe_catalog_provenance || null;
     if (!provenance) return { ok: true, issues: [] as string[] };
     return await revalidateRecipeCatalogProvenance(provenance, { catalogBaseDir: sessionCwd });
@@ -342,7 +344,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     bestMetric,
     direction,
     metricName,
-  }: LooseObject) {
+  }: CommandRecord) {
     const current = finiteMetric(currentMetric);
     const best = finiteMetric(bestMetric);
     if (current == null || best == null || best === 0) return "";
@@ -354,7 +356,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     return `Benchmark drift: current ${metricName}=${current} is far worse than historical best ${best}. Treat the old best as historical evidence, not current runtime proof.`;
   }
 
-  function doctorExplanation(result: LooseObject): LooseObject {
+  function doctorExplanation(result: CommandRecord): CommandRecord {
     const runtimeSummary = result.runtimeDriftSummary || null;
     return {
       verdict: result.ok
@@ -384,7 +386,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     };
   }
 
-  function guidanceBlockers(guidance: LooseObject): string[] {
+  function guidanceBlockers(guidance: CommandRecord): string[] {
     const blockers = [
       ...listOption(guidance.gateQuality?.blockers),
       ...(guidance.preflight?.status === "blocked" ? listOption(guidance.preflight?.blockers) : []),
@@ -397,14 +399,14 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     return uniqueStrings(blockers);
   }
 
-  function guidanceWarnings(guidance: LooseObject): string[] {
+  function guidanceWarnings(guidance: CommandRecord): string[] {
     return uniqueStrings([
       ...listOption(guidance.gateQuality?.warnings),
       ...listOption(guidance.preflight?.warnings),
     ]);
   }
 
-  function doctorLoopContractAuthority(decisionEnvelope: LooseObject | null | undefined) {
+  function doctorLoopContractAuthority(decisionEnvelope: CommandRecord | null | undefined) {
     const envelope = decisionEnvelope || {};
     const loopContract = envelope.loopContract || null;
     const canonicalNextAction = envelope.canonicalNextAction || null;
@@ -432,7 +434,7 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
     if (text && !target.includes(text)) target.push(text);
   }
 
-  function hasSharperDoctorBlocker(state: LooseObject, blocker: unknown = ""): boolean {
+  function hasSharperDoctorBlocker(state: CommandRecord, blocker: unknown = ""): boolean {
     if (hasScaffoldBlocker(state.scaffoldHealth)) return true;
     if (
       blocker &&
@@ -456,8 +458,8 @@ export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
   }
 
   function hasScaffoldBlocker(scaffoldHealth: unknown): boolean {
-    const checks = Array.isArray((scaffoldHealth as LooseObject | null)?.checks)
-      ? (scaffoldHealth as LooseObject).checks
+    const checks = Array.isArray((scaffoldHealth as CommandRecord | null)?.checks)
+      ? (scaffoldHealth as CommandRecord).checks
       : [];
     return checks.some((check: any) => check?.severity === "blocker");
   }

--- a/plugins/codex-autoresearch/lib/commands/doctor.ts
+++ b/plugins/codex-autoresearch/lib/commands/doctor.ts
@@ -1,0 +1,466 @@
+type LooseObject = Record<string, any>;
+
+export type DoctorCommandServiceDeps = Record<string, any>;
+
+export function createDoctorCommandService(deps: DoctorCommandServiceDeps) {
+  const {
+    actionMessage,
+    benchmarkContractDiagnostics,
+    boolOption,
+    buildDecisionEnvelope,
+    buildDriftReport,
+    buildRunProgress,
+    continuationCommands,
+    currentState,
+    decisionGuidance,
+    errorMessage,
+    finiteMetric,
+    fixedControlBlockForCommand,
+    insideGitRepo,
+    inspectRuntimeDrift,
+    latestBenchmarkContractEntry,
+    listOption,
+    loopContinuation,
+    metricParseSource,
+    missingBenchmarkCommandMessage,
+    numberOption,
+    packetEnvModeFromArgs,
+    parseMetricLines,
+    publicState,
+    redactCommandDisplay,
+    redactEvidenceObject,
+    revalidateRecipeCatalogProvenance,
+    resolveBenchmarkCommandSource,
+    resolveWorkDir,
+    runShell,
+    runtimeProvenance,
+    shouldSuppressPreflightGateBlockerForCapsule,
+    uniqueStrings,
+    withCanonicalActionCommand,
+  } = deps;
+  const COMMAND_EXECUTION_BOUNDARY = deps.commandExecutionBoundary;
+  const PLUGIN_ROOT = deps.pluginRoot;
+  const PLUGIN_VERSION = deps.pluginVersion;
+
+  async function doctorSession(args: LooseObject): Promise<LooseObject> {
+    const { sessionCwd, workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
+    const state: LooseObject = await publicState({ ...args, compact: false });
+    const primaryMetricName =
+      args.metric_name ||
+      args.metricName ||
+      config.metricName ||
+      state.config.metricName ||
+      "metric";
+    const issues = [];
+    const warnings = [];
+    const warningDetails = [];
+    const inGit = await insideGitRepo(workDir);
+
+    if (!state.config.metricName) issues.push("No primary metric is configured.");
+    if (state.runs === 0)
+      warnings.push("No runs are logged yet. Run a baseline before experimenting.");
+    warnings.push(...(state.memory?.warnings || []));
+    if (!inGit)
+      warnings.push(
+        "Working directory is not a Git repository; keep commits and discard reverts are unavailable.",
+      );
+    const operatorDetails = Array.isArray(state.warningDetails) ? state.warningDetails : [];
+    for (const detail of operatorDetails) {
+      if (!detail?.message) continue;
+      warningDetails.push(detail);
+      if (
+        detail.code === "benchmark_contract_changed" ||
+        String(detail.code || "").startsWith("protected_benchmark_")
+      ) {
+        if (detail.severity === "error" || detail.code === "benchmark_contract_changed") {
+          issues.push(detail.message);
+        } else {
+          warnings.push(detail.message);
+        }
+      } else warnings.push(detail.message);
+    }
+    for (const check of state.scaffoldHealth?.checks || []) {
+      if (!check?.message) continue;
+      warningDetails.push(check);
+      warnings.push(check.message);
+      if (check.severity === "blocker") issues.push(check.message);
+    }
+    for (const warning of state.researchIntegrity?.warnings || []) {
+      warnings.push(warning);
+    }
+    for (const blocker of state.researchIntegrity?.blockers || []) {
+      issues.push(blocker);
+    }
+    const catalogTrust = await catalogTrustCheck(config, sessionCwd).catch((error: unknown) => ({
+      ok: false,
+      issues: [`Trusted recipe catalog could not be revalidated: ${errorMessage(error)}`],
+    }));
+    if (!catalogTrust.ok) issues.push(...catalogTrust.issues);
+    const drift = await buildDriftReport({
+      pluginRoot: PLUGIN_ROOT,
+      includeInstalled: boolOption(args.check_installed ?? args.checkInstalled, false),
+    });
+    const checkInstalledRuntime = boolOption(args.check_installed ?? args.checkInstalled, false);
+    const runtimeDriftSummary = await inspectRuntimeDrift({
+      packageRoot: PLUGIN_ROOT,
+      sourceVersion: PLUGIN_VERSION,
+    });
+    let benchmarkCommandHint = "";
+    let benchmarkCommandSource: Awaited<ReturnType<typeof resolveBenchmarkCommandSource>> | null =
+      null;
+    try {
+      benchmarkCommandSource = await resolveBenchmarkCommandSource(args, workDir, {
+        fallbackToDefault: true,
+        config,
+      });
+      benchmarkCommandHint = benchmarkCommandSource.command;
+    } catch (error: unknown) {
+      pushUniqueMessage(issues, errorMessage(error));
+    }
+    warnings.push(...drift.warnings);
+    const guidance = await decisionGuidance({
+      workDir,
+      config,
+      state,
+      scaffoldHealth: state.scaffoldHealth,
+      warningDetails,
+      runtimeDriftSummary,
+      runtimeTrustScope: checkInstalledRuntime ? "installed-plugin" : "source-checkout",
+      benchmarkCommand: benchmarkCommandHint,
+    });
+    const publicCommandAuthority = publicCommandPayload(guidance.commandAuthority);
+    const publicPreflight = publicCommandPayload(guidance.preflight);
+    const runtimeAuthority = (guidance.runtimeAuthority || null) as LooseObject | null;
+    if (runtimeAuthority?.blocking === true) {
+      pushUniqueMessage(issues, runtimeAuthority.blocker);
+    }
+    for (const blocker of guidanceBlockers(guidance)) {
+      if (!hasSharperDoctorBlocker(state, blocker)) {
+        pushUniqueMessage(issues, blocker);
+      }
+    }
+    for (const warning of guidanceWarnings(guidance)) pushUniqueMessage(warnings, warning);
+    const loopAuthority = doctorLoopContractAuthority(
+      withCanonicalActionCommand(
+        buildDecisionEnvelope({
+          state: {
+            ...state,
+            gateQuality: guidance.gateQuality,
+            preflight: publicPreflight,
+            portfolioRecommendation: null,
+            runtimeDriftSummary,
+            runtimeAuthority: guidance.runtimeAuthority,
+            scaffoldHealth: state.scaffoldHealth,
+          },
+          nextAction: "Run the next experiment, then log keep or discard with ASI.",
+          finalization: state.decisionEnvelope?.finalizationReadiness || null,
+        }),
+        continuationCommands(workDir),
+      ),
+    );
+    for (const blocker of loopAuthority.blockers) pushUniqueMessage(issues, blocker);
+
+    const benchmark: LooseObject = {
+      checked: false,
+      command: args.command || "",
+      packetEnvMode: null,
+      emitsPrimary: null,
+      parsedMetrics: {},
+      exitCode: null,
+      timedOut: false,
+      metricError: null,
+      progress: null,
+    };
+
+    if (boolOption(args.check_benchmark ?? args.checkBenchmark, false)) {
+      benchmark.checked = true;
+      benchmarkCommandSource =
+        benchmarkCommandSource ||
+        (await resolveBenchmarkCommandSource(args, workDir, {
+          fallbackToDefault: true,
+          requireCommand: false,
+          config,
+        }));
+      benchmark.command = benchmarkCommandSource.command;
+      if (!benchmark.command) {
+        benchmark.metricError =
+          benchmarkCommandSource.missingReason || missingBenchmarkCommandMessage();
+        issues.push(benchmark.metricError);
+      } else {
+        const fixedControlBlock = fixedControlBlockForCommand(benchmark.command, config, args);
+        if (fixedControlBlock) {
+          benchmark.fixedControlViolation = fixedControlBlock.fixedControlViolation;
+          benchmark.metricError = fixedControlBlock.issue;
+          issues.push(fixedControlBlock.issue);
+        } else {
+          const latestContract = latestBenchmarkContractEntry(workDir, state)?.benchmarkContract;
+          const doctorPacketEnvMode =
+            latestContract && Object.hasOwn(latestContract, "packetEnvMode")
+              ? packetEnvModeFromArgs({ packetEnvMode: latestContract.packetEnvMode })
+              : "inherit";
+          benchmark.packetEnvMode = doctorPacketEnvMode;
+          const run = await runShell(
+            benchmark.command,
+            workDir,
+            numberOption(args.timeout_seconds ?? args.timeoutSeconds, 60),
+            {
+              envMode: doctorPacketEnvMode,
+              retainMetricNames: [primaryMetricName],
+            },
+          );
+          benchmark.exitCode = run.exitCode;
+          benchmark.timedOut = run.timedOut;
+          benchmark.parsedMetrics = parseMetricLines(metricParseSource(run));
+          benchmark.emitsPrimary = finiteMetric(benchmark.parsedMetrics[primaryMetricName]) != null;
+          benchmark.progress = buildRunProgress({
+            benchmark: run,
+            checks: null,
+            checksCommand: null,
+            passed: run.exitCode === 0 && !run.timedOut && benchmark.emitsPrimary,
+          });
+          if (run.exitCode !== 0 || run.timedOut) {
+            issues.push(
+              `Benchmark command failed during doctor check: exit ${run.exitCode ?? "none"}${run.timedOut ? " (timed out)" : ""}.`,
+            );
+          } else if (!benchmark.emitsPrimary) {
+            benchmark.metricError = `Benchmark did not emit primary metric METRIC ${primaryMetricName}=<number>.`;
+            issues.push(benchmark.metricError);
+          }
+          const driftWarning = benchmarkDriftWarning({
+            currentMetric: benchmark.parsedMetrics[primaryMetricName],
+            bestMetric: state.best,
+            direction: state.config.bestDirection,
+            metricName: primaryMetricName,
+          });
+          if (driftWarning) warnings.push(driftWarning);
+        }
+      }
+    }
+
+    let nextAction = "Run the next experiment, then log keep or discard with ASI.";
+    if (runtimeAuthority?.blocking === true) {
+      nextAction =
+        String(runtimeAuthority.blocker || "").trim() ||
+        "Inspect or refresh the installed plugin runtime before claiming installed behavior.";
+    } else if (loopAuthority.canonicalNextAction?.safeAction === "ledger-doctor") {
+      nextAction = "Run ledger-doctor before another packet.";
+    } else if (loopAuthority.nextAction) {
+      nextAction = loopAuthority.nextAction;
+    } else if (issues.some((issue: any) => /contract changed/i.test(issue))) {
+      nextAction =
+        "Start a new segment or explicitly invalidate the old evidence before running another packet.";
+    } else if (issues.some((issue: any) => /primary metric|benchmark/i.test(issue))) {
+      nextAction =
+        "Fix the benchmark command so it emits the configured primary metric before continuing.";
+    } else if (issues.some((issue: any) => /fixed_control_rerun_blocked/i.test(String(issue)))) {
+      nextAction = "Reuse the fixed control artifact instead of running the benchmark check.";
+    } else if (state.runs === 0) {
+      nextAction = "Run and log a baseline before trying optimizations.";
+    } else if (state.limit.limitReached) {
+      nextAction = "Iteration limit reached; export the dashboard or start a new segment.";
+    } else if (warnings.some((warning: any) => /dirty/.test(String(warning)))) {
+      nextAction = "Review the dirty Git state before logging a kept result.";
+    }
+
+    const commandExecutionBoundary = benchmarkCommandHint
+      ? {
+          mode: COMMAND_EXECUTION_BOUNDARY.mode,
+          note: COMMAND_EXECUTION_BOUNDARY.note,
+          recommendation: COMMAND_EXECUTION_BOUNDARY.recommendation,
+        }
+      : null;
+    const activeBenchmarkContractEntry =
+      state.code === "ledger_jsonl_invalid" ? null : latestBenchmarkContractEntry(workDir, state);
+    const contractDiagnostics = benchmarkContractDiagnostics({
+      state,
+    });
+    const continuationState =
+      state.code === "ledger_jsonl_invalid"
+        ? { current: [], allRecords: [], ...state }
+        : currentState(workDir);
+    const benchmarkContractChanged = warningDetails.some(
+      (detail: any) => detail?.code === "benchmark_contract_changed",
+    );
+    const publicBenchmark = {
+      ...benchmark,
+      command: redactCommandDisplay(benchmark.command),
+    };
+
+    const result: LooseObject = {
+      ok: issues.length === 0,
+      workDir,
+      config: state.config,
+      state,
+      git: {
+        inside: inGit,
+        clean: state.decisionEnvelope?.dirtySourceDrift?.dirty === true ? false : true,
+      },
+      benchmarkContract: {
+        ok: benchmarkContractChanged === false,
+        activeSource: contractDiagnostics.activeSource,
+        activeContract: contractDiagnostics.activeContract,
+        historicalContracts: contractDiagnostics.historicalContracts,
+        historical: contractDiagnostics.historicalContracts.length > 0,
+        segmentEntry: activeBenchmarkContractEntry?.benchmarkContractScope === "segment",
+      },
+      benchmark: publicBenchmark,
+      drift,
+      runtimeDriftSummary,
+      runtimeAuthority: guidance.runtimeAuthority,
+      gateQuality: guidance.gateQuality,
+      commandAuthority: publicCommandAuthority,
+      preflight: publicPreflight,
+      decisionEnvelope: loopAuthority.decisionEnvelope,
+      loopContract: loopAuthority.loopContract,
+      canonicalNextAction: loopAuthority.canonicalNextAction,
+      commandExecutionBoundary,
+      runtimeProvenance: runtimeProvenance(drift),
+      scaffoldHealth: state.scaffoldHealth,
+      researchIntegrity: state.researchIntegrity,
+      issues,
+      warnings,
+      warningDetails,
+      nextAction,
+      continuation: loopContinuation(workDir, continuationState, config, "doctor"),
+    };
+    if (boolOption(args.explain, false)) result.explanation = doctorExplanation(result);
+    return result;
+  }
+
+  async function catalogTrustCheck(config: LooseObject, sessionCwd: string) {
+    const provenance = config.recipeCatalogProvenance || config.recipe_catalog_provenance || null;
+    if (!provenance) return { ok: true, issues: [] as string[] };
+    return await revalidateRecipeCatalogProvenance(provenance, { catalogBaseDir: sessionCwd });
+  }
+
+  function publicCommandPayload<T>(value: T): T {
+    return redactEvidenceObject(value) as T;
+  }
+
+  function benchmarkDriftWarning({
+    currentMetric,
+    bestMetric,
+    direction,
+    metricName,
+  }: LooseObject) {
+    const current = finiteMetric(currentMetric);
+    const best = finiteMetric(bestMetric);
+    if (current == null || best == null || best === 0) return "";
+    const worse =
+      direction === "higher"
+        ? current < best && Math.abs((best - current) / best) >= 0.25
+        : current > best && Math.abs((current - best) / best) >= 0.25;
+    if (!worse) return "";
+    return `Benchmark drift: current ${metricName}=${current} is far worse than historical best ${best}. Treat the old best as historical evidence, not current runtime proof.`;
+  }
+
+  function doctorExplanation(result: LooseObject): LooseObject {
+    const runtimeSummary = result.runtimeDriftSummary || null;
+    return {
+      verdict: result.ok
+        ? "Doctor found no blocking issues."
+        : "Doctor found issues that must be fixed before trusting the loop.",
+      priorityFixes: [
+        ...(result.issues || []),
+        ...(result.warnings || []).filter((warning: any) =>
+          /dirty|drift|benchmark|missing|stale|commitPaths/i.test(String(warning)),
+        ),
+      ].slice(0, 5),
+      runtimeDriftSummary: runtimeSummary
+        ? {
+            installedRuntime: runtimeSummary.installedRuntime,
+            builtRuntime: runtimeSummary.builtRuntime,
+            smokeCheck: runtimeSummary.smokeCheck,
+            nextActionHint: runtimeSummary.nextActionHint,
+          }
+        : null,
+      runtimeAuthority: result.runtimeAuthority || null,
+      gateQuality: result.gateQuality || null,
+      preflight: result.preflight || null,
+      nextSafeAction: result.nextAction,
+      commandExecutionBoundary: result.commandExecutionBoundary || null,
+      readAs:
+        "Issues block the loop. Warnings reduce trust and should be resolved before keeping results when they affect evidence, Git, or runtime drift.",
+    };
+  }
+
+  function guidanceBlockers(guidance: LooseObject): string[] {
+    const blockers = [
+      ...listOption(guidance.gateQuality?.blockers),
+      ...(guidance.preflight?.status === "blocked" ? listOption(guidance.preflight?.blockers) : []),
+    ]
+      .map((blocker: any) => String(blocker || "").trim())
+      .filter(Boolean);
+    if (guidance.preflight?.status === "blocked" && blockers.length === 0) {
+      blockers.push("Preflight readiness is blocked.");
+    }
+    return uniqueStrings(blockers);
+  }
+
+  function guidanceWarnings(guidance: LooseObject): string[] {
+    return uniqueStrings([
+      ...listOption(guidance.gateQuality?.warnings),
+      ...listOption(guidance.preflight?.warnings),
+    ]);
+  }
+
+  function doctorLoopContractAuthority(decisionEnvelope: LooseObject | null | undefined) {
+    const envelope = decisionEnvelope || {};
+    const loopContract = envelope.loopContract || null;
+    const canonicalNextAction = envelope.canonicalNextAction || null;
+    const blockers = Array.isArray(loopContract?.blockers)
+      ? loopContract.blockers.map(actionMessage).filter(Boolean)
+      : [];
+    const strongestActionMessage = actionMessage(loopContract?.strongestAction);
+    if (blockers.length === 0 && strongestActionMessage && loopContract?.ok === false) {
+      blockers.push(strongestActionMessage);
+    }
+    return {
+      decisionEnvelope: envelope,
+      loopContract,
+      canonicalNextAction,
+      blockers: uniqueStrings(blockers),
+      nextAction:
+        blockers.length > 0
+          ? actionMessage(canonicalNextAction) || strongestActionMessage || blockers[0]
+          : "",
+    };
+  }
+
+  function pushUniqueMessage(target: any[], message: unknown) {
+    const text = String(message || "").trim();
+    if (text && !target.includes(text)) target.push(text);
+  }
+
+  function hasSharperDoctorBlocker(state: LooseObject, blocker: unknown = ""): boolean {
+    if (hasScaffoldBlocker(state.scaffoldHealth)) return true;
+    if (
+      blocker &&
+      shouldSuppressPreflightGateBlockerForCapsule(
+        { sessionDecisionCapsule: state.sessionDecisionCapsule },
+        blocker,
+      )
+    ) {
+      return true;
+    }
+    if (
+      blocker &&
+      shouldSuppressPreflightGateBlockerForCapsule(
+        { sessionDecisionCapsule: state.decisionEnvelope?.sessionDecisionCapsule },
+        blocker,
+      )
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  function hasScaffoldBlocker(scaffoldHealth: unknown): boolean {
+    const checks = Array.isArray((scaffoldHealth as LooseObject | null)?.checks)
+      ? (scaffoldHealth as LooseObject).checks
+      : [];
+    return checks.some((check: any) => check?.severity === "blocker");
+  }
+
+  return { doctorSession };
+}

--- a/plugins/codex-autoresearch/lib/commands/state.ts
+++ b/plugins/codex-autoresearch/lib/commands/state.ts
@@ -233,3 +233,1108 @@ export function buildCompactStateResponse(input: CompactStateBuilderInput): Comp
 function copyIfProvided<T extends object>(target: T, key: string, value: unknown) {
   if (value !== undefined) (target as JsonObject)[key] = value;
 }
+
+type LooseObject = Record<string, any>;
+
+export type StateCommandServiceDeps = Record<string, any>;
+
+export function createStateCommandService(deps: StateCommandServiceDeps) {
+  const {
+    actionMessage,
+    analyzeExperimentEconomics,
+    analyzeLedgerHealth,
+    analyzeWorkflowFriction,
+    boolOption,
+    buildCheapFinalizationPressure,
+    buildDecisionEnvelope,
+    buildFinalizePreview,
+    buildGoalContract,
+    buildGoalFrame,
+    buildLaneLifecycle,
+    buildParallelOrchestrationContext,
+    buildScaffoldHealth,
+    buildServeRegistryHealthInput,
+    buildSessionReadModel,
+    buildSessionReadModelState,
+    buildSourceCleanliness,
+    buildResearchIntegrity,
+    buildTerminalReport,
+    classifyPacketDiagnostics,
+    continuationCommands,
+    createSessionReadCache,
+    currentQualityGapSummary,
+    dashboardCommands,
+    dashboardSettings,
+    decisionGuidance,
+    discoverLastRunPartialResults,
+    errorMessage,
+    fixedControlStateSummary,
+    isAcceptedCurrentRun,
+    isPacketBrakeKind,
+    iterationLimitInfo,
+    lastRunPacketFreshness,
+    listBuiltInRecipes,
+    loadSessionRecords,
+    loadSessionState,
+    loopContinuation,
+    operatorWarningsForWorkDir,
+    readActiveProgressSnapshot,
+    readLastRunPacket,
+    readLedgerRecordsTolerant,
+    readServeRegistry,
+    recommendPortfolioDirection,
+    redactCommandDisplay,
+    redactEvidenceObject,
+    replacementNextCommandForLastRun,
+    resolveWorkDir,
+    runtimeProvenance,
+    statusCountsFromState,
+    uniqueStrings,
+    verifyDashboardHealthSummary,
+    withCanonicalActionCommand,
+  } = deps;
+  const COMMAND_EXECUTION_BOUNDARY = deps.commandExecutionBoundary;
+  const PENDING_LOG_TRANSACTION_CODE = deps.pendingLogTransactionCode;
+  const PLUGIN_ROOT = deps.pluginRoot;
+  const PLUGIN_VERSION = deps.pluginVersion;
+
+  async function publicState(args: LooseObject): Promise<LooseObject> {
+    const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
+    const compact = boolOption(args.compact, false);
+    const report = boolOption(args.report, false);
+    const codexGoalObjective = args.codexGoalObjective || args.codex_goal_objective;
+    const readCache = args.readCache || createSessionReadCache();
+    if (compact || report) {
+      let compactState: LooseObject;
+      try {
+        compactState = await publicCompactState({
+          workDir,
+          config,
+          codexGoalObjective,
+          readCache,
+        });
+      } catch (error) {
+        if (!isStrictLedgerParseError(error)) throw error;
+        compactState = repairFirstStateForInvalidLedger({
+          workDir,
+          config,
+          codexGoalObjective,
+          error,
+          compact: true,
+        });
+      }
+      if (!report) return compactState;
+      const response: LooseObject = {
+        ok: compactState.ok !== false,
+        workDir,
+        report: buildTerminalReport(compactState),
+      };
+      if (compact) response.compactState = compactState;
+      return response;
+    }
+
+    let state: ReturnType<typeof loadSessionState>;
+    let records: ReturnType<typeof loadSessionRecords>;
+    try {
+      state = loadSessionState(workDir, readCache);
+      records = loadSessionRecords(workDir, readCache);
+    } catch (error) {
+      if (!isStrictLedgerParseError(error)) throw error;
+      return repairFirstStateForInvalidLedger({
+        workDir,
+        config,
+        codexGoalObjective,
+        error,
+        compact: false,
+      });
+    }
+    const ledgerHealth = analyzeLedgerHealth(records);
+    const scaffoldHealth = await buildScaffoldHealth({ workDir, config });
+    const researchIntegrity = buildResearchIntegrity({ state, config });
+    const warningDetails = await operatorWarningsForWorkDir(workDir, state);
+    const lastRun = await readLastRunPacket(workDir).catch((): null => null);
+    const activeProgress = await readActiveProgressSnapshot(workDir, config);
+    const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
+    const replaceLastRunCommand = await replacementNextCommandForLastRun(workDir, lastRun);
+    const qualityGap = await currentQualityGapSummary(workDir);
+    const finalization = await finalizationPressureForWorkDir({
+      workDir,
+      state,
+      qualityGap,
+      warningDetails,
+    });
+    const settings = dashboardSettings(config);
+    const orchestration = buildParallelOrchestrationContext({
+      workDir,
+      state,
+      config,
+      settings,
+      records,
+    });
+    const { memory, fanoutPlan, fanoutProvenance, parallelLanes, watchdogSummary } = orchestration;
+    const laneLifecycle = buildLaneLifecycle({
+      state,
+      records,
+      fanoutPlan,
+      parallelLanes,
+      laneResults: orchestration.laneResults,
+      workDir,
+      pluginRoot: PLUGIN_ROOT,
+    });
+    const packetDiagnostics = lastRun
+      ? classifyPacketDiagnostics({
+          packetEvidence: lastRun.packetEvidence || {},
+          run: lastRun.run || {},
+          decision: lastRun.decision || {},
+          metrics: lastRun.decision?.metrics || lastRun.run?.parsedMetrics || {},
+          metricName: state.config.metricName,
+          command: continuationCommands(workDir).partialResults,
+        })
+      : classifyPacketDiagnostics();
+    const currentRuntimeProvenance = runtimeProvenance();
+    const dashboardHealth = await dashboardHealthForWorkDir(workDir);
+    const sourceCleanliness = buildSourceCleanliness({ warningDetails });
+    const guidance = await decisionGuidance({
+      workDir,
+      config,
+      state,
+      scaffoldHealth,
+      warningDetails,
+    });
+    const publicCommandAuthority = publicCommandPayload(guidance.commandAuthority);
+    const publicPreflight = publicCommandPayload(guidance.preflight);
+    const stateWithQualityGap = {
+      ...buildSessionReadModelState({
+        state,
+        qualityGap,
+        laneLifecycle,
+        packetDiagnostics,
+        runtimeProvenance: currentRuntimeProvenance,
+        runtimeDriftSummary: guidance.runtimeDriftSummary,
+        dashboardHealth,
+        sourceCleanliness,
+        gateQuality: guidance.gateQuality,
+        preflight: publicPreflight,
+      }),
+      runtimeAuthority: guidance.runtimeAuthority,
+      ledgerHealth,
+    };
+    const recipeSummaries = listBuiltInRecipes().map((recipe: any) => ({
+      id: recipe.id,
+      title: recipe.title,
+      tags: recipe.tags || [],
+    }));
+    const partialResults = await discoverLastRunPartialResults(workDir, state, lastRun);
+    const workflowFriction = analyzeWorkflowFriction({
+      state: stateWithQualityGap,
+      lastRun,
+      warningDetails,
+      recipes: recipeSummaries,
+    });
+    const experimentEconomics = analyzeExperimentEconomics({
+      state: stateWithQualityGap,
+      lastRun,
+      progress:
+        activeProgress ||
+        (await readActiveProgressSnapshot(workDir, config)) ||
+        lastRun?.packetEvidence?.progressSnapshot ||
+        null,
+    });
+    const portfolioRecommendation = recommendPortfolioDirection({
+      runtimeDrift: guidance.runtimeDriftSummary,
+      gateQuality: guidance.gateQuality,
+      preflight: publicPreflight,
+      laneLifecycle,
+      laneResults: laneLifecycle.latestResults,
+      packetDiagnostics,
+      experimentMemory: memory,
+      best: state.best,
+      current: state.current,
+    });
+    const readModel = buildSessionReadModel({
+      workDir,
+      config,
+      state,
+      records,
+      codexGoalObjective,
+      parallelLanes,
+      workflowFriction,
+      finalization,
+      commands: continuationCommands(workDir),
+      qualityGap,
+      laneLifecycle,
+      packetDiagnostics,
+      runtimeProvenance: currentRuntimeProvenance,
+      runtimeDriftSummary: guidance.runtimeDriftSummary,
+      dashboardHealth,
+      sourceCleanliness,
+      gateQuality: guidance.gateQuality,
+      preflight: publicPreflight,
+    });
+    const controlPlane = readModel.controlPlane;
+    const statusCounts = readModel.statusCounts;
+    const continuation = loopContinuation(workDir, state, config, "state");
+    const stateCommands = {
+      ...continuation.commands,
+      ...(replaceLastRunCommand ? { replaceLast: replaceLastRunCommand } : {}),
+    };
+    const decisionEnvelope = withCanonicalActionCommand(
+      buildDecisionEnvelope({
+        state: {
+          ...stateWithQualityGap,
+          portfolioRecommendation,
+          ...controlPlane,
+          limit: iterationLimitInfo(state, config),
+        },
+        nextAction: continuation.nextAction,
+        lastRunFreshness,
+        warningDetails,
+        scaffoldHealth,
+        researchIntegrity,
+        qualityGap,
+        finalization,
+        experimentEconomics,
+        salvageCandidates: partialResults.candidates,
+        workflowFriction,
+        experimentMemory: memory,
+        watchdog: watchdogSummary,
+      }),
+      stateCommands,
+    );
+    const fullState = {
+      ok: true,
+      workDir,
+      config: publicSessionConfig(state.config),
+      segment: state.segment,
+      runs: state.current.length,
+      totalRuns: state.results.length,
+      kept: statusCounts.keep,
+      discarded: statusCounts.discard,
+      measured: statusCounts.measure,
+      crashed: statusCounts.crash,
+      checksFailed: statusCounts.checks_failed,
+      baseline: state.baseline,
+      best: state.best,
+      historicalBest: state.historicalBest,
+      development: state.development,
+      promotion: state.promotion,
+      evidenceRegistry: state.evidenceRegistry,
+      productClaimCoverage: state.productClaimCoverage,
+      sessionDecisionCapsule: state.sessionDecisionCapsule || null,
+      confidence: state.confidence,
+      scaffoldHealth,
+      researchIntegrity,
+      runtimeProvenance: currentRuntimeProvenance,
+      runtimeDriftSummary: guidance.runtimeDriftSummary,
+      runtimeAuthority: guidance.runtimeAuthority,
+      dashboardHealth,
+      sourceCleanliness,
+      ledgerHealth,
+      gateQuality: guidance.gateQuality,
+      fixedControl: fixedControlStateSummary(config.fixedControl),
+      commandAuthority: publicCommandAuthority,
+      preflight: publicPreflight,
+      limit: iterationLimitInfo(state, config),
+      settings: {
+        autonomyMode: config.autonomyMode || "guarded",
+        checksPolicy: config.checksPolicy || "always",
+        keepPolicy: config.keepPolicy || "primary-only",
+        dashboardRefreshSeconds: config.dashboardRefreshSeconds || 5,
+        commitPaths: config.commitPaths || [],
+      },
+      commands: dashboardCommands(workDir),
+      warnings: warningDetails.map((warning: any) => warning.message),
+      warningDetails,
+      fanoutPlan,
+      fanoutProvenance,
+      parallelLanes,
+      laneLifecycle,
+      packetDiagnostics,
+      metricSemanticsWarning: state.metricSemanticsWarning || null,
+      commandExecutionBoundary: commandExecutionBoundaryForState({ state, lastRun }),
+      portfolioRecommendation,
+      ...controlPlane,
+      watchdogSummary,
+      memory,
+      experimentEconomics,
+      partialResults,
+      workflowFriction,
+      continuation,
+      resumeAudit: decisionEnvelope,
+      decisionEnvelope,
+    };
+    return compact ? compactPublicState(fullState) : fullState;
+  }
+
+  function isStrictLedgerParseError(error: unknown): boolean {
+    return /Invalid JSONL in .*[\\/]?autoresearch\.jsonl at line \d+:/i.test(errorMessage(error));
+  }
+
+  function repairFirstStateForInvalidLedger({
+    workDir,
+    config,
+    codexGoalObjective,
+    error,
+    compact,
+  }: {
+    workDir: string;
+    config: LooseObject;
+    codexGoalObjective?: unknown;
+    error: unknown;
+    compact: boolean;
+  }): LooseObject {
+    const ledger = readLedgerRecordsTolerant(workDir);
+    const rawLedgerHealth = analyzeLedgerHealth(ledger.records, {
+      parseErrors: ledger.parseErrors,
+    });
+    const commands = continuationCommands(workDir);
+    const ledgerHealth = {
+      ...rawLedgerHealth,
+      command: commands.ledgerDoctor,
+    };
+    const runtime = runtimeProvenance();
+    const decisionEnvelope = withCanonicalActionCommand(
+      buildDecisionEnvelope({
+        state: {
+          config,
+          current: [],
+          results: [],
+          ledgerHealth,
+          runtimeProvenance: runtime,
+        },
+        nextAction: "Run ledger-doctor before another Autoresearch packet.",
+      }),
+      commands,
+    );
+    const response = {
+      ok: false,
+      code: "ledger_jsonl_invalid",
+      workDir,
+      config: publicSessionConfig(config),
+      segment: 0,
+      runs: ledger.records.length,
+      totalRuns: ledger.records.length,
+      kept: 0,
+      discarded: 0,
+      measured: 0,
+      crashed: 0,
+      checksFailed: 0,
+      baseline: null,
+      best: null,
+      historicalBest: null,
+      development: null,
+      promotion: null,
+      confidence: null,
+      ledgerPath: ledger.ledgerPath,
+      ledgerHealth,
+      parseErrors: ledgerHealth.parseErrors,
+      warnings: ledgerHealth.warnings,
+      error: errorMessage(error),
+      commands,
+      continuation: {
+        shouldContinue: false,
+        nextAction: "Run ledger-doctor before another packet.",
+        commands,
+      },
+      nextAction: "Run ledger-doctor before another packet.",
+      blockers: ledgerHealth.warnings,
+      runtimeProvenance: runtime,
+      codexGoalObjective,
+      resumeAudit: decisionEnvelope,
+      decisionEnvelope,
+      canonicalNextAction: decisionEnvelope.canonicalNextAction,
+      loopContract: decisionEnvelope.loopContract,
+    };
+    return compact ? compactPublicState(response) : response;
+  }
+
+  async function publicCompactState({
+    workDir,
+    config,
+    codexGoalObjective,
+    readCache,
+  }: {
+    workDir: string;
+    config: LooseObject;
+    codexGoalObjective?: unknown;
+    readCache?: unknown;
+  }): Promise<LooseObject> {
+    const effectiveReadCache = (readCache || createSessionReadCache()) as any;
+    const state = loadSessionState(workDir, effectiveReadCache);
+    const records = loadSessionRecords(workDir, effectiveReadCache);
+    const ledgerHealth = analyzeLedgerHealth(records);
+    const lastRun = await readLastRunPacket(workDir).catch((): null => null);
+    const activeProgress = await readActiveProgressSnapshot(workDir, config);
+    const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
+    const replaceLastRunCommand = await replacementNextCommandForLastRun(workDir, lastRun);
+    const qualityGap = await currentQualityGapSummary(workDir);
+    const scaffoldHealth = await buildScaffoldHealth({ workDir, config });
+    const researchIntegrity = buildResearchIntegrity({ state, config });
+    const warningDetails = await operatorWarningsForWorkDir(workDir, state);
+    const settings = dashboardSettings(config);
+    const orchestration = buildParallelOrchestrationContext({
+      workDir,
+      state,
+      config,
+      settings,
+      records,
+    });
+    const { memory, fanoutPlan, fanoutProvenance, parallelLanes, watchdogSummary } = orchestration;
+    const laneLifecycle = buildLaneLifecycle({
+      state,
+      records,
+      fanoutPlan,
+      parallelLanes,
+      laneResults: orchestration.laneResults,
+      workDir,
+      pluginRoot: PLUGIN_ROOT,
+    });
+    const packetDiagnostics = lastRun
+      ? classifyPacketDiagnostics({
+          packetEvidence: lastRun.packetEvidence || {},
+          run: lastRun.run || {},
+          decision: lastRun.decision || {},
+          metrics: lastRun.decision?.metrics || lastRun.run?.parsedMetrics || {},
+          metricName: state.config.metricName,
+          command: continuationCommands(workDir).partialResults,
+        })
+      : classifyPacketDiagnostics();
+    const currentRuntimeProvenance = runtimeProvenance();
+    const dashboardHealth = await dashboardHealthForWorkDir(workDir);
+    const sourceCleanliness = buildSourceCleanliness({ warningDetails });
+    const guidance = await decisionGuidance({
+      workDir,
+      config,
+      state,
+      scaffoldHealth,
+      warningDetails,
+    });
+    const publicPreflight = publicCommandPayload(guidance.preflight);
+    const stateWithQualityGap = {
+      ...buildSessionReadModelState({
+        state,
+        qualityGap,
+        laneLifecycle,
+        packetDiagnostics,
+        runtimeProvenance: currentRuntimeProvenance,
+        runtimeDriftSummary: guidance.runtimeDriftSummary,
+        dashboardHealth,
+        sourceCleanliness,
+        gateQuality: guidance.gateQuality,
+        preflight: publicPreflight,
+      }),
+      runtimeAuthority: guidance.runtimeAuthority,
+      ledgerHealth,
+    };
+    const partialResults = await discoverLastRunPartialResults(workDir, state, lastRun);
+    const recipeSummaries = listBuiltInRecipes().map((recipe: any) => ({
+      id: recipe.id,
+      title: recipe.title,
+      tags: recipe.tags || [],
+    }));
+    const workflowFriction = analyzeWorkflowFriction({
+      state: stateWithQualityGap,
+      lastRun,
+      warningDetails,
+      recipes: recipeSummaries,
+    });
+    const experimentEconomics = analyzeExperimentEconomics({
+      state: stateWithQualityGap,
+      lastRun,
+      progress: activeProgress || lastRun?.packetEvidence?.progressSnapshot || null,
+    });
+    const portfolioRecommendation = recommendPortfolioDirection({
+      runtimeDrift: guidance.runtimeDriftSummary,
+      gateQuality: guidance.gateQuality,
+      preflight: publicPreflight,
+      laneLifecycle,
+      laneResults: laneLifecycle.latestResults,
+      packetDiagnostics,
+      experimentMemory: memory,
+      best: state.best,
+      current: state.current,
+    });
+    const statusCounts = statusCountsFromState(state);
+    const continuation = loopContinuation(workDir, state, config, "state");
+    const compactCommands = {
+      ...continuation.commands,
+      ...(replaceLastRunCommand ? { replaceLast: replaceLastRunCommand } : {}),
+    };
+    const finalization = await finalizationPressureForWorkDir({
+      workDir,
+      state,
+      qualityGap,
+      warningDetails,
+    });
+    const readModel = buildSessionReadModel({
+      workDir,
+      config,
+      state,
+      records,
+      codexGoalObjective,
+      parallelLanes,
+      workflowFriction,
+      finalization,
+      commands: continuationCommands(workDir),
+      qualityGap,
+      laneLifecycle,
+      packetDiagnostics,
+      runtimeProvenance: currentRuntimeProvenance,
+      runtimeDriftSummary: guidance.runtimeDriftSummary,
+      dashboardHealth,
+      sourceCleanliness,
+      gateQuality: guidance.gateQuality,
+      preflight: publicPreflight,
+    });
+    const controlPlane = readModel.controlPlane;
+    const decisionEnvelope = withCanonicalActionCommand(
+      buildDecisionEnvelope({
+        state: {
+          ...stateWithQualityGap,
+          portfolioRecommendation,
+          ...controlPlane,
+          limit: iterationLimitInfo(state, config),
+        },
+        nextAction: continuation.nextAction,
+        lastRunFreshness,
+        warningDetails,
+        scaffoldHealth,
+        researchIntegrity,
+        qualityGap,
+        finalization,
+        experimentEconomics,
+        salvageCandidates: partialResults.candidates,
+        workflowFriction,
+        experimentMemory: memory,
+        watchdog: watchdogSummary,
+      }),
+      compactCommands,
+    );
+    return compactPublicState({
+      ok: true,
+      workDir,
+      config: publicSessionConfig(state.config),
+      segment: state.segment,
+      runs: state.current.length,
+      totalRuns: state.results.length,
+      kept: statusCounts.keep,
+      discarded: statusCounts.discard,
+      measured: statusCounts.measure,
+      crashed: statusCounts.crash,
+      checksFailed: statusCounts.checks_failed,
+      baseline: state.baseline,
+      best: state.best,
+      historicalBest: state.historicalBest,
+      development: state.development,
+      promotion: state.promotion,
+      evidenceRegistry: state.evidenceRegistry,
+      productClaimCoverage: state.productClaimCoverage,
+      sessionDecisionCapsule: state.sessionDecisionCapsule || null,
+      confidence: state.confidence,
+      scaffoldHealth,
+      researchIntegrity,
+      runtimeProvenance: currentRuntimeProvenance,
+      runtimeDriftSummary: guidance.runtimeDriftSummary,
+      runtimeAuthority: guidance.runtimeAuthority,
+      dashboardHealth,
+      sourceCleanliness,
+      ledgerHealth,
+      gateQuality: guidance.gateQuality,
+      fixedControl: fixedControlStateSummary(config.fixedControl),
+      preflight: publicPreflight,
+      limit: iterationLimitInfo(state, config),
+      settings: {
+        autonomyMode: config.autonomyMode || "guarded",
+        checksPolicy: config.checksPolicy || "always",
+        keepPolicy: config.keepPolicy || "primary-only",
+        dashboardRefreshSeconds: config.dashboardRefreshSeconds || 5,
+        commitPaths: config.commitPaths || [],
+      },
+      commands: compactCommands,
+      warnings: warningDetails.map((warning: any) => warning.message),
+      warningDetails,
+      qualityGap,
+      memory,
+      fanoutPlan,
+      fanoutProvenance,
+      parallelLanes,
+      watchdogSummary,
+      laneLifecycle,
+      packetDiagnostics,
+      metricSemanticsWarning: state.metricSemanticsWarning || null,
+      commandExecutionBoundary: commandExecutionBoundaryForState({ state, lastRun }),
+      portfolioRecommendation,
+      experimentEconomics,
+      partialResults,
+      workflowFriction,
+      ...controlPlane,
+      codexGoalObjective,
+      resumeAudit: decisionEnvelope,
+      decisionEnvelope,
+      continuation,
+    });
+  }
+
+  async function finalizationPressureForWorkDir({
+    workDir,
+    state,
+    qualityGap,
+    warningDetails,
+  }: {
+    workDir: string;
+    state: LooseObject;
+    qualityGap: LooseObject | null;
+    warningDetails: LooseObject[];
+  }): Promise<LooseObject> {
+    const cheap = buildCheapFinalizationPressure({ state, qualityGap, warningDetails });
+    if (!hasFinalizationEvidence(state)) return cheap;
+    return await buildFinalizePreview({ cwd: workDir }).catch((error: any) => ({
+      ...cheap,
+      ok: false,
+      ready: false,
+      warnings: [...(cheap.warnings || []), error.message],
+      nextAction:
+        cheap.nextAction || "Fix finalization preview errors before relying on review readiness.",
+    }));
+  }
+
+  function hasFinalizationEvidence(state: LooseObject): boolean {
+    const runs = Array.isArray(state.results)
+      ? state.results
+      : Array.isArray(state.current)
+        ? state.current
+        : [];
+    return runs.some((run: LooseObject) => isAcceptedCurrentRun(run));
+  }
+
+  function publicSessionConfig(config: unknown): LooseObject {
+    const record = config && typeof config === "object" ? { ...(config as LooseObject) } : {};
+    const output = redactEvidenceObject(record) as LooseObject;
+    for (const field of [
+      "benchmarkCommand",
+      "benchmark_command",
+      "checksCommand",
+      "checks_command",
+    ]) {
+      if (typeof record[field] === "string") {
+        output[field] = redactCommandDisplay(record[field]);
+      }
+    }
+    if (Object.hasOwn(record, "fixedControl")) {
+      output.fixedControl = fixedControlStateSummary(record.fixedControl);
+    }
+    return output;
+  }
+
+  function publicCommandPayload<T>(value: T): T {
+    return redactEvidenceObject(value) as T;
+  }
+
+  function compactPublicState(state: LooseObject) {
+    const limit = state.limit || {};
+    const continuation = state.continuation || {};
+    const compactDecisionEnvelope = compactEnvelope(state.decisionEnvelope || state.resumeAudit);
+    const canonicalNextAction =
+      compactDecisionEnvelope?.canonicalNextAction ||
+      state.decisionEnvelope?.canonicalNextAction ||
+      state.resumeAudit?.canonicalNextAction ||
+      null;
+    const loopBlockers = Array.isArray(compactDecisionEnvelope?.loopContract?.blockers)
+      ? compactDecisionEnvelope.loopContract.blockers.map(actionMessage).filter(Boolean)
+      : [];
+    const canonicalBlocker =
+      canonicalNextAction && isPacketBrakeKind(canonicalNextAction.kind)
+        ? actionMessage(canonicalNextAction)
+        : "";
+    const warningBlockers = Array.isArray(state.warningDetails)
+      ? state.warningDetails
+          .filter((warning: any) =>
+            ["git_dirty", "missing_commit_paths", PENDING_LOG_TRANSACTION_CODE].includes(
+              String(warning?.code || ""),
+            ),
+          )
+          .map((warning: any) => warning.message || warning.code)
+      : [];
+    const blockers = uniqueStrings(
+      [...loopBlockers, canonicalBlocker, ...warningBlockers].filter(Boolean),
+    );
+    const goalFrame = buildGoalFrame({
+      autoresearchGoal: state.config?.goal,
+      codexGoalObjective: state.codexGoalObjective,
+    });
+    const goalContract =
+      state.goalContract ||
+      buildGoalContract({
+        autoresearchGoal: state.config?.goal,
+        codexGoalObjective: state.codexGoalObjective,
+        benchmarkGoal: state.config?.benchmarkGoal || state.config?.goal,
+        finalizationClaim: state.config?.finalizationClaim,
+        recoveryCommand: state.commands?.codexGoalBrief || state.commands?.state,
+      });
+    const operatorHandoff = {
+      goal: goalFrame.operatorLine,
+      next: canonicalNextAction?.reason || continuation.nextAction || "Run doctor, then next.",
+      blocker: blockers[0] || "",
+      command: canonicalNextAction?.command || continuation.commands?.next || "",
+    };
+    return buildCompactStateResponse({
+      ok: state.ok,
+      workDir: state.workDir,
+      name: state.config?.name || "Autoresearch",
+      goal: state.config?.goal || "",
+      metric: state.config?.metricName || "metric",
+      direction: state.config?.bestDirection || "lower",
+      segment: state.segment,
+      runs: state.runs,
+      kept: state.kept,
+      discarded: state.discarded,
+      measured: state.measured,
+      baseline: state.baseline,
+      best: state.best,
+      historicalBest: state.historicalBest ?? null,
+      developmentBest: state.development?.best ?? null,
+      promotionBest: state.promotion?.best ?? null,
+      goalFrame,
+      goalContract,
+      operatorHandoff,
+      evidenceRegistry: state.evidenceRegistry
+        ? {
+            counts: state.evidenceRegistry.counts,
+            acceptedCurrent: Array.isArray(state.evidenceRegistry.acceptedCurrent)
+              ? state.evidenceRegistry.acceptedCurrent.length
+              : 0,
+            currentArtifacts: Array.isArray(state.evidenceRegistry.currentArtifacts)
+              ? state.evidenceRegistry.currentArtifacts.slice(0, 5)
+              : [],
+          }
+        : null,
+      productClaimCoverage: state.productClaimCoverage || null,
+      sessionDecisionCapsule:
+        state.sessionDecisionCapsule || compactDecisionEnvelope?.sessionDecisionCapsule || null,
+      evidenceLabels: state.researchIntegrity?.evidenceLabels || [],
+      scaffoldHealth: state.scaffoldHealth
+        ? {
+            ok: state.scaffoldHealth.ok,
+            status: state.scaffoldHealth.status,
+            blockers: (state.scaffoldHealth.checks || [])
+              .filter((check: any) => check.severity === "blocker")
+              .map((check: any) => check.message || check.code),
+          }
+        : null,
+      researchIntegrity: state.researchIntegrity
+        ? {
+            ok: state.researchIntegrity.ok,
+            currentLabel: state.researchIntegrity.currentLabel,
+            evidenceLabels: state.researchIntegrity.evidenceLabels || [],
+            notPromotableBecause: state.researchIntegrity.notPromotableBecause || [],
+          }
+        : null,
+      limitReached: Boolean(limit.limitReached),
+      remainingIterations: limit.remainingIterations ?? null,
+      nextAction:
+        canonicalNextAction?.reason || continuation.nextAction || "Run doctor, then next.",
+      shouldContinue: continuation.shouldContinue === true,
+      forbidFinalAnswer: continuation.forbidFinalAnswer === true,
+      activeBudget: continuation.activeBudget === true,
+      requiresLogDecision: continuation.requiresLogDecision === true,
+      afterLogAction: continuation.afterLogAction || "",
+      finalAnswerPolicy: continuation.finalAnswerPolicy || "",
+      parallelLanes: Array.isArray(state.parallelLanes)
+        ? state.parallelLanes.slice(0, 6).map((lane: any) => ({
+            id: lane.id,
+            title: lane.title || lane.label,
+            status: lane.status,
+            mode: lane.mode,
+            evidenceStatus: lane.evidenceStatus,
+            nextActionHint: lane.nextActionHint,
+            brief: lane.brief || null,
+          }))
+        : [],
+      fanoutPlan: state.fanoutPlan
+        ? {
+            id: state.fanoutPlan.id,
+            status: state.fanoutPlan.status,
+            segment: state.fanoutPlan.segment ?? state.segment,
+            nextAction: state.fanoutPlan.nextAction,
+          }
+        : null,
+      fanoutProvenance: state.fanoutProvenance || null,
+      watchdogSummary: state.watchdogSummary
+        ? {
+            stale: state.watchdogSummary.stale === true,
+            status: state.watchdogSummary.status || "",
+            recommendation: state.watchdogSummary.recommendation || "",
+            quietHours: state.watchdogSummary.quietHours ?? null,
+          }
+        : state.decisionEnvelope?.watchdog || null,
+      blockers: [...new Set(blockers)].slice(0, 6),
+      goalAdvice: compactDecisionEnvelope?.goalAdvice || null,
+      report: {
+        happened: `${state.runs} run${state.runs === 1 ? "" : "s"} in this segment; ${state.kept} kept, ${state.discarded} discarded, ${state.measured} measured, ${state.crashed} crashed, ${state.checksFailed} checks failed.`,
+        decision:
+          continuation.requiresLogDecision === true
+            ? "A packet is waiting for a keep/discard/measure/crash/checks_failed log decision."
+            : state.best == null
+              ? "No best metric yet."
+              : `Best ${state.config?.metricName || "metric"} is ${state.best}.`,
+        next: continuation.nextAction || "Run doctor, then next.",
+      },
+      memory: {
+        plateau: state.memory?.plateau?.detected === true,
+        suggestedLane: state.memory?.summary?.suggestedLane || "",
+        latestNextAction: state.memory?.latestNextAction || "",
+        exhaustedFamilies: Array.isArray(state.memory?.exhaustedFamilies)
+          ? state.memory.exhaustedFamilies.slice(0, 3)
+          : [],
+        metricShelves: Array.isArray(state.memory?.metricShelves)
+          ? state.memory.metricShelves.slice(0, 3)
+          : [],
+      },
+      experimentEconomics: state.experimentEconomics
+        ? {
+            runtimeClass: state.experimentEconomics.runtimeClass,
+            expectedRuntimeSeconds: state.experimentEconomics.expectedRuntimeSeconds ?? null,
+            baselineFreshness: state.experimentEconomics.baselineFreshness,
+            freshRunRequired: state.experimentEconomics.freshRunRequired === true,
+            freshRunReason: state.experimentEconomics.freshRunReason || "",
+            warnings: Array.isArray(state.experimentEconomics.warnings)
+              ? state.experimentEconomics.warnings.slice(0, 3)
+              : [],
+            progress: state.experimentEconomics.progress || null,
+          }
+        : null,
+      partialResults: {
+        candidates: Array.isArray(state.partialResults?.candidates)
+          ? state.partialResults.candidates.slice(0, 5)
+          : [],
+        skippedArtifacts: Array.isArray(state.partialResults?.skippedArtifacts)
+          ? state.partialResults.skippedArtifacts.slice(0, 5)
+          : [],
+      },
+      commandExecutionBoundary: state.commandExecutionBoundary || null,
+      portfolioRecommendation: compactPortfolioRecommendation(state.portfolioRecommendation),
+      workflowFriction: Array.isArray(state.workflowFriction)
+        ? state.workflowFriction.slice(0, 5)
+        : [],
+      commands: state.commands || {},
+      resumeAudit: compactDecisionEnvelope,
+      decisionEnvelope: compactDecisionEnvelope,
+      canonicalNextAction,
+      runtimeProvenance: state.runtimeProvenance,
+      runtimeDriftSummary: state.runtimeDriftSummary
+        ? {
+            installedRuntime: state.runtimeDriftSummary.installedRuntime,
+            builtRuntime: state.runtimeDriftSummary.builtRuntime,
+            nextActionHint: state.runtimeDriftSummary.nextActionHint,
+          }
+        : null,
+      runtimeAuthority: compactRuntimeAuthority(state.runtimeAuthority),
+      dashboardHealth: state.dashboardHealth || null,
+      sourceCleanliness: state.sourceCleanliness || null,
+      ledgerHealth: state.ledgerHealth || null,
+      gateQuality: state.gateQuality
+        ? {
+            posture: state.gateQuality.posture,
+            blockers: state.gateQuality.blockers || [],
+            warnings: state.gateQuality.warnings || [],
+            nextActionHint: state.gateQuality.nextActionHint || "",
+          }
+        : null,
+      fixedControl: state.fixedControl || null,
+      preflight: state.preflight
+        ? {
+            status: state.preflight.status,
+            blockers: state.preflight.blockers || [],
+            warnings: state.preflight.warnings || [],
+            nextCommand: state.preflight.nextCommand || "",
+          }
+        : null,
+      loopContract: compactDecisionEnvelope?.loopContract,
+      approvalLedger: state.approvalLedger || null,
+      resourcePreflight: state.resourcePreflight || null,
+      evidenceMaturity: state.evidenceMaturity || null,
+      laneOrchestration: state.laneOrchestration || null,
+      finalizationRunway: state.finalizationRunway || null,
+      operatorReadout: compactDecisionEnvelope?.operatorReadout || state.operatorReadout || null,
+      laneLifecycle: compactLaneLifecycle(state.laneLifecycle),
+      packetDiagnostics: state.packetDiagnostics,
+      metricSemanticsWarning: state.metricSemanticsWarning || null,
+    });
+  }
+
+  function commandExecutionBoundaryForState({
+    state,
+    lastRun,
+  }: {
+    state: LooseObject;
+    lastRun?: LooseObject | null;
+  }): LooseObject | null {
+    const boundary =
+      lastRun?.packetEvidence?.commandExecutionBoundary ||
+      [...(Array.isArray(state.current) ? state.current : [])]
+        .reverse()
+        .map((run: LooseObject) => run.commandExecutionBoundary)
+        .find(Boolean);
+    if (!boundary) return null;
+    return {
+      mode: String(boundary),
+      note: COMMAND_EXECUTION_BOUNDARY.note,
+      recommendation: COMMAND_EXECUTION_BOUNDARY.recommendation,
+    };
+  }
+
+  function compactEnvelope(envelope: LooseObject | null | undefined): LooseObject | null {
+    if (!envelope) return null;
+    return {
+      activeSegment: envelope.activeSegment || null,
+      historicalBest: envelope.historicalBest || null,
+      promotionGradeBest: envelope.promotionGradeBest || null,
+      latestPacketFreshness: envelope.latestPacketFreshness || null,
+      benchmarkConfigDrift: envelope.benchmarkConfigDrift || null,
+      dirtySourceDrift: envelope.dirtySourceDrift || null,
+      sourceCleanliness: envelope.sourceCleanliness || null,
+      goalContract: envelope.goalContract || null,
+      approvalLedger: envelope.approvalLedger || null,
+      resourcePreflight: envelope.resourcePreflight || null,
+      evidenceMaturity: envelope.evidenceMaturity || null,
+      laneOrchestration: envelope.laneOrchestration || null,
+      finalizationRunway: envelope.finalizationRunway || null,
+      budgetStatus: envelope.budgetStatus || null,
+      qualityRound: envelope.qualityRound || null,
+      scaffoldHealth: compactScaffoldHealth(envelope.scaffoldHealth),
+      researchIntegrity: envelope.researchIntegrity || null,
+      goalAdvice: envelope.goalAdvice || null,
+      finalizationReadiness: compactFinalizationReadiness(envelope.finalizationReadiness),
+      experimentEconomics: compactExperimentEconomics(envelope.experimentEconomics),
+      workflowFriction: Array.isArray(envelope.workflowFriction)
+        ? envelope.workflowFriction.slice(0, 5)
+        : [],
+      watchdog: envelope.watchdog || null,
+      contextDistillation: envelope.contextDistillation || null,
+      laneLifecycle: compactLaneLifecycle(envelope.laneLifecycle),
+      runtimeProvenance: envelope.runtimeProvenance || null,
+      packetDiagnostics: envelope.packetDiagnostics || null,
+      sessionDecisionCapsule: envelope.sessionDecisionCapsule || null,
+      nextAction: envelope.nextAction || "",
+      loopContract: envelope.loopContract || null,
+      canonicalNextAction: envelope.canonicalNextAction || null,
+      operatorReadout: envelope.operatorReadout || null,
+    };
+  }
+
+  function compactScaffoldHealth(
+    scaffoldHealth: LooseObject | null | undefined,
+  ): LooseObject | null {
+    if (!scaffoldHealth) return null;
+    return {
+      ok: scaffoldHealth.ok,
+      status: scaffoldHealth.status,
+      blockers: Array.isArray(scaffoldHealth.blockers)
+        ? scaffoldHealth.blockers.slice(0, 6)
+        : Array.isArray(scaffoldHealth.checks)
+          ? scaffoldHealth.checks
+              .filter((check: any) => check.severity === "blocker")
+              .map((check: any) => check.message || check.code)
+              .slice(0, 6)
+          : [],
+    };
+  }
+
+  function compactFinalizationReadiness(readiness: LooseObject | null | undefined): LooseObject {
+    return {
+      available: readiness?.available !== false,
+      ready: readiness?.ready === null ? null : readiness?.ready === true,
+      productGradeReady: readiness?.productGradeReady !== false,
+      productGradeIssue: readiness?.productGradeIssue || null,
+      nextAction: readiness?.nextAction || readiness?.recommendation || "",
+      warnings: Array.isArray(readiness?.warnings) ? readiness.warnings.slice(0, 3) : [],
+    };
+  }
+
+  function compactExperimentEconomics(
+    economics: LooseObject | null | undefined,
+  ): LooseObject | null {
+    if (!economics) return null;
+    return {
+      runtimeClass: economics.runtimeClass,
+      expectedRuntimeSeconds: economics.expectedRuntimeSeconds ?? null,
+      baselineFreshness: economics.baselineFreshness,
+      freshRunRequired: economics.freshRunRequired === true,
+      freshRunReason: economics.freshRunReason || "",
+      warnings: Array.isArray(economics.warnings) ? economics.warnings.slice(0, 3) : [],
+      progress: economics.progress || null,
+    };
+  }
+
+  function compactLaneLifecycle(laneLifecycle: LooseObject | null | undefined): LooseObject | null {
+    if (!laneLifecycle) return null;
+    const lanes = Array.isArray(laneLifecycle.lanes) ? laneLifecycle.lanes : [];
+    return {
+      stale: laneLifecycle.stale === true,
+      counts: {
+        planned: Array.isArray(laneLifecycle.plannedLanes) ? laneLifecycle.plannedLanes.length : 0,
+        running: Array.isArray(laneLifecycle.runningLanes) ? laneLifecycle.runningLanes.length : 0,
+        result: Array.isArray(laneLifecycle.resultLanes) ? laneLifecycle.resultLanes.length : 0,
+        stale: Array.isArray(laneLifecycle.staleLanes) ? laneLifecycle.staleLanes.length : 0,
+      },
+      lanes: lanes.slice(0, 6).map((lane: any) => ({
+        id: lane.id,
+        title: lane.title || lane.label,
+        status: lane.status,
+        mode: lane.mode,
+        evidenceStatus: lane.evidenceStatus,
+        nextActionHint: lane.nextActionHint,
+        brief: lane.brief || null,
+      })),
+      lessonsToAvoid: Array.isArray(laneLifecycle.lessonsToAvoid)
+        ? laneLifecycle.lessonsToAvoid.slice(0, 8)
+        : [],
+      recommendation: laneLifecycle.recommendation || "",
+      command: laneLifecycle.command || "",
+    };
+  }
+
+  function compactRuntimeAuthority(value: LooseObject | null | undefined): LooseObject | null {
+    if (!value) return null;
+    return {
+      sourceRuntime: value.sourceRuntime || null,
+      installedRuntime: value.installedRuntime || null,
+      trustScope: value.trustScope || "source-checkout",
+      blocking: value.blocking === true,
+      blocker: value.blocker || "",
+      warning: value.warning || "",
+    };
+  }
+
+  function compactPortfolioRecommendation(
+    value: LooseObject | null | undefined,
+  ): LooseObject | null {
+    if (!value) return null;
+    return {
+      kind: value.kind || "insufficient-evidence",
+      confidence: value.confidence || "low",
+      reason: value.reason || "",
+      nextActionHint: value.nextActionHint || "",
+      evidence: Array.isArray(value.evidence) ? value.evidence.slice(0, 6) : [],
+    };
+  }
+
+  async function dashboardHealthForWorkDir(workDir: string): Promise<LooseObject> {
+    const record = await readServeRegistry(workDir);
+    return verifyDashboardHealthSummary(
+      buildServeRegistryHealthInput(workDir, record, {
+        expectedVersion: PLUGIN_VERSION,
+        timeoutMs: 500,
+      }),
+    );
+  }
+
+  return {
+    publicState,
+    publicCompactState,
+    compactPublicState,
+    publicSessionConfig,
+    dashboardHealthForWorkDir,
+    finalizationPressureForWorkDir,
+  };
+}

--- a/plugins/codex-autoresearch/lib/commands/state.ts
+++ b/plugins/codex-autoresearch/lib/commands/state.ts
@@ -1,3 +1,5 @@
+import type { UnknownRecord } from "../types/json.js";
+
 type JsonObject = Record<string, unknown>;
 
 export interface CompactStateBuilderInput {
@@ -234,7 +236,7 @@ function copyIfProvided<T extends object>(target: T, key: string, value: unknown
   if (value !== undefined) (target as JsonObject)[key] = value;
 }
 
-type LooseObject = Record<string, any>;
+type CommandRecord = UnknownRecord & Record<string, any>;
 
 export type StateCommandServiceDeps = Record<string, any>;
 
@@ -298,14 +300,14 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
   const PLUGIN_ROOT = deps.pluginRoot;
   const PLUGIN_VERSION = deps.pluginVersion;
 
-  async function publicState(args: LooseObject): Promise<LooseObject> {
+  async function publicState(args: CommandRecord): Promise<CommandRecord> {
     const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
     const compact = boolOption(args.compact, false);
     const report = boolOption(args.report, false);
     const codexGoalObjective = args.codexGoalObjective || args.codex_goal_objective;
     const readCache = args.readCache || createSessionReadCache();
     if (compact || report) {
-      let compactState: LooseObject;
+      let compactState: CommandRecord;
       try {
         compactState = await publicCompactState({
           workDir,
@@ -324,7 +326,7 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
         });
       }
       if (!report) return compactState;
-      const response: LooseObject = {
+      const response: CommandRecord = {
         ok: compactState.ok !== false,
         workDir,
         report: buildTerminalReport(compactState),
@@ -578,11 +580,11 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     compact,
   }: {
     workDir: string;
-    config: LooseObject;
+    config: CommandRecord;
     codexGoalObjective?: unknown;
     error: unknown;
     compact: boolean;
-  }): LooseObject {
+  }): CommandRecord {
     const ledger = readLedgerRecordsTolerant(workDir);
     const rawLedgerHealth = analyzeLedgerHealth(ledger.records, {
       parseErrors: ledger.parseErrors,
@@ -655,10 +657,10 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     readCache,
   }: {
     workDir: string;
-    config: LooseObject;
+    config: CommandRecord;
     codexGoalObjective?: unknown;
     readCache?: unknown;
-  }): Promise<LooseObject> {
+  }): Promise<CommandRecord> {
     const effectiveReadCache = (readCache || createSessionReadCache()) as any;
     const state = loadSessionState(workDir, effectiveReadCache);
     const records = loadSessionRecords(workDir, effectiveReadCache);
@@ -882,10 +884,10 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     warningDetails,
   }: {
     workDir: string;
-    state: LooseObject;
-    qualityGap: LooseObject | null;
-    warningDetails: LooseObject[];
-  }): Promise<LooseObject> {
+    state: CommandRecord;
+    qualityGap: CommandRecord | null;
+    warningDetails: CommandRecord[];
+  }): Promise<CommandRecord> {
     const cheap = buildCheapFinalizationPressure({ state, qualityGap, warningDetails });
     if (!hasFinalizationEvidence(state)) return cheap;
     return await buildFinalizePreview({ cwd: workDir }).catch((error: any) => ({
@@ -898,18 +900,18 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     }));
   }
 
-  function hasFinalizationEvidence(state: LooseObject): boolean {
+  function hasFinalizationEvidence(state: CommandRecord): boolean {
     const runs = Array.isArray(state.results)
       ? state.results
       : Array.isArray(state.current)
         ? state.current
         : [];
-    return runs.some((run: LooseObject) => isAcceptedCurrentRun(run));
+    return runs.some((run: CommandRecord) => isAcceptedCurrentRun(run));
   }
 
-  function publicSessionConfig(config: unknown): LooseObject {
-    const record = config && typeof config === "object" ? { ...(config as LooseObject) } : {};
-    const output = redactEvidenceObject(record) as LooseObject;
+  function publicSessionConfig(config: unknown): CommandRecord {
+    const record = config && typeof config === "object" ? { ...(config as CommandRecord) } : {};
+    const output = redactEvidenceObject(record) as CommandRecord;
     for (const field of [
       "benchmarkCommand",
       "benchmark_command",
@@ -930,7 +932,7 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     return redactEvidenceObject(value) as T;
   }
 
-  function compactPublicState(state: LooseObject) {
+  function compactPublicState(state: CommandRecord): CommandRecord {
     const limit = state.limit || {};
     const continuation = state.continuation || {};
     const compactDecisionEnvelope = compactEnvelope(state.decisionEnvelope || state.resumeAudit);
@@ -1159,21 +1161,21 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
       laneLifecycle: compactLaneLifecycle(state.laneLifecycle),
       packetDiagnostics: state.packetDiagnostics,
       metricSemanticsWarning: state.metricSemanticsWarning || null,
-    });
+    }) as unknown as CommandRecord;
   }
 
   function commandExecutionBoundaryForState({
     state,
     lastRun,
   }: {
-    state: LooseObject;
-    lastRun?: LooseObject | null;
-  }): LooseObject | null {
+    state: CommandRecord;
+    lastRun?: CommandRecord | null;
+  }): CommandRecord | null {
     const boundary =
       lastRun?.packetEvidence?.commandExecutionBoundary ||
       [...(Array.isArray(state.current) ? state.current : [])]
         .reverse()
-        .map((run: LooseObject) => run.commandExecutionBoundary)
+        .map((run: CommandRecord) => run.commandExecutionBoundary)
         .find(Boolean);
     if (!boundary) return null;
     return {
@@ -1183,7 +1185,7 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     };
   }
 
-  function compactEnvelope(envelope: LooseObject | null | undefined): LooseObject | null {
+  function compactEnvelope(envelope: CommandRecord | null | undefined): CommandRecord | null {
     if (!envelope) return null;
     return {
       activeSegment: envelope.activeSegment || null,
@@ -1223,8 +1225,8 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
   }
 
   function compactScaffoldHealth(
-    scaffoldHealth: LooseObject | null | undefined,
-  ): LooseObject | null {
+    scaffoldHealth: CommandRecord | null | undefined,
+  ): CommandRecord | null {
     if (!scaffoldHealth) return null;
     return {
       ok: scaffoldHealth.ok,
@@ -1240,7 +1242,9 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     };
   }
 
-  function compactFinalizationReadiness(readiness: LooseObject | null | undefined): LooseObject {
+  function compactFinalizationReadiness(
+    readiness: CommandRecord | null | undefined,
+  ): CommandRecord {
     return {
       available: readiness?.available !== false,
       ready: readiness?.ready === null ? null : readiness?.ready === true,
@@ -1252,8 +1256,8 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
   }
 
   function compactExperimentEconomics(
-    economics: LooseObject | null | undefined,
-  ): LooseObject | null {
+    economics: CommandRecord | null | undefined,
+  ): CommandRecord | null {
     if (!economics) return null;
     return {
       runtimeClass: economics.runtimeClass,
@@ -1266,7 +1270,9 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     };
   }
 
-  function compactLaneLifecycle(laneLifecycle: LooseObject | null | undefined): LooseObject | null {
+  function compactLaneLifecycle(
+    laneLifecycle: CommandRecord | null | undefined,
+  ): CommandRecord | null {
     if (!laneLifecycle) return null;
     const lanes = Array.isArray(laneLifecycle.lanes) ? laneLifecycle.lanes : [];
     return {
@@ -1294,7 +1300,7 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     };
   }
 
-  function compactRuntimeAuthority(value: LooseObject | null | undefined): LooseObject | null {
+  function compactRuntimeAuthority(value: CommandRecord | null | undefined): CommandRecord | null {
     if (!value) return null;
     return {
       sourceRuntime: value.sourceRuntime || null,
@@ -1307,8 +1313,8 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
   }
 
   function compactPortfolioRecommendation(
-    value: LooseObject | null | undefined,
-  ): LooseObject | null {
+    value: CommandRecord | null | undefined,
+  ): CommandRecord | null {
     if (!value) return null;
     return {
       kind: value.kind || "insufficient-evidence",
@@ -1319,7 +1325,7 @@ export function createStateCommandService(deps: StateCommandServiceDeps) {
     };
   }
 
-  async function dashboardHealthForWorkDir(workDir: string): Promise<LooseObject> {
+  async function dashboardHealthForWorkDir(workDir: string): Promise<CommandRecord> {
     const record = await readServeRegistry(workDir);
     return verifyDashboardHealthSummary(
       buildServeRegistryHealthInput(workDir, record, {

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -409,27 +409,12 @@ const stateCommandService = createStateCommandService({
   verifyDashboardHealthSummary,
   withCanonicalActionCommand,
 });
-const publicSessionConfig = stateCommandService.publicSessionConfig;
-
 async function publicState(args: LooseObject): Promise<LooseObject> {
   return await stateCommandService.publicState(args);
 }
 
-async function publicCompactState(args: {
-  workDir: string;
-  config: LooseObject;
-  codexGoalObjective?: unknown;
-  readCache?: unknown;
-}): Promise<LooseObject> {
-  return await stateCommandService.publicCompactState(args);
-}
-
 function compactPublicState(state: LooseObject): LooseObject {
   return stateCommandService.compactPublicState(state);
-}
-
-async function dashboardHealthForWorkDir(workDir: string): Promise<LooseObject> {
-  return await stateCommandService.dashboardHealthForWorkDir(workDir);
 }
 
 async function finalizationPressureForWorkDir(args: {

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -30,7 +30,8 @@ import {
   selectRecommendNextRuntimeAuthority,
 } from "../lib/commands/recommend-next.js";
 import { assertRunResourcePreflight, buildActiveRunPacketId } from "../lib/commands/run.js";
-import { buildCompactStateResponse } from "../lib/commands/state.js";
+import { createDoctorCommandService } from "../lib/commands/doctor.js";
+import { createStateCommandService } from "../lib/commands/state.js";
 import { clearPendingLogTransactionWithWarning } from "../lib/commands/log.js";
 import {
   defaultCommandShell,
@@ -349,6 +350,139 @@ const PLUGIN_ROOT = resolvePackageRoot(import.meta.url);
 const REPO_ROOT = resolveRepoRoot(import.meta.url);
 const EMPTY_COMMIT_PATHS_WARNING_CODE = "empty_commit_paths_in_git_repo";
 const PENDING_LOG_TRANSACTION_CODE = "pending_log_transaction";
+
+const stateCommandService = createStateCommandService({
+  actionMessage,
+  analyzeExperimentEconomics,
+  analyzeLedgerHealth,
+  analyzeWorkflowFriction,
+  boolOption,
+  buildCheapFinalizationPressure,
+  buildDecisionEnvelope,
+  buildFinalizePreview,
+  buildGoalContract,
+  buildGoalFrame,
+  buildLaneLifecycle,
+  buildParallelOrchestrationContext,
+  buildResearchIntegrity,
+  buildScaffoldHealth,
+  buildServeRegistryHealthInput,
+  buildSessionReadModel,
+  buildSessionReadModelState,
+  buildSourceCleanliness,
+  buildTerminalReport,
+  classifyPacketDiagnostics,
+  commandExecutionBoundary: COMMAND_EXECUTION_BOUNDARY,
+  continuationCommands,
+  createSessionReadCache,
+  currentQualityGapSummary,
+  dashboardCommands,
+  dashboardSettings,
+  decisionGuidance,
+  discoverLastRunPartialResults,
+  errorMessage,
+  fixedControlStateSummary,
+  isAcceptedCurrentRun,
+  isPacketBrakeKind,
+  iterationLimitInfo,
+  lastRunPacketFreshness,
+  listBuiltInRecipes,
+  loadSessionRecords,
+  loadSessionState,
+  loopContinuation,
+  operatorWarningsForWorkDir,
+  pendingLogTransactionCode: PENDING_LOG_TRANSACTION_CODE,
+  pluginRoot: PLUGIN_ROOT,
+  pluginVersion: PLUGIN_VERSION,
+  readActiveProgressSnapshot,
+  readLastRunPacket,
+  readLedgerRecordsTolerant,
+  readServeRegistry,
+  recommendPortfolioDirection,
+  redactCommandDisplay,
+  redactEvidenceObject,
+  replacementNextCommandForLastRun,
+  resolveWorkDir,
+  runtimeProvenance,
+  statusCountsFromState,
+  uniqueStrings,
+  verifyDashboardHealthSummary,
+  withCanonicalActionCommand,
+});
+const publicSessionConfig = stateCommandService.publicSessionConfig;
+
+async function publicState(args: LooseObject): Promise<LooseObject> {
+  return await stateCommandService.publicState(args);
+}
+
+async function publicCompactState(args: {
+  workDir: string;
+  config: LooseObject;
+  codexGoalObjective?: unknown;
+  readCache?: unknown;
+}): Promise<LooseObject> {
+  return await stateCommandService.publicCompactState(args);
+}
+
+function compactPublicState(state: LooseObject): LooseObject {
+  return stateCommandService.compactPublicState(state);
+}
+
+async function dashboardHealthForWorkDir(workDir: string): Promise<LooseObject> {
+  return await stateCommandService.dashboardHealthForWorkDir(workDir);
+}
+
+async function finalizationPressureForWorkDir(args: {
+  workDir: string;
+  state: LooseObject;
+  qualityGap: LooseObject | null;
+  warningDetails: LooseObject[];
+}): Promise<LooseObject> {
+  return await stateCommandService.finalizationPressureForWorkDir(args);
+}
+
+const doctorCommandService = createDoctorCommandService({
+  actionMessage,
+  benchmarkContractDiagnostics,
+  boolOption,
+  buildDecisionEnvelope,
+  buildDriftReport,
+  buildRunProgress,
+  commandExecutionBoundary: COMMAND_EXECUTION_BOUNDARY,
+  continuationCommands,
+  currentState,
+  decisionGuidance,
+  errorMessage,
+  finiteMetric,
+  fixedControlBlockForCommand,
+  insideGitRepo,
+  inspectRuntimeDrift,
+  latestBenchmarkContractEntry,
+  listOption,
+  loopContinuation,
+  metricParseSource,
+  missingBenchmarkCommandMessage,
+  numberOption,
+  packetEnvModeFromArgs,
+  parseMetricLines,
+  pluginRoot: PLUGIN_ROOT,
+  pluginVersion: PLUGIN_VERSION,
+  publicState,
+  redactCommandDisplay,
+  redactEvidenceObject,
+  revalidateRecipeCatalogProvenance,
+  resolveBenchmarkCommandSource,
+  resolveWorkDir,
+  runShell,
+  runtimeProvenance,
+  shouldSuppressPreflightGateBlockerForCapsule,
+  uniqueStrings,
+  withCanonicalActionCommand,
+});
+
+async function doctorSession(args: LooseObject): Promise<LooseObject> {
+  return await doctorCommandService.doctorSession(args);
+}
 const PENDING_LOG_TRANSACTION_GIT_PATH = "autoresearch/pending-log-transaction.json";
 const DASHBOARD_GUIDANCE_EXTRA_DROP_FIELDS = new Set([
   "runtimeDriftSummary",
@@ -6987,356 +7121,6 @@ function partialResultEligiblePacket(packet: LooseObject | null): boolean {
   return exitCode != null && exitCode !== 0;
 }
 
-async function publicState(args: LooseObject): Promise<LooseObject> {
-  const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
-  const compact = boolOption(args.compact, false);
-  const report = boolOption(args.report, false);
-  const codexGoalObjective = args.codexGoalObjective || args.codex_goal_objective;
-  const readCache = args.readCache || createSessionReadCache();
-  if (compact || report) {
-    let compactState: LooseObject;
-    try {
-      compactState = await publicCompactState({
-        workDir,
-        config,
-        codexGoalObjective,
-        readCache,
-      });
-    } catch (error) {
-      if (!isStrictLedgerParseError(error)) throw error;
-      compactState = repairFirstStateForInvalidLedger({
-        workDir,
-        config,
-        codexGoalObjective,
-        error,
-        compact: true,
-      });
-    }
-    if (!report) return compactState;
-    const response: LooseObject = {
-      ok: compactState.ok !== false,
-      workDir,
-      report: buildTerminalReport(compactState),
-    };
-    if (compact) response.compactState = compactState;
-    return response;
-  }
-
-  let state: ReturnType<typeof loadSessionState>;
-  let records: ReturnType<typeof loadSessionRecords>;
-  try {
-    state = loadSessionState(workDir, readCache);
-    records = loadSessionRecords(workDir, readCache);
-  } catch (error) {
-    if (!isStrictLedgerParseError(error)) throw error;
-    return repairFirstStateForInvalidLedger({
-      workDir,
-      config,
-      codexGoalObjective,
-      error,
-      compact: false,
-    });
-  }
-  const ledgerHealth = analyzeLedgerHealth(records);
-  const scaffoldHealth = await buildScaffoldHealth({ workDir, config });
-  const researchIntegrity = buildResearchIntegrity({ state, config });
-  const warningDetails = await operatorWarningsForWorkDir(workDir, state);
-  const lastRun = await readLastRunPacket(workDir).catch((): null => null);
-  const activeProgress = await readActiveProgressSnapshot(workDir, config);
-  const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
-  const replaceLastRunCommand = await replacementNextCommandForLastRun(workDir, lastRun);
-  const qualityGap = await currentQualityGapSummary(workDir);
-  const finalization = await finalizationPressureForWorkDir({
-    workDir,
-    state,
-    qualityGap,
-    warningDetails,
-  });
-  const settings = dashboardSettings(config);
-  const orchestration = buildParallelOrchestrationContext({
-    workDir,
-    state,
-    config,
-    settings,
-    records,
-  });
-  const { memory, fanoutPlan, fanoutProvenance, parallelLanes, watchdogSummary } = orchestration;
-  const laneLifecycle = buildLaneLifecycle({
-    state,
-    records,
-    fanoutPlan,
-    parallelLanes,
-    laneResults: orchestration.laneResults,
-    workDir,
-    pluginRoot: PLUGIN_ROOT,
-  });
-  const packetDiagnostics = lastRun
-    ? classifyPacketDiagnostics({
-        packetEvidence: lastRun.packetEvidence || {},
-        run: lastRun.run || {},
-        decision: lastRun.decision || {},
-        metrics: lastRun.decision?.metrics || lastRun.run?.parsedMetrics || {},
-        metricName: state.config.metricName,
-        command: continuationCommands(workDir).partialResults,
-      })
-    : classifyPacketDiagnostics();
-  const currentRuntimeProvenance = runtimeProvenance();
-  const dashboardHealth = await dashboardHealthForWorkDir(workDir);
-  const sourceCleanliness = buildSourceCleanliness({ warningDetails });
-  const guidance = await decisionGuidance({
-    workDir,
-    config,
-    state,
-    scaffoldHealth,
-    warningDetails,
-  });
-  const publicCommandAuthority = publicCommandPayload(guidance.commandAuthority);
-  const publicPreflight = publicCommandPayload(guidance.preflight);
-  const stateWithQualityGap = {
-    ...buildSessionReadModelState({
-      state,
-      qualityGap,
-      laneLifecycle,
-      packetDiagnostics,
-      runtimeProvenance: currentRuntimeProvenance,
-      runtimeDriftSummary: guidance.runtimeDriftSummary,
-      dashboardHealth,
-      sourceCleanliness,
-      gateQuality: guidance.gateQuality,
-      preflight: publicPreflight,
-    }),
-    runtimeAuthority: guidance.runtimeAuthority,
-    ledgerHealth,
-  };
-  const recipeSummaries = listBuiltInRecipes().map((recipe: any) => ({
-    id: recipe.id,
-    title: recipe.title,
-    tags: recipe.tags || [],
-  }));
-  const partialResults = await discoverLastRunPartialResults(workDir, state, lastRun);
-  const workflowFriction = analyzeWorkflowFriction({
-    state: stateWithQualityGap,
-    lastRun,
-    warningDetails,
-    recipes: recipeSummaries,
-  });
-  const experimentEconomics = analyzeExperimentEconomics({
-    state: stateWithQualityGap,
-    lastRun,
-    progress:
-      activeProgress ||
-      (await readActiveProgressSnapshot(workDir, config)) ||
-      lastRun?.packetEvidence?.progressSnapshot ||
-      null,
-  });
-  const portfolioRecommendation = recommendPortfolioDirection({
-    runtimeDrift: guidance.runtimeDriftSummary,
-    gateQuality: guidance.gateQuality,
-    preflight: publicPreflight,
-    laneLifecycle,
-    laneResults: laneLifecycle.latestResults,
-    packetDiagnostics,
-    experimentMemory: memory,
-    best: state.best,
-    current: state.current,
-  });
-  const readModel = buildSessionReadModel({
-    workDir,
-    config,
-    state,
-    records,
-    codexGoalObjective,
-    parallelLanes,
-    workflowFriction,
-    finalization,
-    commands: continuationCommands(workDir),
-    qualityGap,
-    laneLifecycle,
-    packetDiagnostics,
-    runtimeProvenance: currentRuntimeProvenance,
-    runtimeDriftSummary: guidance.runtimeDriftSummary,
-    dashboardHealth,
-    sourceCleanliness,
-    gateQuality: guidance.gateQuality,
-    preflight: publicPreflight,
-  });
-  const controlPlane = readModel.controlPlane;
-  const statusCounts = readModel.statusCounts;
-  const continuation = loopContinuation(workDir, state, config, "state");
-  const stateCommands = {
-    ...continuation.commands,
-    ...(replaceLastRunCommand ? { replaceLast: replaceLastRunCommand } : {}),
-  };
-  const decisionEnvelope = withCanonicalActionCommand(
-    buildDecisionEnvelope({
-      state: {
-        ...stateWithQualityGap,
-        portfolioRecommendation,
-        ...controlPlane,
-        limit: iterationLimitInfo(state, config),
-      },
-      nextAction: continuation.nextAction,
-      lastRunFreshness,
-      warningDetails,
-      scaffoldHealth,
-      researchIntegrity,
-      qualityGap,
-      finalization,
-      experimentEconomics,
-      salvageCandidates: partialResults.candidates,
-      workflowFriction,
-      experimentMemory: memory,
-      watchdog: watchdogSummary,
-    }),
-    stateCommands,
-  );
-  const fullState = {
-    ok: true,
-    workDir,
-    config: publicSessionConfig(state.config),
-    segment: state.segment,
-    runs: state.current.length,
-    totalRuns: state.results.length,
-    kept: statusCounts.keep,
-    discarded: statusCounts.discard,
-    measured: statusCounts.measure,
-    crashed: statusCounts.crash,
-    checksFailed: statusCounts.checks_failed,
-    baseline: state.baseline,
-    best: state.best,
-    historicalBest: state.historicalBest,
-    development: state.development,
-    promotion: state.promotion,
-    evidenceRegistry: state.evidenceRegistry,
-    productClaimCoverage: state.productClaimCoverage,
-    sessionDecisionCapsule: state.sessionDecisionCapsule || null,
-    confidence: state.confidence,
-    scaffoldHealth,
-    researchIntegrity,
-    runtimeProvenance: currentRuntimeProvenance,
-    runtimeDriftSummary: guidance.runtimeDriftSummary,
-    runtimeAuthority: guidance.runtimeAuthority,
-    dashboardHealth,
-    sourceCleanliness,
-    ledgerHealth,
-    gateQuality: guidance.gateQuality,
-    fixedControl: fixedControlStateSummary(config.fixedControl),
-    commandAuthority: publicCommandAuthority,
-    preflight: publicPreflight,
-    limit: iterationLimitInfo(state, config),
-    settings: {
-      autonomyMode: config.autonomyMode || "guarded",
-      checksPolicy: config.checksPolicy || "always",
-      keepPolicy: config.keepPolicy || "primary-only",
-      dashboardRefreshSeconds: config.dashboardRefreshSeconds || 5,
-      commitPaths: config.commitPaths || [],
-    },
-    commands: dashboardCommands(workDir),
-    warnings: warningDetails.map((warning: any) => warning.message),
-    warningDetails,
-    fanoutPlan,
-    fanoutProvenance,
-    parallelLanes,
-    laneLifecycle,
-    packetDiagnostics,
-    metricSemanticsWarning: state.metricSemanticsWarning || null,
-    commandExecutionBoundary: commandExecutionBoundaryForState({ state, lastRun }),
-    portfolioRecommendation,
-    ...controlPlane,
-    watchdogSummary,
-    memory,
-    experimentEconomics,
-    partialResults,
-    workflowFriction,
-    continuation,
-    resumeAudit: decisionEnvelope,
-    decisionEnvelope,
-  };
-  return compact ? compactPublicState(fullState) : fullState;
-}
-
-function isStrictLedgerParseError(error: unknown): boolean {
-  return /Invalid JSONL in .*[\\/]?autoresearch\.jsonl at line \d+:/i.test(errorMessage(error));
-}
-
-function repairFirstStateForInvalidLedger({
-  workDir,
-  config,
-  codexGoalObjective,
-  error,
-  compact,
-}: {
-  workDir: string;
-  config: LooseObject;
-  codexGoalObjective?: unknown;
-  error: unknown;
-  compact: boolean;
-}): LooseObject {
-  const ledger = readLedgerRecordsTolerant(workDir);
-  const rawLedgerHealth = analyzeLedgerHealth(ledger.records, {
-    parseErrors: ledger.parseErrors,
-  });
-  const commands = continuationCommands(workDir);
-  const ledgerHealth = {
-    ...rawLedgerHealth,
-    command: commands.ledgerDoctor,
-  };
-  const runtime = runtimeProvenance();
-  const decisionEnvelope = withCanonicalActionCommand(
-    buildDecisionEnvelope({
-      state: {
-        config,
-        current: [],
-        results: [],
-        ledgerHealth,
-        runtimeProvenance: runtime,
-      },
-      nextAction: "Run ledger-doctor before another Autoresearch packet.",
-    }),
-    commands,
-  );
-  const response = {
-    ok: false,
-    code: "ledger_jsonl_invalid",
-    workDir,
-    config: publicSessionConfig(config),
-    segment: 0,
-    runs: ledger.records.length,
-    totalRuns: ledger.records.length,
-    kept: 0,
-    discarded: 0,
-    measured: 0,
-    crashed: 0,
-    checksFailed: 0,
-    baseline: null,
-    best: null,
-    historicalBest: null,
-    development: null,
-    promotion: null,
-    confidence: null,
-    ledgerPath: ledger.ledgerPath,
-    ledgerHealth,
-    parseErrors: ledgerHealth.parseErrors,
-    warnings: ledgerHealth.warnings,
-    error: errorMessage(error),
-    commands,
-    continuation: {
-      shouldContinue: false,
-      nextAction: "Run ledger-doctor before another packet.",
-      commands,
-    },
-    nextAction: "Run ledger-doctor before another packet.",
-    blockers: ledgerHealth.warnings,
-    runtimeProvenance: runtime,
-    codexGoalObjective,
-    resumeAudit: decisionEnvelope,
-    decisionEnvelope,
-    canonicalNextAction: decisionEnvelope.canonicalNextAction,
-    loopContract: decisionEnvelope.loopContract,
-  };
-  return compact ? compactPublicState(response) : response;
-}
-
 async function ledgerDoctor(args: LooseObject): Promise<LooseObject> {
   const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
   const ledger = readLedgerRecordsTolerant(workDir);
@@ -7425,680 +7209,6 @@ function formatJsonl(records: Array<Record<string, unknown>>): string {
 
 function ledgerBackupTimestamp(date = new Date()): string {
   return date.toISOString().replace(/[:.]/g, "-");
-}
-
-async function publicCompactState({
-  workDir,
-  config,
-  codexGoalObjective,
-  readCache,
-}: {
-  workDir: string;
-  config: LooseObject;
-  codexGoalObjective?: unknown;
-  readCache?: unknown;
-}): Promise<LooseObject> {
-  const effectiveReadCache = (readCache || createSessionReadCache()) as any;
-  const state = loadSessionState(workDir, effectiveReadCache);
-  const records = loadSessionRecords(workDir, effectiveReadCache);
-  const ledgerHealth = analyzeLedgerHealth(records);
-  const lastRun = await readLastRunPacket(workDir).catch((): null => null);
-  const activeProgress = await readActiveProgressSnapshot(workDir, config);
-  const lastRunFreshness = lastRun ? await lastRunPacketFreshness(workDir, lastRun) : null;
-  const replaceLastRunCommand = await replacementNextCommandForLastRun(workDir, lastRun);
-  const qualityGap = await currentQualityGapSummary(workDir);
-  const scaffoldHealth = await buildScaffoldHealth({ workDir, config });
-  const researchIntegrity = buildResearchIntegrity({ state, config });
-  const warningDetails = await operatorWarningsForWorkDir(workDir, state);
-  const settings = dashboardSettings(config);
-  const orchestration = buildParallelOrchestrationContext({
-    workDir,
-    state,
-    config,
-    settings,
-    records,
-  });
-  const { memory, fanoutPlan, fanoutProvenance, parallelLanes, watchdogSummary } = orchestration;
-  const laneLifecycle = buildLaneLifecycle({
-    state,
-    records,
-    fanoutPlan,
-    parallelLanes,
-    laneResults: orchestration.laneResults,
-    workDir,
-    pluginRoot: PLUGIN_ROOT,
-  });
-  const packetDiagnostics = lastRun
-    ? classifyPacketDiagnostics({
-        packetEvidence: lastRun.packetEvidence || {},
-        run: lastRun.run || {},
-        decision: lastRun.decision || {},
-        metrics: lastRun.decision?.metrics || lastRun.run?.parsedMetrics || {},
-        metricName: state.config.metricName,
-        command: continuationCommands(workDir).partialResults,
-      })
-    : classifyPacketDiagnostics();
-  const currentRuntimeProvenance = runtimeProvenance();
-  const dashboardHealth = await dashboardHealthForWorkDir(workDir);
-  const sourceCleanliness = buildSourceCleanliness({ warningDetails });
-  const guidance = await decisionGuidance({
-    workDir,
-    config,
-    state,
-    scaffoldHealth,
-    warningDetails,
-  });
-  const publicPreflight = publicCommandPayload(guidance.preflight);
-  const stateWithQualityGap = {
-    ...buildSessionReadModelState({
-      state,
-      qualityGap,
-      laneLifecycle,
-      packetDiagnostics,
-      runtimeProvenance: currentRuntimeProvenance,
-      runtimeDriftSummary: guidance.runtimeDriftSummary,
-      dashboardHealth,
-      sourceCleanliness,
-      gateQuality: guidance.gateQuality,
-      preflight: publicPreflight,
-    }),
-    runtimeAuthority: guidance.runtimeAuthority,
-    ledgerHealth,
-  };
-  const partialResults = await discoverLastRunPartialResults(workDir, state, lastRun);
-  const recipeSummaries = listBuiltInRecipes().map((recipe: any) => ({
-    id: recipe.id,
-    title: recipe.title,
-    tags: recipe.tags || [],
-  }));
-  const workflowFriction = analyzeWorkflowFriction({
-    state: stateWithQualityGap,
-    lastRun,
-    warningDetails,
-    recipes: recipeSummaries,
-  });
-  const experimentEconomics = analyzeExperimentEconomics({
-    state: stateWithQualityGap,
-    lastRun,
-    progress: activeProgress || lastRun?.packetEvidence?.progressSnapshot || null,
-  });
-  const portfolioRecommendation = recommendPortfolioDirection({
-    runtimeDrift: guidance.runtimeDriftSummary,
-    gateQuality: guidance.gateQuality,
-    preflight: publicPreflight,
-    laneLifecycle,
-    laneResults: laneLifecycle.latestResults,
-    packetDiagnostics,
-    experimentMemory: memory,
-    best: state.best,
-    current: state.current,
-  });
-  const statusCounts = statusCountsFromState(state);
-  const continuation = loopContinuation(workDir, state, config, "state");
-  const compactCommands = {
-    ...continuation.commands,
-    ...(replaceLastRunCommand ? { replaceLast: replaceLastRunCommand } : {}),
-  };
-  const finalization = await finalizationPressureForWorkDir({
-    workDir,
-    state,
-    qualityGap,
-    warningDetails,
-  });
-  const readModel = buildSessionReadModel({
-    workDir,
-    config,
-    state,
-    records,
-    codexGoalObjective,
-    parallelLanes,
-    workflowFriction,
-    finalization,
-    commands: continuationCommands(workDir),
-    qualityGap,
-    laneLifecycle,
-    packetDiagnostics,
-    runtimeProvenance: currentRuntimeProvenance,
-    runtimeDriftSummary: guidance.runtimeDriftSummary,
-    dashboardHealth,
-    sourceCleanliness,
-    gateQuality: guidance.gateQuality,
-    preflight: publicPreflight,
-  });
-  const controlPlane = readModel.controlPlane;
-  const decisionEnvelope = withCanonicalActionCommand(
-    buildDecisionEnvelope({
-      state: {
-        ...stateWithQualityGap,
-        portfolioRecommendation,
-        ...controlPlane,
-        limit: iterationLimitInfo(state, config),
-      },
-      nextAction: continuation.nextAction,
-      lastRunFreshness,
-      warningDetails,
-      scaffoldHealth,
-      researchIntegrity,
-      qualityGap,
-      finalization,
-      experimentEconomics,
-      salvageCandidates: partialResults.candidates,
-      workflowFriction,
-      experimentMemory: memory,
-      watchdog: watchdogSummary,
-    }),
-    compactCommands,
-  );
-  return compactPublicState({
-    ok: true,
-    workDir,
-    config: publicSessionConfig(state.config),
-    segment: state.segment,
-    runs: state.current.length,
-    totalRuns: state.results.length,
-    kept: statusCounts.keep,
-    discarded: statusCounts.discard,
-    measured: statusCounts.measure,
-    crashed: statusCounts.crash,
-    checksFailed: statusCounts.checks_failed,
-    baseline: state.baseline,
-    best: state.best,
-    historicalBest: state.historicalBest,
-    development: state.development,
-    promotion: state.promotion,
-    evidenceRegistry: state.evidenceRegistry,
-    productClaimCoverage: state.productClaimCoverage,
-    sessionDecisionCapsule: state.sessionDecisionCapsule || null,
-    confidence: state.confidence,
-    scaffoldHealth,
-    researchIntegrity,
-    runtimeProvenance: currentRuntimeProvenance,
-    runtimeDriftSummary: guidance.runtimeDriftSummary,
-    runtimeAuthority: guidance.runtimeAuthority,
-    dashboardHealth,
-    sourceCleanliness,
-    ledgerHealth,
-    gateQuality: guidance.gateQuality,
-    fixedControl: fixedControlStateSummary(config.fixedControl),
-    preflight: publicPreflight,
-    limit: iterationLimitInfo(state, config),
-    settings: {
-      autonomyMode: config.autonomyMode || "guarded",
-      checksPolicy: config.checksPolicy || "always",
-      keepPolicy: config.keepPolicy || "primary-only",
-      dashboardRefreshSeconds: config.dashboardRefreshSeconds || 5,
-      commitPaths: config.commitPaths || [],
-    },
-    commands: compactCommands,
-    warnings: warningDetails.map((warning: any) => warning.message),
-    warningDetails,
-    qualityGap,
-    memory,
-    fanoutPlan,
-    fanoutProvenance,
-    parallelLanes,
-    watchdogSummary,
-    laneLifecycle,
-    packetDiagnostics,
-    metricSemanticsWarning: state.metricSemanticsWarning || null,
-    commandExecutionBoundary: commandExecutionBoundaryForState({ state, lastRun }),
-    portfolioRecommendation,
-    experimentEconomics,
-    partialResults,
-    workflowFriction,
-    ...controlPlane,
-    codexGoalObjective,
-    resumeAudit: decisionEnvelope,
-    decisionEnvelope,
-    continuation,
-  });
-}
-
-async function finalizationPressureForWorkDir({
-  workDir,
-  state,
-  qualityGap,
-  warningDetails,
-}: {
-  workDir: string;
-  state: LooseObject;
-  qualityGap: LooseObject | null;
-  warningDetails: LooseObject[];
-}): Promise<LooseObject> {
-  const cheap = buildCheapFinalizationPressure({ state, qualityGap, warningDetails });
-  if (!hasFinalizationEvidence(state)) return cheap;
-  return await buildFinalizePreview({ cwd: workDir }).catch((error: any) => ({
-    ...cheap,
-    ok: false,
-    ready: false,
-    warnings: [...(cheap.warnings || []), error.message],
-    nextAction:
-      cheap.nextAction || "Fix finalization preview errors before relying on review readiness.",
-  }));
-}
-
-function hasFinalizationEvidence(state: LooseObject): boolean {
-  const runs = Array.isArray(state.results)
-    ? state.results
-    : Array.isArray(state.current)
-      ? state.current
-      : [];
-  return runs.some((run: LooseObject) => isAcceptedCurrentRun(run));
-}
-
-function publicSessionConfig(config: unknown): LooseObject {
-  const record = config && typeof config === "object" ? { ...(config as LooseObject) } : {};
-  const output = redactEvidenceObject(record) as LooseObject;
-  for (const field of [
-    "benchmarkCommand",
-    "benchmark_command",
-    "checksCommand",
-    "checks_command",
-  ]) {
-    if (typeof record[field] === "string") {
-      output[field] = redactCommandDisplay(record[field]);
-    }
-  }
-  if (Object.hasOwn(record, "fixedControl")) {
-    output.fixedControl = fixedControlStateSummary(record.fixedControl);
-  }
-  return output;
-}
-
-function publicCommandPayload<T>(value: T): T {
-  return redactEvidenceObject(value) as T;
-}
-
-function compactPublicState(state: LooseObject) {
-  const limit = state.limit || {};
-  const continuation = state.continuation || {};
-  const compactDecisionEnvelope = compactEnvelope(state.decisionEnvelope || state.resumeAudit);
-  const canonicalNextAction =
-    compactDecisionEnvelope?.canonicalNextAction ||
-    state.decisionEnvelope?.canonicalNextAction ||
-    state.resumeAudit?.canonicalNextAction ||
-    null;
-  const loopBlockers = Array.isArray(compactDecisionEnvelope?.loopContract?.blockers)
-    ? compactDecisionEnvelope.loopContract.blockers.map(actionMessage).filter(Boolean)
-    : [];
-  const canonicalBlocker =
-    canonicalNextAction && isPacketBrakeKind(canonicalNextAction.kind)
-      ? actionMessage(canonicalNextAction)
-      : "";
-  const warningBlockers = Array.isArray(state.warningDetails)
-    ? state.warningDetails
-        .filter((warning: any) =>
-          ["git_dirty", "missing_commit_paths", PENDING_LOG_TRANSACTION_CODE].includes(
-            String(warning?.code || ""),
-          ),
-        )
-        .map((warning: any) => warning.message || warning.code)
-    : [];
-  const blockers = uniqueStrings(
-    [...loopBlockers, canonicalBlocker, ...warningBlockers].filter(Boolean),
-  );
-  const goalFrame = buildGoalFrame({
-    autoresearchGoal: state.config?.goal,
-    codexGoalObjective: state.codexGoalObjective,
-  });
-  const goalContract =
-    state.goalContract ||
-    buildGoalContract({
-      autoresearchGoal: state.config?.goal,
-      codexGoalObjective: state.codexGoalObjective,
-      benchmarkGoal: state.config?.benchmarkGoal || state.config?.goal,
-      finalizationClaim: state.config?.finalizationClaim,
-      recoveryCommand: state.commands?.codexGoalBrief || state.commands?.state,
-    });
-  const operatorHandoff = {
-    goal: goalFrame.operatorLine,
-    next: canonicalNextAction?.reason || continuation.nextAction || "Run doctor, then next.",
-    blocker: blockers[0] || "",
-    command: canonicalNextAction?.command || continuation.commands?.next || "",
-  };
-  return buildCompactStateResponse({
-    ok: state.ok,
-    workDir: state.workDir,
-    name: state.config?.name || "Autoresearch",
-    goal: state.config?.goal || "",
-    metric: state.config?.metricName || "metric",
-    direction: state.config?.bestDirection || "lower",
-    segment: state.segment,
-    runs: state.runs,
-    kept: state.kept,
-    discarded: state.discarded,
-    measured: state.measured,
-    baseline: state.baseline,
-    best: state.best,
-    historicalBest: state.historicalBest ?? null,
-    developmentBest: state.development?.best ?? null,
-    promotionBest: state.promotion?.best ?? null,
-    goalFrame,
-    goalContract,
-    operatorHandoff,
-    evidenceRegistry: state.evidenceRegistry
-      ? {
-          counts: state.evidenceRegistry.counts,
-          acceptedCurrent: Array.isArray(state.evidenceRegistry.acceptedCurrent)
-            ? state.evidenceRegistry.acceptedCurrent.length
-            : 0,
-          currentArtifacts: Array.isArray(state.evidenceRegistry.currentArtifacts)
-            ? state.evidenceRegistry.currentArtifacts.slice(0, 5)
-            : [],
-        }
-      : null,
-    productClaimCoverage: state.productClaimCoverage || null,
-    sessionDecisionCapsule:
-      state.sessionDecisionCapsule || compactDecisionEnvelope?.sessionDecisionCapsule || null,
-    evidenceLabels: state.researchIntegrity?.evidenceLabels || [],
-    scaffoldHealth: state.scaffoldHealth
-      ? {
-          ok: state.scaffoldHealth.ok,
-          status: state.scaffoldHealth.status,
-          blockers: (state.scaffoldHealth.checks || [])
-            .filter((check: any) => check.severity === "blocker")
-            .map((check: any) => check.message || check.code),
-        }
-      : null,
-    researchIntegrity: state.researchIntegrity
-      ? {
-          ok: state.researchIntegrity.ok,
-          currentLabel: state.researchIntegrity.currentLabel,
-          evidenceLabels: state.researchIntegrity.evidenceLabels || [],
-          notPromotableBecause: state.researchIntegrity.notPromotableBecause || [],
-        }
-      : null,
-    limitReached: Boolean(limit.limitReached),
-    remainingIterations: limit.remainingIterations ?? null,
-    nextAction: canonicalNextAction?.reason || continuation.nextAction || "Run doctor, then next.",
-    shouldContinue: continuation.shouldContinue === true,
-    forbidFinalAnswer: continuation.forbidFinalAnswer === true,
-    activeBudget: continuation.activeBudget === true,
-    requiresLogDecision: continuation.requiresLogDecision === true,
-    afterLogAction: continuation.afterLogAction || "",
-    finalAnswerPolicy: continuation.finalAnswerPolicy || "",
-    parallelLanes: Array.isArray(state.parallelLanes)
-      ? state.parallelLanes.slice(0, 6).map((lane: any) => ({
-          id: lane.id,
-          title: lane.title || lane.label,
-          status: lane.status,
-          mode: lane.mode,
-          evidenceStatus: lane.evidenceStatus,
-          nextActionHint: lane.nextActionHint,
-          brief: lane.brief || null,
-        }))
-      : [],
-    fanoutPlan: state.fanoutPlan
-      ? {
-          id: state.fanoutPlan.id,
-          status: state.fanoutPlan.status,
-          segment: state.fanoutPlan.segment ?? state.segment,
-          nextAction: state.fanoutPlan.nextAction,
-        }
-      : null,
-    fanoutProvenance: state.fanoutProvenance || null,
-    watchdogSummary: state.watchdogSummary
-      ? {
-          stale: state.watchdogSummary.stale === true,
-          status: state.watchdogSummary.status || "",
-          recommendation: state.watchdogSummary.recommendation || "",
-          quietHours: state.watchdogSummary.quietHours ?? null,
-        }
-      : state.decisionEnvelope?.watchdog || null,
-    blockers: [...new Set(blockers)].slice(0, 6),
-    goalAdvice: compactDecisionEnvelope?.goalAdvice || null,
-    report: {
-      happened: `${state.runs} run${state.runs === 1 ? "" : "s"} in this segment; ${state.kept} kept, ${state.discarded} discarded, ${state.measured} measured, ${state.crashed} crashed, ${state.checksFailed} checks failed.`,
-      decision:
-        continuation.requiresLogDecision === true
-          ? "A packet is waiting for a keep/discard/measure/crash/checks_failed log decision."
-          : state.best == null
-            ? "No best metric yet."
-            : `Best ${state.config?.metricName || "metric"} is ${state.best}.`,
-      next: continuation.nextAction || "Run doctor, then next.",
-    },
-    memory: {
-      plateau: state.memory?.plateau?.detected === true,
-      suggestedLane: state.memory?.summary?.suggestedLane || "",
-      latestNextAction: state.memory?.latestNextAction || "",
-      exhaustedFamilies: Array.isArray(state.memory?.exhaustedFamilies)
-        ? state.memory.exhaustedFamilies.slice(0, 3)
-        : [],
-      metricShelves: Array.isArray(state.memory?.metricShelves)
-        ? state.memory.metricShelves.slice(0, 3)
-        : [],
-    },
-    experimentEconomics: state.experimentEconomics
-      ? {
-          runtimeClass: state.experimentEconomics.runtimeClass,
-          expectedRuntimeSeconds: state.experimentEconomics.expectedRuntimeSeconds ?? null,
-          baselineFreshness: state.experimentEconomics.baselineFreshness,
-          freshRunRequired: state.experimentEconomics.freshRunRequired === true,
-          freshRunReason: state.experimentEconomics.freshRunReason || "",
-          warnings: Array.isArray(state.experimentEconomics.warnings)
-            ? state.experimentEconomics.warnings.slice(0, 3)
-            : [],
-          progress: state.experimentEconomics.progress || null,
-        }
-      : null,
-    partialResults: {
-      candidates: Array.isArray(state.partialResults?.candidates)
-        ? state.partialResults.candidates.slice(0, 5)
-        : [],
-      skippedArtifacts: Array.isArray(state.partialResults?.skippedArtifacts)
-        ? state.partialResults.skippedArtifacts.slice(0, 5)
-        : [],
-    },
-    commandExecutionBoundary: state.commandExecutionBoundary || null,
-    portfolioRecommendation: compactPortfolioRecommendation(state.portfolioRecommendation),
-    workflowFriction: Array.isArray(state.workflowFriction)
-      ? state.workflowFriction.slice(0, 5)
-      : [],
-    commands: state.commands || {},
-    resumeAudit: compactDecisionEnvelope,
-    decisionEnvelope: compactDecisionEnvelope,
-    canonicalNextAction,
-    runtimeProvenance: state.runtimeProvenance,
-    runtimeDriftSummary: state.runtimeDriftSummary
-      ? {
-          installedRuntime: state.runtimeDriftSummary.installedRuntime,
-          builtRuntime: state.runtimeDriftSummary.builtRuntime,
-          nextActionHint: state.runtimeDriftSummary.nextActionHint,
-        }
-      : null,
-    runtimeAuthority: compactRuntimeAuthority(state.runtimeAuthority),
-    dashboardHealth: state.dashboardHealth || null,
-    sourceCleanliness: state.sourceCleanliness || null,
-    ledgerHealth: state.ledgerHealth || null,
-    gateQuality: state.gateQuality
-      ? {
-          posture: state.gateQuality.posture,
-          blockers: state.gateQuality.blockers || [],
-          warnings: state.gateQuality.warnings || [],
-          nextActionHint: state.gateQuality.nextActionHint || "",
-        }
-      : null,
-    fixedControl: state.fixedControl || null,
-    preflight: state.preflight
-      ? {
-          status: state.preflight.status,
-          blockers: state.preflight.blockers || [],
-          warnings: state.preflight.warnings || [],
-          nextCommand: state.preflight.nextCommand || "",
-        }
-      : null,
-    loopContract: compactDecisionEnvelope?.loopContract,
-    approvalLedger: state.approvalLedger || null,
-    resourcePreflight: state.resourcePreflight || null,
-    evidenceMaturity: state.evidenceMaturity || null,
-    laneOrchestration: state.laneOrchestration || null,
-    finalizationRunway: state.finalizationRunway || null,
-    operatorReadout: compactDecisionEnvelope?.operatorReadout || state.operatorReadout || null,
-    laneLifecycle: compactLaneLifecycle(state.laneLifecycle),
-    packetDiagnostics: state.packetDiagnostics,
-    metricSemanticsWarning: state.metricSemanticsWarning || null,
-  });
-}
-
-function commandExecutionBoundaryForState({
-  state,
-  lastRun,
-}: {
-  state: LooseObject;
-  lastRun?: LooseObject | null;
-}): LooseObject | null {
-  const boundary =
-    lastRun?.packetEvidence?.commandExecutionBoundary ||
-    [...(Array.isArray(state.current) ? state.current : [])]
-      .reverse()
-      .map((run: LooseObject) => run.commandExecutionBoundary)
-      .find(Boolean);
-  if (!boundary) return null;
-  return {
-    mode: String(boundary),
-    note: COMMAND_EXECUTION_BOUNDARY.note,
-    recommendation: COMMAND_EXECUTION_BOUNDARY.recommendation,
-  };
-}
-
-function compactEnvelope(envelope: LooseObject | null | undefined): LooseObject | null {
-  if (!envelope) return null;
-  return {
-    activeSegment: envelope.activeSegment || null,
-    historicalBest: envelope.historicalBest || null,
-    promotionGradeBest: envelope.promotionGradeBest || null,
-    latestPacketFreshness: envelope.latestPacketFreshness || null,
-    benchmarkConfigDrift: envelope.benchmarkConfigDrift || null,
-    dirtySourceDrift: envelope.dirtySourceDrift || null,
-    sourceCleanliness: envelope.sourceCleanliness || null,
-    goalContract: envelope.goalContract || null,
-    approvalLedger: envelope.approvalLedger || null,
-    resourcePreflight: envelope.resourcePreflight || null,
-    evidenceMaturity: envelope.evidenceMaturity || null,
-    laneOrchestration: envelope.laneOrchestration || null,
-    finalizationRunway: envelope.finalizationRunway || null,
-    budgetStatus: envelope.budgetStatus || null,
-    qualityRound: envelope.qualityRound || null,
-    scaffoldHealth: compactScaffoldHealth(envelope.scaffoldHealth),
-    researchIntegrity: envelope.researchIntegrity || null,
-    goalAdvice: envelope.goalAdvice || null,
-    finalizationReadiness: compactFinalizationReadiness(envelope.finalizationReadiness),
-    experimentEconomics: compactExperimentEconomics(envelope.experimentEconomics),
-    workflowFriction: Array.isArray(envelope.workflowFriction)
-      ? envelope.workflowFriction.slice(0, 5)
-      : [],
-    watchdog: envelope.watchdog || null,
-    contextDistillation: envelope.contextDistillation || null,
-    laneLifecycle: compactLaneLifecycle(envelope.laneLifecycle),
-    runtimeProvenance: envelope.runtimeProvenance || null,
-    packetDiagnostics: envelope.packetDiagnostics || null,
-    sessionDecisionCapsule: envelope.sessionDecisionCapsule || null,
-    nextAction: envelope.nextAction || "",
-    loopContract: envelope.loopContract || null,
-    canonicalNextAction: envelope.canonicalNextAction || null,
-    operatorReadout: envelope.operatorReadout || null,
-  };
-}
-
-function compactScaffoldHealth(scaffoldHealth: LooseObject | null | undefined): LooseObject | null {
-  if (!scaffoldHealth) return null;
-  return {
-    ok: scaffoldHealth.ok,
-    status: scaffoldHealth.status,
-    blockers: Array.isArray(scaffoldHealth.blockers)
-      ? scaffoldHealth.blockers.slice(0, 6)
-      : Array.isArray(scaffoldHealth.checks)
-        ? scaffoldHealth.checks
-            .filter((check: any) => check.severity === "blocker")
-            .map((check: any) => check.message || check.code)
-            .slice(0, 6)
-        : [],
-  };
-}
-
-function compactFinalizationReadiness(readiness: LooseObject | null | undefined): LooseObject {
-  return {
-    available: readiness?.available !== false,
-    ready: readiness?.ready === null ? null : readiness?.ready === true,
-    productGradeReady: readiness?.productGradeReady !== false,
-    productGradeIssue: readiness?.productGradeIssue || null,
-    nextAction: readiness?.nextAction || readiness?.recommendation || "",
-    warnings: Array.isArray(readiness?.warnings) ? readiness.warnings.slice(0, 3) : [],
-  };
-}
-
-function compactExperimentEconomics(economics: LooseObject | null | undefined): LooseObject | null {
-  if (!economics) return null;
-  return {
-    runtimeClass: economics.runtimeClass,
-    expectedRuntimeSeconds: economics.expectedRuntimeSeconds ?? null,
-    baselineFreshness: economics.baselineFreshness,
-    freshRunRequired: economics.freshRunRequired === true,
-    freshRunReason: economics.freshRunReason || "",
-    warnings: Array.isArray(economics.warnings) ? economics.warnings.slice(0, 3) : [],
-    progress: economics.progress || null,
-  };
-}
-
-function compactLaneLifecycle(laneLifecycle: LooseObject | null | undefined): LooseObject | null {
-  if (!laneLifecycle) return null;
-  const lanes = Array.isArray(laneLifecycle.lanes) ? laneLifecycle.lanes : [];
-  return {
-    stale: laneLifecycle.stale === true,
-    counts: {
-      planned: Array.isArray(laneLifecycle.plannedLanes) ? laneLifecycle.plannedLanes.length : 0,
-      running: Array.isArray(laneLifecycle.runningLanes) ? laneLifecycle.runningLanes.length : 0,
-      result: Array.isArray(laneLifecycle.resultLanes) ? laneLifecycle.resultLanes.length : 0,
-      stale: Array.isArray(laneLifecycle.staleLanes) ? laneLifecycle.staleLanes.length : 0,
-    },
-    lanes: lanes.slice(0, 6).map((lane: any) => ({
-      id: lane.id,
-      title: lane.title || lane.label,
-      status: lane.status,
-      mode: lane.mode,
-      evidenceStatus: lane.evidenceStatus,
-      nextActionHint: lane.nextActionHint,
-      brief: lane.brief || null,
-    })),
-    lessonsToAvoid: Array.isArray(laneLifecycle.lessonsToAvoid)
-      ? laneLifecycle.lessonsToAvoid.slice(0, 8)
-      : [],
-    recommendation: laneLifecycle.recommendation || "",
-    command: laneLifecycle.command || "",
-  };
-}
-
-function compactRuntimeAuthority(value: LooseObject | null | undefined): LooseObject | null {
-  if (!value) return null;
-  return {
-    sourceRuntime: value.sourceRuntime || null,
-    installedRuntime: value.installedRuntime || null,
-    trustScope: value.trustScope || "source-checkout",
-    blocking: value.blocking === true,
-    blocker: value.blocker || "",
-    warning: value.warning || "",
-  };
-}
-
-function compactPortfolioRecommendation(value: LooseObject | null | undefined): LooseObject | null {
-  if (!value) return null;
-  return {
-    kind: value.kind || "insufficient-evidence",
-    confidence: value.confidence || "low",
-    reason: value.reason || "",
-    nextActionHint: value.nextActionHint || "",
-    evidence: Array.isArray(value.evidence) ? value.evidence.slice(0, 6) : [],
-  };
-}
-
-async function dashboardHealthForWorkDir(workDir: string): Promise<LooseObject> {
-  const record = await readServeRegistry(workDir);
-  return verifyDashboardHealthSummary(
-    buildServeRegistryHealthInput(workDir, record, {
-      expectedVersion: PLUGIN_VERSION,
-      timeoutMs: 500,
-    }),
-  );
 }
 
 function dashboardCommands(workDir: string, qualityGap: any = null) {
@@ -8887,378 +7997,6 @@ function currentQualityGapSlug(workDir: string) {
   return activeQualityGapSlugCandidatesSync(workDir)[0]?.slug || null;
 }
 
-async function doctorSession(args: LooseObject): Promise<LooseObject> {
-  const { sessionCwd, workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
-  const state: LooseObject = await publicState({ ...args, compact: false });
-  const primaryMetricName =
-    args.metric_name || args.metricName || config.metricName || state.config.metricName || "metric";
-  const issues = [];
-  const warnings = [];
-  const warningDetails = [];
-  const inGit = await insideGitRepo(workDir);
-
-  if (!state.config.metricName) issues.push("No primary metric is configured.");
-  if (state.runs === 0)
-    warnings.push("No runs are logged yet. Run a baseline before experimenting.");
-  warnings.push(...(state.memory?.warnings || []));
-  if (!inGit)
-    warnings.push(
-      "Working directory is not a Git repository; keep commits and discard reverts are unavailable.",
-    );
-  const operatorDetails = Array.isArray(state.warningDetails) ? state.warningDetails : [];
-  for (const detail of operatorDetails) {
-    if (!detail?.message) continue;
-    warningDetails.push(detail);
-    if (
-      detail.code === "benchmark_contract_changed" ||
-      String(detail.code || "").startsWith("protected_benchmark_")
-    ) {
-      if (detail.severity === "error" || detail.code === "benchmark_contract_changed") {
-        issues.push(detail.message);
-      } else {
-        warnings.push(detail.message);
-      }
-    } else warnings.push(detail.message);
-  }
-  for (const check of state.scaffoldHealth?.checks || []) {
-    if (!check?.message) continue;
-    warningDetails.push(check);
-    warnings.push(check.message);
-    if (check.severity === "blocker") issues.push(check.message);
-  }
-  for (const warning of state.researchIntegrity?.warnings || []) {
-    warnings.push(warning);
-  }
-  for (const blocker of state.researchIntegrity?.blockers || []) {
-    issues.push(blocker);
-  }
-  const catalogTrust = await catalogTrustCheck(config, sessionCwd).catch((error: unknown) => ({
-    ok: false,
-    issues: [`Trusted recipe catalog could not be revalidated: ${errorMessage(error)}`],
-  }));
-  if (!catalogTrust.ok) issues.push(...catalogTrust.issues);
-  const drift = await buildDriftReport({
-    pluginRoot: PLUGIN_ROOT,
-    includeInstalled: boolOption(args.check_installed ?? args.checkInstalled, false),
-  });
-  const checkInstalledRuntime = boolOption(args.check_installed ?? args.checkInstalled, false);
-  const runtimeDriftSummary = await inspectRuntimeDrift({
-    packageRoot: PLUGIN_ROOT,
-    sourceVersion: PLUGIN_VERSION,
-  });
-  let benchmarkCommandHint = "";
-  let benchmarkCommandSource: Awaited<ReturnType<typeof resolveBenchmarkCommandSource>> | null =
-    null;
-  try {
-    benchmarkCommandSource = await resolveBenchmarkCommandSource(args, workDir, {
-      fallbackToDefault: true,
-      config,
-    });
-    benchmarkCommandHint = benchmarkCommandSource.command;
-  } catch (error: unknown) {
-    pushUniqueMessage(issues, errorMessage(error));
-  }
-  warnings.push(...drift.warnings);
-  const guidance = await decisionGuidance({
-    workDir,
-    config,
-    state,
-    scaffoldHealth: state.scaffoldHealth,
-    warningDetails,
-    runtimeDriftSummary,
-    runtimeTrustScope: checkInstalledRuntime ? "installed-plugin" : "source-checkout",
-    benchmarkCommand: benchmarkCommandHint,
-  });
-  const publicCommandAuthority = publicCommandPayload(guidance.commandAuthority);
-  const publicPreflight = publicCommandPayload(guidance.preflight);
-  const runtimeAuthority = (guidance.runtimeAuthority || null) as LooseObject | null;
-  if (runtimeAuthority?.blocking === true) {
-    pushUniqueMessage(issues, runtimeAuthority.blocker);
-  }
-  for (const blocker of guidanceBlockers(guidance)) {
-    if (!hasSharperDoctorBlocker(state, blocker)) {
-      pushUniqueMessage(issues, blocker);
-    }
-  }
-  for (const warning of guidanceWarnings(guidance)) pushUniqueMessage(warnings, warning);
-  const loopAuthority = doctorLoopContractAuthority(
-    withCanonicalActionCommand(
-      buildDecisionEnvelope({
-        state: {
-          ...state,
-          gateQuality: guidance.gateQuality,
-          preflight: publicPreflight,
-          portfolioRecommendation: null,
-          runtimeDriftSummary,
-          runtimeAuthority: guidance.runtimeAuthority,
-          scaffoldHealth: state.scaffoldHealth,
-        },
-        nextAction: "Run the next experiment, then log keep or discard with ASI.",
-        finalization: state.decisionEnvelope?.finalizationReadiness || null,
-      }),
-      continuationCommands(workDir),
-    ),
-  );
-  for (const blocker of loopAuthority.blockers) pushUniqueMessage(issues, blocker);
-
-  const benchmark: LooseObject = {
-    checked: false,
-    command: args.command || "",
-    packetEnvMode: null,
-    emitsPrimary: null,
-    parsedMetrics: {},
-    exitCode: null,
-    timedOut: false,
-    metricError: null,
-    progress: null,
-  };
-
-  if (boolOption(args.check_benchmark ?? args.checkBenchmark, false)) {
-    benchmark.checked = true;
-    benchmarkCommandSource =
-      benchmarkCommandSource ||
-      (await resolveBenchmarkCommandSource(args, workDir, {
-        fallbackToDefault: true,
-        requireCommand: false,
-        config,
-      }));
-    benchmark.command = benchmarkCommandSource.command;
-    if (!benchmark.command) {
-      benchmark.metricError =
-        benchmarkCommandSource.missingReason || missingBenchmarkCommandMessage();
-      issues.push(benchmark.metricError);
-    } else {
-      const fixedControlBlock = fixedControlBlockForCommand(benchmark.command, config, args);
-      if (fixedControlBlock) {
-        benchmark.fixedControlViolation = fixedControlBlock.fixedControlViolation;
-        benchmark.metricError = fixedControlBlock.issue;
-        issues.push(fixedControlBlock.issue);
-      } else {
-        const latestContract = latestBenchmarkContractEntry(workDir, state)?.benchmarkContract;
-        const doctorPacketEnvMode =
-          latestContract && Object.hasOwn(latestContract, "packetEnvMode")
-            ? packetEnvModeFromArgs({ packetEnvMode: latestContract.packetEnvMode })
-            : "inherit";
-        benchmark.packetEnvMode = doctorPacketEnvMode;
-        const run = await runShell(
-          benchmark.command,
-          workDir,
-          numberOption(args.timeout_seconds ?? args.timeoutSeconds, 60),
-          {
-            envMode: doctorPacketEnvMode,
-            retainMetricNames: [primaryMetricName],
-          },
-        );
-        benchmark.exitCode = run.exitCode;
-        benchmark.timedOut = run.timedOut;
-        benchmark.parsedMetrics = parseMetricLines(metricParseSource(run));
-        benchmark.emitsPrimary = finiteMetric(benchmark.parsedMetrics[primaryMetricName]) != null;
-        benchmark.progress = buildRunProgress({
-          benchmark: run,
-          checks: null,
-          checksCommand: null,
-          passed: run.exitCode === 0 && !run.timedOut && benchmark.emitsPrimary,
-        });
-        if (run.exitCode !== 0 || run.timedOut) {
-          issues.push(
-            `Benchmark command failed during doctor check: exit ${run.exitCode ?? "none"}${run.timedOut ? " (timed out)" : ""}.`,
-          );
-        } else if (!benchmark.emitsPrimary) {
-          benchmark.metricError = `Benchmark did not emit primary metric METRIC ${primaryMetricName}=<number>.`;
-          issues.push(benchmark.metricError);
-        }
-        const driftWarning = benchmarkDriftWarning({
-          currentMetric: benchmark.parsedMetrics[primaryMetricName],
-          bestMetric: state.best,
-          direction: state.config.bestDirection,
-          metricName: primaryMetricName,
-        });
-        if (driftWarning) warnings.push(driftWarning);
-      }
-    }
-  }
-
-  let nextAction = "Run the next experiment, then log keep or discard with ASI.";
-  if (runtimeAuthority?.blocking === true) {
-    nextAction =
-      String(runtimeAuthority.blocker || "").trim() ||
-      "Inspect or refresh the installed plugin runtime before claiming installed behavior.";
-  } else if (loopAuthority.canonicalNextAction?.safeAction === "ledger-doctor") {
-    nextAction = "Run ledger-doctor before another packet.";
-  } else if (loopAuthority.nextAction) {
-    nextAction = loopAuthority.nextAction;
-  } else if (issues.some((issue: any) => /contract changed/i.test(issue))) {
-    nextAction =
-      "Start a new segment or explicitly invalidate the old evidence before running another packet.";
-  } else if (issues.some((issue: any) => /primary metric|benchmark/i.test(issue))) {
-    nextAction =
-      "Fix the benchmark command so it emits the configured primary metric before continuing.";
-  } else if (issues.some((issue: any) => /fixed_control_rerun_blocked/i.test(String(issue)))) {
-    nextAction = "Reuse the fixed control artifact instead of running the benchmark check.";
-  } else if (state.runs === 0) {
-    nextAction = "Run and log a baseline before trying optimizations.";
-  } else if (state.limit.limitReached) {
-    nextAction = "Iteration limit reached; export the dashboard or start a new segment.";
-  } else if (warnings.some((warning: any) => /dirty/.test(String(warning)))) {
-    nextAction = "Review the dirty Git state before logging a kept result.";
-  }
-
-  const commandExecutionBoundary = benchmarkCommandHint
-    ? {
-        mode: COMMAND_EXECUTION_BOUNDARY.mode,
-        note: COMMAND_EXECUTION_BOUNDARY.note,
-        recommendation: COMMAND_EXECUTION_BOUNDARY.recommendation,
-      }
-    : null;
-  const activeBenchmarkContractEntry =
-    state.code === "ledger_jsonl_invalid" ? null : latestBenchmarkContractEntry(workDir, state);
-  const contractDiagnostics = benchmarkContractDiagnostics({
-    state,
-  });
-  const continuationState =
-    state.code === "ledger_jsonl_invalid"
-      ? { current: [], allRecords: [], ...state }
-      : currentState(workDir);
-  const benchmarkContractChanged = warningDetails.some(
-    (detail: any) => detail?.code === "benchmark_contract_changed",
-  );
-  const publicBenchmark = {
-    ...benchmark,
-    command: redactCommandDisplay(benchmark.command),
-  };
-
-  const result: LooseObject = {
-    ok: issues.length === 0,
-    workDir,
-    config: state.config,
-    state,
-    git: {
-      inside: inGit,
-      clean: state.decisionEnvelope?.dirtySourceDrift?.dirty === true ? false : true,
-    },
-    benchmarkContract: {
-      ok: benchmarkContractChanged === false,
-      activeSource: contractDiagnostics.activeSource,
-      activeContract: contractDiagnostics.activeContract,
-      historicalContracts: contractDiagnostics.historicalContracts,
-      historical: contractDiagnostics.historicalContracts.length > 0,
-      segmentEntry: activeBenchmarkContractEntry?.benchmarkContractScope === "segment",
-    },
-    benchmark: publicBenchmark,
-    drift,
-    runtimeDriftSummary,
-    runtimeAuthority: guidance.runtimeAuthority,
-    gateQuality: guidance.gateQuality,
-    commandAuthority: publicCommandAuthority,
-    preflight: publicPreflight,
-    decisionEnvelope: loopAuthority.decisionEnvelope,
-    loopContract: loopAuthority.loopContract,
-    canonicalNextAction: loopAuthority.canonicalNextAction,
-    commandExecutionBoundary,
-    runtimeProvenance: runtimeProvenance(drift),
-    scaffoldHealth: state.scaffoldHealth,
-    researchIntegrity: state.researchIntegrity,
-    issues,
-    warnings,
-    warningDetails,
-    nextAction,
-    continuation: loopContinuation(workDir, continuationState, config, "doctor"),
-  };
-  if (boolOption(args.explain, false)) result.explanation = doctorExplanation(result);
-  return result;
-}
-
-async function catalogTrustCheck(config: LooseObject, sessionCwd: string) {
-  const provenance = config.recipeCatalogProvenance || config.recipe_catalog_provenance || null;
-  if (!provenance) return { ok: true, issues: [] as string[] };
-  return await revalidateRecipeCatalogProvenance(provenance, { catalogBaseDir: sessionCwd });
-}
-
-function benchmarkDriftWarning({ currentMetric, bestMetric, direction, metricName }: LooseObject) {
-  const current = finiteMetric(currentMetric);
-  const best = finiteMetric(bestMetric);
-  if (current == null || best == null || best === 0) return "";
-  const worse =
-    direction === "higher"
-      ? current < best && Math.abs((best - current) / best) >= 0.25
-      : current > best && Math.abs((current - best) / best) >= 0.25;
-  if (!worse) return "";
-  return `Benchmark drift: current ${metricName}=${current} is far worse than historical best ${best}. Treat the old best as historical evidence, not current runtime proof.`;
-}
-
-function doctorExplanation(result: LooseObject): LooseObject {
-  const runtimeSummary = result.runtimeDriftSummary || null;
-  return {
-    verdict: result.ok
-      ? "Doctor found no blocking issues."
-      : "Doctor found issues that must be fixed before trusting the loop.",
-    priorityFixes: [
-      ...(result.issues || []),
-      ...(result.warnings || []).filter((warning: any) =>
-        /dirty|drift|benchmark|missing|stale|commitPaths/i.test(String(warning)),
-      ),
-    ].slice(0, 5),
-    runtimeDriftSummary: runtimeSummary
-      ? {
-          installedRuntime: runtimeSummary.installedRuntime,
-          builtRuntime: runtimeSummary.builtRuntime,
-          smokeCheck: runtimeSummary.smokeCheck,
-          nextActionHint: runtimeSummary.nextActionHint,
-        }
-      : null,
-    runtimeAuthority: result.runtimeAuthority || null,
-    gateQuality: result.gateQuality || null,
-    preflight: result.preflight || null,
-    nextSafeAction: result.nextAction,
-    commandExecutionBoundary: result.commandExecutionBoundary || null,
-    readAs:
-      "Issues block the loop. Warnings reduce trust and should be resolved before keeping results when they affect evidence, Git, or runtime drift.",
-  };
-}
-
-function guidanceBlockers(guidance: LooseObject): string[] {
-  const blockers = [
-    ...listOption(guidance.gateQuality?.blockers),
-    ...(guidance.preflight?.status === "blocked" ? listOption(guidance.preflight?.blockers) : []),
-  ]
-    .map((blocker: any) => String(blocker || "").trim())
-    .filter(Boolean);
-  if (guidance.preflight?.status === "blocked" && blockers.length === 0) {
-    blockers.push("Preflight readiness is blocked.");
-  }
-  return uniqueStrings(blockers);
-}
-
-function guidanceWarnings(guidance: LooseObject): string[] {
-  return uniqueStrings([
-    ...listOption(guidance.gateQuality?.warnings),
-    ...listOption(guidance.preflight?.warnings),
-  ]);
-}
-
-function doctorLoopContractAuthority(decisionEnvelope: LooseObject | null | undefined) {
-  const envelope = decisionEnvelope || {};
-  const loopContract = envelope.loopContract || null;
-  const canonicalNextAction = envelope.canonicalNextAction || null;
-  const blockers = Array.isArray(loopContract?.blockers)
-    ? loopContract.blockers.map(actionMessage).filter(Boolean)
-    : [];
-  const strongestActionMessage = actionMessage(loopContract?.strongestAction);
-  if (blockers.length === 0 && strongestActionMessage && loopContract?.ok === false) {
-    blockers.push(strongestActionMessage);
-  }
-  return {
-    decisionEnvelope: envelope,
-    loopContract,
-    canonicalNextAction,
-    blockers: uniqueStrings(blockers),
-    nextAction:
-      blockers.length > 0
-        ? actionMessage(canonicalNextAction) || strongestActionMessage || blockers[0]
-        : "",
-  };
-}
-
 function actionMessage(value: unknown): string {
   if (typeof value === "string") return value.trim();
   if (!value || typeof value !== "object" || Array.isArray(value)) return "";
@@ -9266,41 +8004,6 @@ function actionMessage(value: unknown): string {
   return String(
     record.reason || record.message || record.nextActionHint || record.title || record.kind || "",
   ).trim();
-}
-
-function pushUniqueMessage(target: any[], message: unknown) {
-  const text = String(message || "").trim();
-  if (text && !target.includes(text)) target.push(text);
-}
-
-function hasSharperDoctorBlocker(state: LooseObject, blocker: unknown = ""): boolean {
-  if (hasScaffoldBlocker(state.scaffoldHealth)) return true;
-  if (
-    blocker &&
-    shouldSuppressPreflightGateBlockerForCapsule(
-      { sessionDecisionCapsule: state.sessionDecisionCapsule },
-      blocker,
-    )
-  ) {
-    return true;
-  }
-  if (
-    blocker &&
-    shouldSuppressPreflightGateBlockerForCapsule(
-      { sessionDecisionCapsule: state.decisionEnvelope?.sessionDecisionCapsule },
-      blocker,
-    )
-  ) {
-    return true;
-  }
-  return false;
-}
-
-function hasScaffoldBlocker(scaffoldHealth: unknown): boolean {
-  const checks = Array.isArray((scaffoldHealth as LooseObject | null)?.checks)
-    ? (scaffoldHealth as LooseObject).checks
-    : [];
-  return checks.some((check: any) => check?.severity === "blocker");
 }
 
 async function doctorHooks(args: LooseObject = {}): Promise<LooseObject> {


### PR DESCRIPTION
## Context

Refs #223. Parent epic: #231.

`state`, `state --compact`, and `doctor` were still implemented inside `scripts/autoresearch.ts`, which made the CLI entrypoint own read-only session readout, ledger repair guidance, doctor readiness, runtime drift, and compact-state shaping alongside command dispatch. This slice keeps behavior intact while moving those read-only service bodies behind focused command-service boundaries.

## What Changed

- Added `lib/commands/doctor.ts` with the `doctor` command service body and doctor-only helper logic.
- Extended `lib/commands/state.ts` from compact response shaping into the read-only state/compact-state command service boundary.
- Reduced `scripts/autoresearch.ts` back toward CLI wiring by delegating read-only `state`/compact-state/doctor work to the command services.
- Preserved the wrapper anchors in `scripts/autoresearch.ts` that existing command-surface/perfection tests still inspect, while removing unused wrappers that triggered hosted lint warnings.
- Replaced new command-service local loose-object aliases with the repo's `UnknownRecord`-based command record shape so source hygiene stays clean.

## How To Review

- Start with `scripts/autoresearch.ts` and confirm the command dispatch/wiring remains there while the read-only service bodies moved out.
- Review `lib/commands/state.ts` for state/compact-state behavior preservation, especially ledger parse repair guidance and compact response shaping.
- Review `lib/commands/doctor.ts` for doctor readiness behavior preservation, especially benchmark check, runtime drift, and loop-contract authority handling.
- Confirm no packet lifecycle, `runExperiment`, `nextExperiment`, `logExperiment`, Git mutation, discard cleanup, or commit-path behavior moved.

## Verification

- `npm install` from `plugins/codex-autoresearch`: passed.
- `npm run typecheck` from `S:\plugins\codex-autoresearch`: passed after rebasing onto `origin/dev` `cd589b2702966aeca1ac73230dcf655bae8fe703`.
- Focused read-only CLI surface: `node --test --test-name-pattern "state|doctor|recommend-next" dist\tests\autoresearch-cli.test.mjs`: passed, 53 tests / 0 failures.
- Path-sensitive repro: from the requested worktree path, `npm run test:cli` failed one assertion because the path contains `issue-223-state-doctor-services` and the test asserts a command string does not match `/\bstate\b/`. From neutral `S:` path after rebuilding, `node --test --test-name-pattern "session-forensics routes context distillation" dist\tests\autoresearch-cli.test.mjs` passed, 1 test / 0 failures.
- Serial neutral-path compiled CLI gate: `node dist\scripts\run-test-shards.mjs --jobs 1 dist\tests\autoresearch-cli.test.mjs 24 dist\tests\full-product.test.mjs 4 dist\tests\perfection-benchmark.test.mjs 1`: passed, shard wall time 532.5s.
- `npm run lint`: passed, 0 warnings / 0 errors.
- `npm run typecheck`: passed.
- `npm run format:check`: passed.
- `npm run test:core` from `S:\plugins\codex-autoresearch`: passed, 280 tests / 0 failures in the focused run; the full package gate later passed the compiled core suite with 284 tests / 0 failures.
- `npm run command-surface-map`: passed, 35 public commands, missing=0, issues=0.
- `git diff --check`: passed.
- `npm run check` from neutral `S:\plugins\codex-autoresearch`: passed, including package runtime smoke.
- Hosted checks for head `30ff84e8902c2927ba63dfc1a293ea3e4f97a7df`: Workflow policy, ubuntu-latest, macos-latest, windows-latest, CodeQL actions, and CodeQL javascript-typescript all passed.

## Risk

- The change uses dependency-injected command services to keep the extraction small; this preserves behavior but leaves some shared readout helpers in `scripts/autoresearch.ts` until later slices can move them with narrower ownership.
- `npm run test:cli` remains path-sensitive when the checkout path contains the word `state`; the neutral-path rerun and hosted green checks show the observed local failure is environmental/test-fragility rather than a #223 behavior regression. A separate hardening issue may be useful for that assertion.
