### PR TITLE
Hydrate check launcher runtime

### DIFF
--- a/plugins/codex-autoresearch/lib/checks/package-smoke.ts
+++ b/plugins/codex-autoresearch/lib/checks/package-smoke.ts
@@ -349,6 +349,7 @@ function normalizedPackagePath(entry: PackageEntry) {
 async function packageWrapperProblems(packedEntries: Map<string, PackageEntry>) {
   const wrappers = [
     ["scripts/autoresearch.mjs", 'ensureRuntime("autoresearch.mjs"'],
+    ["scripts/check.mjs", 'ensureRuntime("check.mjs"'],
     ["scripts/finalize-autoresearch.mjs", 'ensureRuntime("finalize-autoresearch.mjs"'],
   ];
   const problems: string[] = [];

--- a/plugins/codex-autoresearch/scripts/check.mjs
+++ b/plugins/codex-autoresearch/scripts/check.mjs
@@ -1,2 +1,4 @@
 #!/usr/bin/env node
-await import(new URL("../dist/scripts/check.mjs", import.meta.url));
+import { ensureRuntime } from "./bootstrap-runtime.mjs";
+
+await import(await ensureRuntime("check.mjs", import.meta.url));

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -9759,6 +9759,9 @@ test("runShell configures a POSIX process group for timeout cleanup", async () =
     cliShim,
     /await import\(await ensureRuntime\("autoresearch\.mjs", import\.meta\.url\)\)/,
   );
+  const checkShim = await readFile(path.join(pluginRoot, "scripts", "check.mjs"), "utf8");
+  assert.match(checkShim, /import \{ ensureRuntime \} from "\.\/bootstrap-runtime\.mjs"/);
+  assert.match(checkShim, /await import\(await ensureRuntime\("check\.mjs", import\.meta\.url\)\)/);
   assert.match(bootstrap, /path\.join\(pluginRoot, "dist", "scripts", entrypoint\)/);
   assert.match(bootstrap, /verifyRuntimeTarballIntegrity/);
   assert.match(bootstrap, /\.tgz\.sha256/);


### PR DESCRIPTION
## Context

Refs #246
Parent: #243

`check:source-hygiene` is exposed as a source checkout command, but `scripts/check.mjs` imported `dist/scripts/check.mjs` directly. In a clean source-shaped checkout without `dist/`, the command failed before the source-hygiene phase could report anything useful.

## What Changed

- Route `scripts/check.mjs` through `ensureRuntime("check.mjs", import.meta.url)` like the other source launchers.
- Extend the package-smoke wrapper guard so packaged `scripts/check.mjs` must keep using `bootstrap-runtime.mjs`.
- Add launcher test coverage for the `check.mjs` wrapper contract.

## How To Review

- Start at `plugins/codex-autoresearch/scripts/check.mjs`; it is now a tiny bootstrap wrapper instead of a raw `dist` import.
- Check `plugins/codex-autoresearch/lib/checks/package-smoke.ts` for the guard that keeps this behavior in package smoke.
- Check `plugins/codex-autoresearch/tests/autoresearch-cli.test.ts` for the focused assertion.

## Verification

- Missing-`dist`, no-`node_modules` simulation before fix: `node scripts/check.mjs --phase source-hygiene` failed with `ERR_MODULE_NOT_FOUND` for `dist/scripts/check.mjs`.
- Missing-`dist`, no-`node_modules` simulation after fix: `node scripts/check.mjs --phase source-hygiene` exited 0 and printed `ok source-hygiene` after release hydration.
- Missing-`dist` local-build simulation after `npm ci`: removed ignored `dist/` and `assets/dashboard-build/`, then `node scripts/check.mjs --phase source-hygiene` exited 0 and printed `ok source-hygiene`.
- `node scripts/check.mjs --phase` exited 1 with usage output.
- `npm run build:node` exited 0.
- `npm run check:source-hygiene` exited 0.
- `node --test --test-name-pattern "runShell configures a POSIX process group for timeout cleanup" dist\\tests\\autoresearch-cli.test.mjs` exited 0.
- `git diff --check` exited 0.
- `npm run check` exited 0.

## Risk

Low. This reuses the existing runtime hydration path and keeps the source wrapper small. The main tradeoff is that a no-`node_modules` clean checkout hydrates the matching release runtime, while a checkout with dependencies can rebuild local source runtime first through the existing `ensureRuntime` behavior.