### PR TITLE
Stabilize compiled CLI test shards

### DIFF
--- a/plugins/codex-autoresearch/scripts/run-test-shards.ts
+++ b/plugins/codex-autoresearch/scripts/run-test-shards.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
+import { access } from "node:fs/promises";
 import { runCommand } from "./check-runner.js";
+
+const DEFAULT_TEST_FILE_READY_TIMEOUT_MS = 10_000;
+const TEST_FILE_READY_POLL_MS = 100;
 
 type ShardResult = {
   code: number | null;
@@ -57,6 +61,41 @@ function parsePositiveInteger(value: unknown, label: string): number {
     );
   }
   return parsed;
+}
+
+function parseNonNegativeInteger(value: unknown, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+async function waitForTestFile(file: string): Promise<void> {
+  const timeoutMs = parseNonNegativeInteger(
+    process.env.CODEX_AUTORESEARCH_TEST_SHARD_FILE_READY_TIMEOUT_MS ??
+      DEFAULT_TEST_FILE_READY_TIMEOUT_MS,
+    "CODEX_AUTORESEARCH_TEST_SHARD_FILE_READY_TIMEOUT_MS",
+  );
+  const startedAt = Date.now();
+  while (true) {
+    try {
+      await access(file);
+      return;
+    } catch (error) {
+      if (
+        !error ||
+        typeof error !== "object" ||
+        (error as { code?: unknown }).code !== "ENOENT" ||
+        Date.now() - startedAt >= timeoutMs
+      ) {
+        throw new Error(
+          `Compiled test file is not ready: ${file}\nRun npm run build:node before the compiled shard gate.`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, TEST_FILE_READY_POLL_MS));
+    }
+  }
 }
 
 function runNode(args: string[], env: NodeJS.ProcessEnv): Promise<ShardResult> {
@@ -162,6 +201,7 @@ function printResult(result: ShardResult): void {
 
 const startedAt = Date.now();
 const { jobs, specs } = parseArgs(process.argv.slice(2));
+await Promise.all(specs.map((spec) => waitForTestFile(spec.file)));
 const tasks = (
   await Promise.all(
     specs.map(async (spec) => {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -635,6 +635,48 @@ test("test shard runner validates jobs and fails closed on discovery gaps", asyn
       /AUTORESEARCH_TEST_COUNT/,
     );
 
+    const missingFile = path.join(dir, "missing-shard-target.test.mjs");
+    const missingFileResult = await runNode([shardRunner, missingFile, "2"], {
+      env: {
+        ...process.env,
+        CODEX_AUTORESEARCH_TEST_SHARD_FILE_READY_TIMEOUT_MS: "0",
+      },
+    });
+    assert.notEqual(missingFileResult.code, 0);
+    assert.match(
+      `${missingFileResult.stdout}\n${missingFileResult.stderr}`,
+      /Compiled test file is not ready/,
+    );
+
+    const delayedFile = path.join(dir, "delayed-sharded.test.mjs");
+    const delayedWrite = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        writeFile(
+          delayedFile,
+          [
+            "import test from 'node:test';",
+            "if (process.env.CODEX_AUTORESEARCH_TEST_DISCOVER === '1') {",
+            "  console.log('AUTORESEARCH_TEST_COUNT 1');",
+            "}",
+            "test('delayed file runs after readiness wait', () => {",
+            "  console.log('DELAYED_EXECUTION_MARKER');",
+            "});",
+          ].join("\n"),
+          "utf8",
+        ).then(resolve, reject);
+      }, 150);
+    });
+    const delayed = await runNode([shardRunner, "--jobs", "1", delayedFile, "2"], {
+      env: {
+        ...process.env,
+        CODEX_AUTORESEARCH_TEST_SHARD_FILE_READY_TIMEOUT_MS: "2000",
+        CODEX_AUTORESEARCH_TEST_SHARD_VERBOSE: "1",
+      },
+    });
+    await delayedWrite;
+    assert.equal(delayed.code, 0, delayed.stderr);
+    assert.match(`${delayed.stdout}\n${delayed.stderr}`, /DELAYED_EXECUTION_MARKER/);
+
     const unevenShardedFile = path.join(dir, "uneven-sharded.test.mjs");
     await writeFile(
       unevenShardedFile,


### PR DESCRIPTION
## Context

Refs #244

`npm run check` was intermittently failing in `test:compiled:cli` when early shard jobs could not see `dist/tests/autoresearch-cli.test.mjs`. The parent evidence showed a rerun of the failed shard passed, pointing at compiled artifact readiness rather than an assertion failure.

## What Changed

- Added a bounded readiness wait in `scripts/run-test-shards.ts` before shard discovery or execution starts for declared test files.
- Kept the runner fail-closed with a clearer message when a compiled test file never becomes available.
- Extended the existing shard-runner regression to cover missing files and a delayed file that appears after the runner starts.

## How To Review

- Start in `plugins/codex-autoresearch/scripts/run-test-shards.ts` and check that the new wait happens once for declared shard specs before discovery builds tasks.
- Then review `plugins/codex-autoresearch/tests/autoresearch-cli.test.ts` around the shard-runner test for the normal, missing-file, and late-file cases.

## Verification

- `npm run build:node` passed from `plugins/codex-autoresearch`.
- `node --test --test-name-pattern "test shard runner validates jobs and fails closed on discovery gaps" dist\\tests\\autoresearch-cli.test.mjs` passed.
- `npm run test:compiled:cli` passed; shard wall time 348.9s.
- `npm run check` passed on rerun. The first run failed earlier at dashboard asset parity after refreshing generated dashboard assets; tracked git status stayed scoped to this two-file change, and the rerun passed through package smoke.
- `git diff --check` passed.

## Risk

Low. The wait is bounded, defaults to 10 seconds, and only applies to explicitly requested shard test files before the runner starts discovery and shard workers. If the file never appears, the runner still fails closed with build guidance.