### PR TITLE
Promote release provenance smoke fix to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+### Fixed
+
+- Fixed release provenance smoke validation for auto-release runs that call the reusable release workflow, where the certificate signer is `release.yml` but the SLSA predicate records `auto-release.yml` as the caller workflow path.
+
 ## 2.5.0 - 2026-06-21
 
 ### Changed

--- a/plugins/codex-autoresearch/lib/checks/package-smoke.ts
+++ b/plugins/codex-autoresearch/lib/checks/package-smoke.ts
@@ -561,9 +561,12 @@ export async function releaseProvenanceIssue(options: ReleaseProvenanceOptions):
 
   const expectedSan = `https://github.com/${signerWorkflow}@refs/heads/main`;
   const expectedRepoUri = `https://github.com/${repo}`;
-  const expectedWorkflowPath = signerWorkflow.slice(`${repo}/`.length);
+  const expectedSignerWorkflowPath = signerWorkflow.slice(`${repo}/`.length);
   const expectedBuilderUri = `https://github.com/${signerWorkflow}@refs/heads/main`;
   for (const entry of matching) {
+    const expectedWorkflowPath =
+      workflowPathFromBuildConfigUri(entry.certificate.buildConfigURI, repo) ||
+      expectedSignerWorkflowPath;
     const issues = [
       requireEqual(
         "certificate subjectAlternativeName",
@@ -708,6 +711,7 @@ function attestationPolicyView(entry: unknown) {
     certificate: {
       githubWorkflowRepository: stringField(certificate, "githubWorkflowRepository"),
       githubWorkflowSHA: stringField(certificate, "githubWorkflowSHA"),
+      buildConfigURI: stringField(certificate, "buildConfigURI"),
       runnerEnvironment: stringField(certificate, "runnerEnvironment"),
       sourceRepositoryDigest: stringField(certificate, "sourceRepositoryDigest"),
       sourceRepositoryRef: stringField(certificate, "sourceRepositoryRef"),
@@ -720,6 +724,7 @@ function attestationPolicyView(entry: unknown) {
     summary: JSON.stringify({
       certificate: {
         githubWorkflowRepository: stringField(certificate, "githubWorkflowRepository"),
+        buildConfigURI: stringField(certificate, "buildConfigURI"),
         sourceRepositoryDigest: stringField(certificate, "sourceRepositoryDigest"),
         sourceRepositoryRef: stringField(certificate, "sourceRepositoryRef"),
         subjectAlternativeName: stringField(certificate, "subjectAlternativeName"),
@@ -732,6 +737,13 @@ function attestationPolicyView(entry: unknown) {
       repository: stringField(workflow, "repository"),
     },
   };
+}
+
+function workflowPathFromBuildConfigUri(buildConfigUri: string, repo: string): string {
+  const prefix = `https://github.com/${repo}/`;
+  const suffix = "@refs/heads/main";
+  if (!buildConfigUri.startsWith(prefix) || !buildConfigUri.endsWith(suffix)) return "";
+  return buildConfigUri.slice(prefix.length, -suffix.length);
 }
 
 function record(value: unknown): Record<string, unknown> {

--- a/plugins/codex-autoresearch/tests/check-runner.test.ts
+++ b/plugins/codex-autoresearch/tests/check-runner.test.ts
@@ -299,6 +299,29 @@ test("release provenance smoke accepts matching checksum, release asset, and cer
   });
 });
 
+test("release provenance smoke accepts reusable release workflow caller path", async () => {
+  await withTempDir("release-provenance-reusable-", async (dir) => {
+    const fixture = await writeReleaseProvenanceFixture(dir);
+    const attestations = structuredClone(fixture.attestations);
+    const certificate = attestations[0].verificationResult.signature.certificate;
+    certificate.buildConfigURI =
+      "https://github.com/TheGreenCedar/codex-autoresearch/.github/workflows/auto-release.yml@refs/heads/main";
+    attestations[0].verificationResult.statement.predicate.buildDefinition.externalParameters.workflow.path =
+      ".github/workflows/auto-release.yml";
+
+    assert.equal(
+      await releaseProvenanceIssue({
+        attestationJson: JSON.stringify(attestations),
+        checksumPath: fixture.checksum,
+        releaseJson: JSON.stringify(fixture.release),
+        targetCommit: fixture.commit,
+        tarball: fixture.tarball,
+      }),
+      "",
+    );
+  });
+});
+
 test("release provenance smoke rejects certificate policy drift", async () => {
   await withTempDir("release-provenance-ref-", async (dir) => {
     const fixture = await writeReleaseProvenanceFixture(dir);


### PR DESCRIPTION
## Context

`v2.5.0` has already been promoted to `main` and released. The release assets and attestation are valid, but the auto-release workflow failed after publish because `release-provenance-smoke` rejected the reusable workflow shape: `release.yml` signs the attestation while `auto-release.yml` appears as the SLSA caller workflow path.

## What Changed

- Promotes the #265 verifier fix from `dev` to `main`.
- Keeps signer validation anchored to `.github/workflows/release.yml`.
- Allows the expected SLSA workflow path to come from the certificate `buildConfigURI`, which is `.github/workflows/auto-release.yml` for auto-release caller runs.
- Adds regression coverage and an Unreleased changelog note.

```mermaid
flowchart LR
  A["main v2.5.0"] --> B["release assets published"]
  B --> C["post-release smoke failed"]
  C --> D["dev #265 fixes verifier"]
  D --> E["main promotion"]
```

## How To Review

- Confirm this promotion contains only `CHANGELOG.md`, `plugins/codex-autoresearch/lib/checks/package-smoke.ts`, and `plugins/codex-autoresearch/tests/check-runner.test.ts`.
- Review the provenance checker path: signer checks still require `release.yml`; predicate workflow path may match the caller from `buildConfigURI`.

## Verification

On #265 before promotion:

- `npm run typecheck` from `plugins/codex-autoresearch` passed.
- `npm run test:core` from `plugins/codex-autoresearch` passed: `288` tests.
- Live `release-provenance-smoke` against published `v2.5.0` release assets passed: `ok release-provenance-smoke`.
- `git diff --check` passed.
- `npm run check` from `plugins/codex-autoresearch` passed, including `ok package-artifact` and `ok package-runtime-smoke`.
- PR #265 checks passed on Ubuntu, macOS, Windows, workflow policy, and CodeQL.

## Risk

No version surfaces changed in this promotion, so auto-release should not publish a new release. The existing `v2.5.0` workflow run remains historically red because it failed before this verifier fix landed; the release and attestation can be validated by the corrected smoke locally.