### PR TITLE
Extract dashboard mission control presenter

### DIFF
--- a/plugins/codex-autoresearch/lib/dashboard-view-model.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model.ts
@@ -2,6 +2,7 @@ import { STATUS_VALUES, buildDecisionEnvelope, finiteMetric } from "./session-co
 import { redactEvidenceObject } from "./evidence-redaction.js";
 import { acceptedCurrentRuns, buildEvidenceRegistry } from "./evidence-registry.js";
 import { buildAiSummary } from "./dashboard-view-model/ai-summary.js";
+import { buildMissionControl } from "./dashboard-view-model/mission-control.js";
 import { buildWatchdogSummary } from "./dashboard-view-model/watchdog-summary.js";
 import {
   actionMetadataForKind,
@@ -16,6 +17,7 @@ import {
 import type { DashboardContext } from "../dashboard/src/types.js";
 
 export { buildAiSummary } from "./dashboard-view-model/ai-summary.js";
+export { buildMissionControl } from "./dashboard-view-model/mission-control.js";
 export { buildWatchdogSummary } from "./dashboard-view-model/watchdog-summary.js";
 
 type LooseObject = Record<string, any>;
@@ -2238,147 +2240,6 @@ function decisionEnvelopeUtility(kind: string): string {
     return "Finalization is ready after higher-priority loop checks.";
   if (kind === "baseline") return "Establish the benchmark floor before tuning.";
   return "Decision envelope is the authoritative next-action source.";
-}
-
-export function buildMissionControl({
-  current,
-  setupPlan,
-  guidedSetup,
-  qualityGap,
-  finalizePreview,
-  experimentMemory,
-  actionRail,
-  commands,
-}: LooseObject) {
-  const commandMap = commandLookup(commands);
-  const stage = guidedSetup?.stage || "ready";
-  const lastRun = guidedSetup?.lastRun || null;
-  const allowedStatuses = Array.isArray(lastRun?.allowedStatuses) ? lastRun.allowedStatuses : [];
-  const suggestedStatus =
-    lastRun?.safeSuggestedStatus ||
-    lastRun?.suggestedStatus ||
-    (allowedStatuses.length === 1 ? allowedStatuses[0] : "");
-  const hasFreshLastRun = Boolean(lastRun && lastRun?.freshness?.fresh !== false);
-  const canLog = stage === "needs-log-decision" && hasFreshLastRun && allowedStatuses.length > 0;
-  const qualityGapOpen = Number(qualityGap?.open);
-  const hasQualityGaps = Number.isFinite(qualityGapOpen) && qualityGapOpen > 0;
-  const setupState =
-    stage === "needs-setup" ? "ready" : setupPlan?.configured || current.length ? "done" : "idle";
-  const gapState = qualityGap ? (hasQualityGaps ? "ready" : "done") : "idle";
-  const logState = lastRun ? (hasFreshLastRun ? "ready" : "blocked") : "idle";
-  const finalizeState = finalizePreview?.ready ? "ready" : current.length ? "idle" : "blocked";
-  const activeStep = canLog
-    ? "log"
-    : stage === "needs-setup"
-      ? "setup"
-      : hasQualityGaps
-        ? "gaps"
-        : finalizePreview?.ready
-          ? "finalize"
-          : qualityGap
-            ? "gaps"
-            : actionRail?.[0]?.kind || "next";
-  return {
-    activeStep,
-    staticFallback: "Serve the dashboard locally for a fresh readout; use CLI for actions.",
-    steps: [
-      missionStep({
-        id: "setup",
-        title: "Setup",
-        state: setupState,
-        detail:
-          guidedSetup?.stage === "needs-setup"
-            ? guidedSetup.nextAction
-            : "Session setup is readable.",
-        safeAction: "setup-plan",
-        command: guidedSetup?.commands?.setup || commandMap.get("setup plan"),
-        commandLabel: "Setup",
-      }),
-      missionStep({
-        id: "gaps",
-        title: "Gap review",
-        state: gapState,
-        detail: qualityGap
-          ? `${qualityGap.open} open / ${qualityGap.total} total in ${qualityGap.slug}.`
-          : "No research gap file detected.",
-        safeAction: "gap-candidates",
-        command: commandMap.get("gap candidates"),
-        commandLabel: "Gaps",
-      }),
-      missionStep({
-        id: "log",
-        title: "Log decision",
-        state: logState,
-        detail: canLog
-          ? `Last packet is ready to log as ${suggestedStatus || "an allowed status"}.`
-          : lastRun?.freshness?.reason || "No fresh last-run packet is waiting.",
-      }),
-      missionStep({
-        id: "finalize",
-        title: "Finalize",
-        state: finalizeState,
-        detail:
-          finalizePreview?.nextAction || "Preview review branches after kept evidence is ready.",
-        safeAction: "finalize-preview",
-        command: commandMap.get("finalize preview"),
-        commandLabel: "Preview",
-      }),
-    ],
-    logDecision: {
-      available: canLog,
-      allowedStatuses,
-      suggestedStatus,
-      metric: lastRun?.metric ?? null,
-      lastRunFingerprint: lastRun?.fingerprint || "",
-      statusGuidance: lastRun?.statusGuidance || "",
-      defaultDescription:
-        suggestedStatus === "discard"
-          ? "Describe the discarded packet"
-          : suggestedStatus === "checks_failed"
-            ? "Describe the failed checks"
-            : "Describe the kept change",
-      asiTemplate: lastRun?.asiTemplate || {},
-      requiresDescription: true,
-      requiresConfirmation: true,
-    },
-    nextAction:
-      actionRail?.[0]?.detail ||
-      experimentMemory?.latestNextAction ||
-      guidedSetup?.nextAction ||
-      "",
-  };
-}
-
-function missionStep({
-  id,
-  title,
-  state,
-  detail,
-  safeAction = "",
-  command = "",
-  commandLabel = "Copy read-only command",
-  mutates = false,
-}: {
-  id: string;
-  title: string;
-  state: string;
-  detail: string;
-  safeAction?: string;
-  command?: string;
-  commandLabel?: string;
-  mutates?: boolean;
-}) {
-  const safeCommand = dashboardReadOnlyCommand(command);
-  return {
-    id,
-    title,
-    state,
-    detail,
-    safeAction,
-    command: safeCommand,
-    primaryCommand: safeCommand ? { label: commandLabel, command: safeCommand } : null,
-    mutates,
-  };
 }
 
 function actionItem({

--- a/plugins/codex-autoresearch/lib/dashboard-view-model/mission-control.ts
+++ b/plugins/codex-autoresearch/lib/dashboard-view-model/mission-control.ts
@@ -1,0 +1,183 @@
+import { dashboardReadOnlyCommand } from "../dashboard-command-safety.js";
+import type { UnknownRecord } from "../types/json.js";
+
+type CommandMap = Map<string, unknown>;
+type MissionAction = UnknownRecord & { detail?: string; kind?: string };
+type MissionGuidedSetup = UnknownRecord & {
+  commands?: { setup?: unknown };
+  lastRun?: MissionLastRun | null;
+  nextAction?: string;
+  stage?: string;
+};
+type MissionLastRun = UnknownRecord & {
+  allowedStatuses?: unknown[];
+  asiTemplate?: unknown;
+  fingerprint?: string;
+  freshness?: { fresh?: boolean; reason?: string };
+  metric?: unknown;
+  safeSuggestedStatus?: unknown;
+  statusGuidance?: string;
+  suggestedStatus?: unknown;
+};
+type MissionControlInput = UnknownRecord & {
+  actionRail?: MissionAction[];
+  commands?: unknown;
+  current?: UnknownRecord[];
+  experimentMemory?: (UnknownRecord & { latestNextAction?: string }) | null;
+  finalizePreview?: (UnknownRecord & { nextAction?: string; ready?: boolean }) | null;
+  guidedSetup?: MissionGuidedSetup | null;
+  qualityGap?: (UnknownRecord & { open?: unknown; slug?: unknown; total?: unknown }) | null;
+  setupPlan?: (UnknownRecord & { configured?: unknown }) | null;
+};
+
+export function buildMissionControl({
+  current,
+  setupPlan,
+  guidedSetup,
+  qualityGap,
+  finalizePreview,
+  experimentMemory,
+  actionRail,
+  commands,
+}: MissionControlInput) {
+  const commandMap = commandLookup(commands);
+  const stage = guidedSetup?.stage || "ready";
+  const lastRun = guidedSetup?.lastRun || null;
+  const allowedStatuses = Array.isArray(lastRun?.allowedStatuses) ? lastRun.allowedStatuses : [];
+  const suggestedStatus =
+    lastRun?.safeSuggestedStatus ||
+    lastRun?.suggestedStatus ||
+    (allowedStatuses.length === 1 ? allowedStatuses[0] : "");
+  const hasFreshLastRun = Boolean(lastRun && lastRun?.freshness?.fresh !== false);
+  const canLog = stage === "needs-log-decision" && hasFreshLastRun && allowedStatuses.length > 0;
+  const qualityGapOpen = Number(qualityGap?.open);
+  const hasQualityGaps = Number.isFinite(qualityGapOpen) && qualityGapOpen > 0;
+  const runCount = current?.length || 0;
+  const setupState =
+    stage === "needs-setup" ? "ready" : setupPlan?.configured || runCount ? "done" : "idle";
+  const gapState = qualityGap ? (hasQualityGaps ? "ready" : "done") : "idle";
+  const logState = lastRun ? (hasFreshLastRun ? "ready" : "blocked") : "idle";
+  const finalizeState = finalizePreview?.ready ? "ready" : runCount ? "idle" : "blocked";
+  const activeStep = canLog
+    ? "log"
+    : stage === "needs-setup"
+      ? "setup"
+      : hasQualityGaps
+        ? "gaps"
+        : finalizePreview?.ready
+          ? "finalize"
+          : qualityGap
+            ? "gaps"
+            : actionRail?.[0]?.kind || "next";
+  return {
+    activeStep,
+    staticFallback: "Serve the dashboard locally for a fresh readout; use CLI for actions.",
+    steps: [
+      missionStep({
+        id: "setup",
+        title: "Setup",
+        state: setupState,
+        detail:
+          guidedSetup?.stage === "needs-setup"
+            ? guidedSetup.nextAction || ""
+            : "Session setup is readable.",
+        safeAction: "setup-plan",
+        command: guidedSetup?.commands?.setup || commandMap.get("setup plan"),
+        commandLabel: "Setup",
+      }),
+      missionStep({
+        id: "gaps",
+        title: "Gap review",
+        state: gapState,
+        detail: qualityGap
+          ? `${qualityGap.open} open / ${qualityGap.total} total in ${qualityGap.slug}.`
+          : "No research gap file detected.",
+        safeAction: "gap-candidates",
+        command: commandMap.get("gap candidates"),
+        commandLabel: "Gaps",
+      }),
+      missionStep({
+        id: "log",
+        title: "Log decision",
+        state: logState,
+        detail: canLog
+          ? `Last packet is ready to log as ${suggestedStatus || "an allowed status"}.`
+          : lastRun?.freshness?.reason || "No fresh last-run packet is waiting.",
+      }),
+      missionStep({
+        id: "finalize",
+        title: "Finalize",
+        state: finalizeState,
+        detail:
+          finalizePreview?.nextAction || "Preview review branches after kept evidence is ready.",
+        safeAction: "finalize-preview",
+        command: commandMap.get("finalize preview"),
+        commandLabel: "Preview",
+      }),
+    ],
+    logDecision: {
+      available: canLog,
+      allowedStatuses,
+      suggestedStatus,
+      metric: lastRun?.metric ?? null,
+      lastRunFingerprint: lastRun?.fingerprint || "",
+      statusGuidance: lastRun?.statusGuidance || "",
+      defaultDescription:
+        suggestedStatus === "discard"
+          ? "Describe the discarded packet"
+          : suggestedStatus === "checks_failed"
+            ? "Describe the failed checks"
+            : "Describe the kept change",
+      asiTemplate: lastRun?.asiTemplate || {},
+      requiresDescription: true,
+      requiresConfirmation: true,
+    },
+    nextAction:
+      actionRail?.[0]?.detail ||
+      experimentMemory?.latestNextAction ||
+      guidedSetup?.nextAction ||
+      "",
+  };
+}
+
+function missionStep({
+  id,
+  title,
+  state,
+  detail,
+  safeAction = "",
+  command = "",
+  commandLabel = "Copy read-only command",
+  mutates = false,
+}: {
+  id: string;
+  title: string;
+  state: string;
+  detail: string;
+  safeAction?: string;
+  command?: unknown;
+  commandLabel?: string;
+  mutates?: boolean;
+}) {
+  const safeCommand = dashboardReadOnlyCommand(command);
+  return {
+    id,
+    title,
+    state,
+    detail,
+    safeAction,
+    command: safeCommand,
+    primaryCommand: safeCommand ? { label: commandLabel, command: safeCommand } : null,
+    mutates,
+  };
+}
+
+function commandLookup(commands: unknown): CommandMap {
+  const map: CommandMap = new Map();
+  for (const item of Array.isArray(commands) ? commands : []) {
+    const record = item && typeof item === "object" ? (item as UnknownRecord) : {};
+    const label = String(record.label || "").toLowerCase();
+    if (label) map.set(label, record.command || "");
+  }
+  return map;
+}


### PR DESCRIPTION
## Context

Refs #258

The dashboard view model still carries multiple presenter concerns inline. This PR continues the boring extraction path by moving only the mission-control presenter logic out of `dashboard-view-model.ts`.

## What Changed

- Added `lib/dashboard-view-model/mission-control.ts` for the mission-control presenter.
- Re-exported `buildMissionControl` from `dashboard-view-model.ts` so existing import paths stay stable.
- Uses the repo-standard `UnknownRecord` type in the extracted presenter instead of adding a new local `LooseObject` compatibility alias.
- Preserved the existing mission-control copy, state selection, log-decision shape, and read-only command sanitization behavior.

## How To Review

- Compare the moved `buildMissionControl` and `missionStep` logic against the previous inline implementation.
- Confirm `dashboard-view-model.ts` now imports/re-exports the presenter without pulling in unrelated dashboard concerns.
- Confirm there are no visual behavior changes, generated artifacts, version bumps, or release changes.

## Verification

- `node scripts/check.mjs --phase source-hygiene` from `plugins/codex-autoresearch` passed.
- `npm run test:dashboard` from `plugins/codex-autoresearch` passed: rebuilt node/dashboard outputs and ran 112 dashboard verification tests.
- `npm run typecheck:node` from `plugins/codex-autoresearch` passed.
- `npm run format:check` from `plugins/codex-autoresearch` passed.
- `git diff --check` passed.
- Browser/dashboard visual checks were not run because this is a behavior-preserving presenter move with no intended visible behavior change.

## Risk

Low. The risk is import/export or accidental divergence while moving code; source hygiene, dashboard verification, and typecheck cover the moved presenter path. No dashboard behavior, copy, command safety policy, generated assets, release surface, or version surface changed.