### PR TITLE
Fix release provenance smoke for auto-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+### Fixed
+
+- Fixed release provenance smoke validation for auto-release runs that call the reusable release workflow, where the certificate signer is `release.yml` but the SLSA predicate records `auto-release.yml` as the caller workflow path.
+
 ## 2.5.0 - 2026-06-21
 
 ### Changed

--- a/plugins/codex-autoresearch/lib/checks/package-smoke.ts
+++ b/plugins/codex-autoresearch/lib/checks/package-smoke.ts
@@ -561,9 +561,12 @@ export async function releaseProvenanceIssue(options: ReleaseProvenanceOptions):
 
   const expectedSan = `https://github.com/${signerWorkflow}@refs/heads/main`;
   const expectedRepoUri = `https://github.com/${repo}`;
-  const expectedWorkflowPath = signerWorkflow.slice(`${repo}/`.length);
+  const expectedSignerWorkflowPath = signerWorkflow.slice(`${repo}/`.length);
   const expectedBuilderUri = `https://github.com/${signerWorkflow}@refs/heads/main`;
   for (const entry of matching) {
+    const expectedWorkflowPath =
+      workflowPathFromBuildConfigUri(entry.certificate.buildConfigURI, repo) ||
+      expectedSignerWorkflowPath;
     const issues = [
       requireEqual(
         "certificate subjectAlternativeName",
@@ -708,6 +711,7 @@ function attestationPolicyView(entry: unknown) {
     certificate: {
       githubWorkflowRepository: stringField(certificate, "githubWorkflowRepository"),
       githubWorkflowSHA: stringField(certificate, "githubWorkflowSHA"),
+      buildConfigURI: stringField(certificate, "buildConfigURI"),
       runnerEnvironment: stringField(certificate, "runnerEnvironment"),
       sourceRepositoryDigest: stringField(certificate, "sourceRepositoryDigest"),
       sourceRepositoryRef: stringField(certificate, "sourceRepositoryRef"),
@@ -720,6 +724,7 @@ function attestationPolicyView(entry: unknown) {
     summary: JSON.stringify({
       certificate: {
         githubWorkflowRepository: stringField(certificate, "githubWorkflowRepository"),
+        buildConfigURI: stringField(certificate, "buildConfigURI"),
         sourceRepositoryDigest: stringField(certificate, "sourceRepositoryDigest"),
         sourceRepositoryRef: stringField(certificate, "sourceRepositoryRef"),
         subjectAlternativeName: stringField(certificate, "subjectAlternativeName"),
@@ -732,6 +737,13 @@ function attestationPolicyView(entry: unknown) {
       repository: stringField(workflow, "repository"),
     },
   };
+}
+
+function workflowPathFromBuildConfigUri(buildConfigUri: string, repo: string): string {
+  const prefix = `https://github.com/${repo}/`;
+  const suffix = "@refs/heads/main";
+  if (!buildConfigUri.startsWith(prefix) || !buildConfigUri.endsWith(suffix)) return "";
+  return buildConfigUri.slice(prefix.length, -suffix.length);
 }
 
 function record(value: unknown): Record<string, unknown> {

--- a/plugins/codex-autoresearch/tests/check-runner.test.ts
+++ b/plugins/codex-autoresearch/tests/check-runner.test.ts
@@ -299,6 +299,29 @@ test("release provenance smoke accepts matching checksum, release asset, and cer
   });
 });
 
+test("release provenance smoke accepts reusable release workflow caller path", async () => {
+  await withTempDir("release-provenance-reusable-", async (dir) => {
+    const fixture = await writeReleaseProvenanceFixture(dir);
+    const attestations = structuredClone(fixture.attestations);
+    const certificate = attestations[0].verificationResult.signature.certificate;
+    certificate.buildConfigURI =
+      "https://github.com/TheGreenCedar/codex-autoresearch/.github/workflows/auto-release.yml@refs/heads/main";
+    attestations[0].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow.path =
+      ".github/workflows/auto-release.yml";
+
+    assert.equal(
+      await releaseProvenanceIssue({
+        attestationJson: JSON.stringify(attestations),
+        checksumPath: fixture.checksum,
+        releaseJson: JSON.stringify(fixture.release),
+        targetCommit: fixture.commit,
+        tarball: fixture.tarball,
+      }),
+      "",
+    );
+  });
+});
+
 test("release provenance smoke rejects certificate policy drift", async () => {
   await withTempDir("release-provenance-ref-", async (dir) => {
     const fixture = await writeReleaseProvenanceFixture(dir);


### PR DESCRIPTION
## Context

The `v2.5.0` auto-release published the release, tarball, checksum, and attestation, then failed in the post-release provenance smoke. The failure was a verifier bug: the reusable `release.yml` workflow signs the attestation, while the SLSA predicate records the caller workflow path from `auto-release.yml`.

## What Changed

- Accept the certificate `buildConfigURI` workflow path as the expected SLSA caller workflow path when validating release provenance.
- Preserve the signer workflow checks against `release.yml`.
- Include `buildConfigURI` in the provenance policy view and failure summary.
- Add a regression test for the reusable-workflow caller path.
- Add an Unreleased changelog note.

```mermaid
flowchart LR
  A["auto-release.yml"] --> B["calls release.yml"]
  B --> C["release.yml signs attestation"]
  C --> D["certificate signer: release.yml"]
  C --> E["predicate workflow path: auto-release.yml"]
  F["release-provenance-smoke"] --> D
  F --> E
```

## How To Review

- Start with `plugins/codex-autoresearch/lib/checks/package-smoke.ts` and confirm signer checks remain anchored to `.github/workflows/release.yml`.
- Review `plugins/codex-autoresearch/tests/check-runner.test.ts` for the reusable-workflow regression case.
- Confirm `CHANGELOG.md` describes this as a verifier fix rather than a release artifact change.

## Verification

- `npm run typecheck` from `plugins/codex-autoresearch` passed.
- `npm run test:core` from `plugins/codex-autoresearch` passed: `288` tests.
- Live `release-provenance-smoke` against published `v2.5.0` release assets passed: `ok release-provenance-smoke`.
- `git diff --check` passed.
- `npm run check` from `plugins/codex-autoresearch` passed, including `ok package-artifact` and `ok package-runtime-smoke`.

## Risk

The `v2.5.0` release already exists. This change does not delete, recreate, or republish it; it fixes the verifier for future runs and for the current release evidence. The remaining operational wrinkle is that the original auto-release workflow run stays red historically even though the release assets and attestation verify with the corrected policy.