### PR TITLE
Docs: refresh release notes and provenance prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+### Changed
+
+- Clarified release-provenance smoke maintainer prerequisites for `gh`
+  authentication, network access, and release tarball/checksum/tag/commit
+  context.
+
 ### Fixed
 
 - Fixed release provenance smoke validation for auto-release runs that call the reusable release workflow, where the certificate signer is `release.yml` but the SLSA predicate records `auto-release.yml` as the caller workflow path.
@@ -19,6 +25,10 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 - Added an opt-in maintainer browser accessibility check for the dashboard
   chart/modal keyboard flow without changing dashboard behavior or adding
   browser-test dependencies.
+- Dashboard/readout surfaces now include chart keyboard guidance,
+  focus-managed run detail dialogs, clearer finalization and runtime-provenance
+  placement, watchdog status, and AI summary handoff shaping while keeping the
+  dashboard read-only.
 - Added a maintainer release-provenance smoke command that combines strict
   tarball/checksum/release-asset digest checks with `gh attestation verify`
   JSON certificate policy checks, without changing runtime hydration.

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -126,8 +126,16 @@ Do not push release tags by hand. After a synchronized version bump lands on `ma
 Release provenance is a maintainer/operator gate, not runtime bootstrap. Source
 runtime hydration stays on the adjacent SHA-256 checksum and packaged
 name/version checks so first-run installs do not depend on GitHub CLI,
-attestation APIs, or Sigstore network state. After downloading a published
-tarball and adjacent checksum, use:
+attestation APIs, or Sigstore network state.
+
+Before running the release-provenance smoke, confirm:
+
+- `gh` is installed and authenticated for `TheGreenCedar/codex-autoresearch`.
+- Network access to GitHub release metadata and attestation APIs is available.
+- The release context is present: downloaded tarball, adjacent checksum file,
+  expected `v<version>` tag, and release target commit.
+
+After downloading a published tarball and adjacent checksum, use:
 
 ```bash
 npm run smoke:release-provenance -- --tarball codex-autoresearch-<version>.tgz --checksum codex-autoresearch-<version>.tgz.sha256 --tag v<version>


### PR DESCRIPTION
## Context

Refs #255.

Issue #255 asks for a tiny docs-only refresh after #249 triage: correct the release notes for visible dashboard/readout polish already shipped in 2.5.0, and make release-provenance smoke prerequisites explicit for maintainers.

## What Changed

- Backfilled/corrected the `CHANGELOG.md` 2.5.0 notes with the shipped dashboard/readout changes: chart keyboard guidance, focus-managed run detail dialogs, finalization/provenance placement, watchdog status, and AI summary handoff shaping.
- Kept `CHANGELOG.md` Unreleased limited to the docs-only maintainer prerequisite clarification.
- Updated `plugins/codex-autoresearch/docs/maintainers.md` to spell out release-provenance smoke prerequisites: `gh` installed and authenticated, network access, downloaded tarball/checksum, expected tag, and release target commit context.

## How To Review

- Read the two-file diff only.
- Confirm the 2.5.0 changelog wording describes behavior already shipped in that release, not new Unreleased behavior.
- Confirm the Unreleased note is docs-only.
- Confirm the maintainer prerequisite list matches what `npm run smoke:release-provenance` needs before it calls `gh api` and `gh attestation verify`.

## Verification

- Markdown readback: `Get-Content -LiteralPath CHANGELOG.md | Select-Object -First 40`
- Markdown readback: `Get-Content -LiteralPath plugins\codex-autoresearch\docs\maintainers.md | Select-Object -Skip 124 -First 28`
- `git diff --check`
- `git diff --cached --check`

## Risk

Docs-only. No version bump, release workflow change, executable change, generated artifact, or package gate run. The remaining risk is wording drift if future dashboard or release-provenance docs change before this branch is merged.