### PR TITLE
[codex] Wire release provenance smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,3 +175,20 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "$TAG" \
             --generate-notes
+
+      - name: Smoke release provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          tarball="codex-autoresearch-${VERSION}.tgz"
+          checksum="$tarball.sha256"
+          node scripts/check.mjs --phase release-provenance-smoke \
+            --tarball "$tarball" \
+            --checksum "$checksum" \
+            --tag "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target-commit "$GITHUB_SHA" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"


### PR DESCRIPTION
## Context

The release workflow already builds and attests the package, runs `release-package-smoke`, and creates the GitHub release. It did not run the existing release provenance policy after the release assets existed.

Refs #245

## What Changed

- Added a post-`gh release create` `Smoke release provenance` step in `.github/workflows/release.yml`.
- The step runs `node scripts/check.mjs --phase release-provenance-smoke` with the tarball, checksum, tag, repository, target commit, and signer workflow from the live release job context.

## How To Review

- Check that the new step runs after `Create GitHub release with tarball`, not before it.
- Check that the command passes `--tag "$TAG"`, `--repo "$GITHUB_REPOSITORY"`, `--target-commit "$GITHUB_SHA"`, and `--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"`.
- Confirm this PR does not change runtime bootstrap, check hydration, or test shard behavior.

## Verification

- `node -e '<static workflow order/context assertion>'` -> `release provenance smoke wired after gh release create`
- `node scripts/check.mjs --phase release-provenance-smoke --tarball <fixture> --checksum <fixture.sha256> --release-json <fixture> --attestation-json <fixture> --repo TheGreenCedar/codex-autoresearch --target-commit 622959562359e2c608f2bfa8e6fa91340751d7af --signer-workflow TheGreenCedar/codex-autoresearch/.github/workflows/release.yml` -> `ok release-provenance-smoke`
- `git diff --check -- .github\workflows\release.yml` -> passed
- `node .github\scripts\check-workflow-policy.mjs` -> passed

## Risk

- No real GitHub release was created or verified locally. The remaining live risk is whether GitHub's release JSON exposes asset digests immediately enough after `gh release create`; if it does not, the release job will fail closed after creating the release and before reporting success.
- The local checkout had unrelated dirty files in `plugins/codex-autoresearch/scripts/run-test-shards.ts` and `plugins/codex-autoresearch/tests/autoresearch-cli.test.ts`; they were not staged or committed.
