### PR TITLE
Make session-forensics command assertions path-insensitive

### DIFF
--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -1424,7 +1424,13 @@ test("session-forensics supports dry-run and safe apply capsule writes", async (
 });
 
 test("session-forensics routes context distillation to apply despite stale safe hints", () => {
-  const script = path.join(pluginRoot, "scripts", "autoresearch.mjs");
+  const script = path.join(pluginRoot, "state", "scripts", "autoresearch.mjs");
+  const subcommandFor = (command: string) => {
+    const launcherIndex = command.indexOf("autoresearch.mjs");
+    assert.notEqual(launcherIndex, -1);
+    const tokens = command.slice(launcherIndex + "autoresearch.mjs".length).trim().split(/\s+/);
+    return tokens[0];
+  };
   const commands = {
     state: `node ${script} state --cwd C:\\repo --compact`,
     recommendNext: `node ${script} recommend-next --cwd C:\\repo --compact`,
@@ -1447,11 +1453,10 @@ test("session-forensics routes context distillation to apply despite stale safe 
     );
 
     assert.match(command, /session-forensics/);
+    assert.equal(subcommandFor(command), "session-forensics");
     assert.match(command, /--apply/);
     assert.match(command, /--session-jsonl rollout\.jsonl/);
     assert.match(command, /--research-slug session-019e/);
-    assert.doesNotMatch(command, /recommend-next/);
-    assert.doesNotMatch(command, /\bstate\b/);
   }
 });
 

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -1428,7 +1428,10 @@ test("session-forensics routes context distillation to apply despite stale safe 
   const subcommandFor = (command: string) => {
     const launcherIndex = command.indexOf("autoresearch.mjs");
     assert.notEqual(launcherIndex, -1);
-    const tokens = command.slice(launcherIndex + "autoresearch.mjs".length).trim().split(/\s+/);
+    const tokens = command
+      .slice(launcherIndex + "autoresearch.mjs".length)
+      .trim()
+      .split(/\s+/);
     return tokens[0];
   };
   const commands = {


### PR DESCRIPTION
## Context

Refs #239

The `session-forensics routes context distillation` CLI test checked for stale `state` routing by matching against the entire rendered command. That made the assertion sensitive to checkout paths containing a standalone `state` segment, even when the selected subcommand was `session-forensics`.

## What Changed

- Added a path-sensitive fixture path segment in the existing session-forensics routing test.
- Replaced whole-command negative subcommand matching with a subcommand-token assertion after `autoresearch.mjs`.

## How To Review

- Review `plugins/codex-autoresearch/tests/autoresearch-cli.test.ts` only.
- Confirm the assertion still fails if `commandForDecisionCapsule` returns `state` or `recommend-next` as the actual subcommand.

## Verification

- `npm run build:node` - passed.
- `node --test --test-name-pattern "session-forensics routes context distillation" dist\tests\autoresearch-cli.test.mjs` - passed: 1 test, 0 failures.
- `git diff --check` - passed.

Additional friction: `npm run test:cli` was attempted and exited 1 because `autoresearch-cli.test.mjs 13/23` hit the shard wall timeout after 300 seconds. The listed tests in that shard passed before the harness timeout; this PR uses the requested narrow proof above.

## Risk

Low. This is a test-only change scoped to the existing session-forensics route assertion; CLI behavior is unchanged.