### PR TITLE
Split package checksum helpers

### DIFF
--- a/plugins/codex-autoresearch/lib/checks/package-checksum.ts
+++ b/plugins/codex-autoresearch/lib/checks/package-checksum.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { ROOT } from "./check-common.js";
+
+export async function releaseChecksumIssue(tarball: string, checksumPath: string): Promise<string> {
+  let checksumText = "";
+  try {
+    checksumText = await fsp.readFile(checksumPath, "utf8");
+  } catch (error) {
+    return `Checksum file could not be read at ${checksumPath}: ${String(error)}`;
+  }
+
+  const tarballName = path.basename(tarball);
+  let expectedHash = "";
+  try {
+    expectedHash = await parseStrictSha256Manifest(checksumText, tarballName);
+  } catch (error) {
+    return String(error instanceof Error ? error.message : error);
+  }
+
+  const actualHash = await fileSha256(tarball);
+  if (actualHash !== expectedHash) {
+    return `Checksum mismatch for ${tarballName}: expected ${expectedHash}, got ${actualHash}.`;
+  }
+  return "";
+}
+
+export async function parseStrictSha256Manifest(
+  text: string,
+  expectedFileName: string,
+): Promise<string> {
+  const releaseIntegrity = (await import(
+    pathToFileURL(path.join(ROOT, "scripts", "release-integrity.mjs")).href
+  )) as {
+    parseSha256Manifest: (text: string, expectedFileName: string) => string;
+  };
+  return releaseIntegrity.parseSha256Manifest(text, expectedFileName);
+}
+
+export async function fileSha256(file: string): Promise<string> {
+  return createHash("sha256")
+    .update(await fsp.readFile(file))
+    .digest("hex");
+}

--- a/plugins/codex-autoresearch/lib/checks/package-smoke.ts
+++ b/plugins/codex-autoresearch/lib/checks/package-smoke.ts
@@ -1,8 +1,6 @@
-import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import {
   errorMessage,
   indent,
@@ -14,6 +12,9 @@ import {
 } from "./check-common.js";
 import { dashboardExportAssetIssues, type DashboardExportAssets } from "./demo-trust.js";
 import { resolveNpmCommand } from "./npm-command.js";
+import { fileSha256, parseStrictSha256Manifest, releaseChecksumIssue } from "./package-checksum.js";
+
+export { releaseChecksumIssue };
 
 interface PackageEntry {
   path?: string;
@@ -458,30 +459,6 @@ async function runPackageRuntimeSmokeFromTarball(tarball: string, extractDir: st
   return true;
 }
 
-export async function releaseChecksumIssue(tarball: string, checksumPath: string): Promise<string> {
-  let checksumText = "";
-  try {
-    checksumText = await fsp.readFile(checksumPath, "utf8");
-  } catch (error) {
-    return `Checksum file could not be read at ${checksumPath}: ${String(error)}`;
-  }
-
-  const tarballName = path.basename(tarball);
-  let expectedHash = "";
-  try {
-    expectedHash = await parseStrictSha256Manifest(checksumText, tarballName);
-  } catch (error) {
-    return String(error instanceof Error ? error.message : error);
-  }
-
-  const bytes = await fsp.readFile(tarball);
-  const actualHash = createHash("sha256").update(bytes).digest("hex");
-  if (actualHash !== expectedHash) {
-    return `Checksum mismatch for ${tarballName}: expected ${expectedHash}, got ${actualHash}.`;
-  }
-  return "";
-}
-
 export interface ReleaseProvenanceOptions {
   attestationJson: string;
   checksumPath: string;
@@ -625,21 +602,6 @@ export async function releaseProvenanceIssue(options: ReleaseProvenanceOptions):
   return `No matching attestation satisfied release provenance policy:\n${matching
     .map((entry) => entry.summary)
     .join("\n")}`;
-}
-
-async function parseStrictSha256Manifest(text: string, expectedFileName: string): Promise<string> {
-  const releaseIntegrity = (await import(
-    pathToFileURL(path.join(ROOT, "scripts", "release-integrity.mjs")).href
-  )) as {
-    parseSha256Manifest: (text: string, expectedFileName: string) => string;
-  };
-  return releaseIntegrity.parseSha256Manifest(text, expectedFileName);
-}
-
-async function fileSha256(file: string): Promise<string> {
-  return createHash("sha256")
-    .update(await fsp.readFile(file))
-    .digest("hex");
 }
 
 function parseJsonObject(text: string, label: string): Record<string, unknown> {


### PR DESCRIPTION
## Context

Refs #257

`lib/checks/package-smoke.ts` mixes package artifact policy, runtime smoke, checksum validation, and release provenance checks. This PR takes one small behavior-preserving slice by moving the pure checksum helpers out of the package smoke module while keeping the CLI phases and release policy unchanged.

## What Changed

- Added `lib/checks/package-checksum.ts` for checksum manifest validation and SHA-256 file hashing.
- Updated `lib/checks/package-smoke.ts` to import those checksum helpers and re-export `releaseChecksumIssue` for existing callers.
- Left package artifact checks, runtime smoke commands, release provenance policy, CLI phase names, and release workflow behavior unchanged.

## How To Review

- Start with `plugins/codex-autoresearch/lib/checks/package-smoke.ts` and confirm the package/release phase flow is still in place.
- Then review `plugins/codex-autoresearch/lib/checks/package-checksum.ts` as a direct extraction of the checksum concern.
- Confirm downstream imports can still use `releaseChecksumIssue` from `package-smoke.ts` through the compatibility re-export.

## Verification

From `C:\Users\alber\.codex\worktrees\autoresearch-issue-257\plugins\codex-autoresearch`:

- `npm run format:check` - passed
- `git diff --check` - passed
- `npm run build:node` - passed
- `node --test dist\tests\check-runner.test.mjs` - passed, 20/20
- `node --test --test-name-pattern "release workflows preserve synchronized auto-release and tarball safeguards" dist\tests\full-product.test.mjs` - passed, 1/1
- `npm run check` - passed

## Risk

Low. The split moves pure checksum helpers and keeps the existing public export stable. No release policy, CLI phase, artifact manifest policy, runtime smoke behavior, or provenance policy changed.