### PR TITLE
Document Git-private autoresearch session snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ setup -> doctor -> next -> log -> state -> finalize-preview
 
 - Benchmark commands must print `METRIC name=value`. The primary metric drives decisions; secondary metrics explain or guard tradeoffs.
 - Use `ARTIFACT name=path` only for benchmark-produced evidence that resolves inside the target working directory.
-- Prefer durable loop state over chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.config.json`, `autoresearch.ideas.md`, `autoresearch.last-run.json`, `autoresearch.research/<slug>/`, evidence index files, and ASI.
+- Prefer durable loop state over chat memory: `autoresearch.md`, `autoresearch.jsonl`, `autoresearch.config.json`, `autoresearch.ideas.md`, Git-private `.git/autoresearch/last-run.json`, `.git/autoresearch/progress.json`, `.git/autoresearch/pending-log-*.json`, non-Git fallback `autoresearch.last-run.json`, `autoresearch.progress.json`, `autoresearch.pending-transaction.json`, `autoresearch.research/<slug>/`, evidence index files, and ASI.
 - `keep`, ordinary `discard`, and `measure` need a finite primary metric. `crash` and `checks_failed` must not invent sentinel metric values.
 - Use `measure` for baselines, no-change probes, environment checks, and diagnostic evidence. It is not a keep and not a finalizer input.
 - `quality_gap=0` only closes the accepted checklist for the current research round. It does not prove discovery is complete forever.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Checks: npm test
 Scope: test runner config and test helpers only
 ```
 
-Autoresearch stores loop evidence in local project files and runs approved benchmark/check commands with local process permissions. Read [Privacy](plugins/codex-autoresearch/docs/privacy.md), [Terms](plugins/codex-autoresearch/docs/terms.md), and [Trust](plugins/codex-autoresearch/docs/trust.md) before using it on repos with secrets, sensitive data, external APIs, or expensive commands.
+Autoresearch stores loop evidence in local project files and, in Git repos, active snapshots and pending log receipts under Git-private `.git/autoresearch/`. Outside Git, those transient records fall back to local files such as `autoresearch.last-run.json`, `autoresearch.progress.json`, and `autoresearch.pending-transaction.json`. Read [Privacy](plugins/codex-autoresearch/docs/privacy.md), [Terms](plugins/codex-autoresearch/docs/terms.md), and [Trust](plugins/codex-autoresearch/docs/trust.md) before using it on repos with secrets, sensitive data, external APIs, or expensive commands.
 
 Ask for the live dashboard in a side chat when you want a visual readout or need fresh run state in the browser.
 


### PR DESCRIPTION
## Context

Refs #247
Parent epic: #243

Detailed docs already describe the active session storage contract, but the root surfaces lagged behind:

- `plugins/codex-autoresearch/docs/start.md` lists Git-private `.git/autoresearch/` last-run/progress/pending-log records and non-Git fallback files.
- `plugins/codex-autoresearch/docs/privacy.md` explains the same privacy boundary.
- Root `README.md` and repo-local `AGENTS.md` still pointed readers at local project files without naming the Git-private active snapshot surface.

## What Changed

- Updated the root README safety warning to name local project files, Git-private `.git/autoresearch/` snapshots/receipts, and non-Git fallback files.
- Updated repo-local `AGENTS.md` durable-state guidance to include `.git/autoresearch/last-run.json`, `.git/autoresearch/progress.json`, `.git/autoresearch/pending-log-*.json`, and the non-Git fallback transient files.

## How To Review

- Read `README.md` around the Try it safety warning.
- Read `AGENTS.md` under Product Contract.
- Compare the wording against `plugins/codex-autoresearch/docs/start.md` and `plugins/codex-autoresearch/docs/privacy.md`.

## Verification

- `git diff --check` - passed with no output.
- Readback of changed Markdown completed for `README.md` and `AGENTS.md`.

## Risk

Low. Docs-only wording sync. No code, release workflow, shard runner, or watchdog implementation changed.
