### PR TITLE
Promote Codex Autoresearch 2.5.1 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+## 2.5.1 - 2026-07-07
+
 ### Changed
 
 - Clarified release-provenance smoke maintainer prerequisites for `gh`
@@ -16,6 +18,8 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ### Fixed
 
+- Removed CodeQL-flagged regex and test process-spawn patterns from runtime
+  hydration and test helpers.
 - Fixed release provenance smoke validation for auto-release runs that call the reusable release workflow, where the certificate signer is `release.yml` but the SLSA predicate records `auto-release.yml` as the caller workflow path.
 
 ## 2.5.0 - 2026-06-21

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Measured Codex loops with benchmark output, local evidence, live readouts, and reviewable branch previews.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/package-lock.json
+++ b/plugins/codex-autoresearch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-autoresearch",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "Codex plugin for bounded, measured benchmark and optimization loops.",
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -152,10 +152,10 @@ export function runtimeReleaseArtifacts(versionInput, options = {}) {
   const tag = `v${version}`;
   const tarballName = `${PACKAGE_NAME}-${version}.tgz`;
   const checksumName = `${PACKAGE_NAME}-${version}.tgz.sha256`;
-  const baseUrl = String(
+  const baseUrl = stripTrailingSlashes(
     options.releaseBaseUrl ||
       `https://github.com/TheGreenCedar/codex-autoresearch/releases/download/${tag}`,
-  ).replace(/\/+$/, "");
+  );
   return {
     version,
     tag,
@@ -164,6 +164,12 @@ export function runtimeReleaseArtifacts(versionInput, options = {}) {
     tarballUrl: `${baseUrl}/${tarballName}`,
     checksumUrl: `${baseUrl}/${checksumName}`,
   };
+}
+
+function stripTrailingSlashes(value) {
+  let text = String(value);
+  while (text.endsWith("/")) text = text.slice(0, -1);
+  return text;
 }
 
 function normalizeReleaseVersion(versionInput) {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -7601,6 +7601,7 @@ test("keep logs fail instead of recording success when git commit fails", async 
     await git(dir, ["init"]);
     await git(dir, ["config", "user.email", "codex@example.test"]);
     await git(dir, ["config", "user.name", "Codex Test"]);
+    await git(dir, ["config", "core.hooksPath", ".git/hooks"]);
     await writeFile(path.join(dir, "tracked.txt"), "before\n", "utf8");
     await git(dir, ["add", "tracked.txt"]);
     await git(dir, ["commit", "-m", "initial"]);
@@ -9897,6 +9898,20 @@ test("source launcher rebuilds local source runtime before use", async () => {
       /rebuiltDashboard/,
     );
   });
+});
+
+test("runtime release artifacts trim trailing slashes without regex matching", async () => {
+  const bootstrap = await import(
+    pathToFileURL(path.join(pluginRoot, "scripts", "bootstrap-runtime.mjs")).href
+  );
+  const artifacts = bootstrap.runtimeReleaseArtifacts("1.2.3", {
+    releaseBaseUrl: "https://example.invalid/releases////",
+  });
+
+  assert.equal(
+    artifacts.tarballUrl,
+    "https://example.invalid/releases/codex-autoresearch-1.2.3.tgz",
+  );
 });
 
 test("source launcher hydrates runtime only after release checksum verification", async () => {

--- a/plugins/codex-autoresearch/tests/check-runner.test.ts
+++ b/plugins/codex-autoresearch/tests/check-runner.test.ts
@@ -15,6 +15,7 @@ import {
   releaseProvenanceIssue,
   resolveNpmCommand,
 } from "../scripts/check.js";
+import { runProcess } from "./helpers/process.js";
 
 test("check runner refuses Windows command scripts instead of routing through cmd", () => {
   assert.throws(
@@ -40,6 +41,28 @@ test("check runner leaves native commands unchanged", () => {
     command: "node",
     args: ["--version"],
   });
+});
+
+const normalizeExecutablePath = (value: string) => {
+  const normalized = path.resolve(value);
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+};
+
+test("test process helper preserves the current node executable and refuses other absolute commands", async () => {
+  const result = await runProcess(
+    process.execPath,
+    ["-e", "process.stdout.write(process.execPath)"],
+    {
+      cwd: process.cwd(),
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(normalizeExecutablePath(result.stdout), normalizeExecutablePath(process.execPath));
+
+  await assert.rejects(
+    () => runProcess(path.join(process.cwd(), "unlisted-node"), ["--version"], process.cwd()),
+    /Refusing to spawn unlisted test command/,
+  );
 });
 
 test("npm resolver uses npm_execpath as a shell-free npm entrypoint", async () => {

--- a/plugins/codex-autoresearch/tests/helpers/process.ts
+++ b/plugins/codex-autoresearch/tests/helpers/process.ts
@@ -16,9 +16,25 @@ const spawnTestProcess = (command, args, cwd, stdio, env) => {
     cwd,
     ...(env ? { env } : {}),
     windowsHide: true,
+    shell: false,
     stdio,
   };
-  return spawn(command, args, options);
+  if (command === process.execPath) {
+    // codeql[js/shell-command-injection-from-environment]: tests must use this exact Node runtime; args remain separate and shell is disabled.
+    return spawn(command, args, options);
+  }
+  switch (command) {
+    case "git":
+      return spawn("git", args, options);
+    case "tar":
+      return spawn("tar", args, options);
+    case "powershell.exe":
+      return spawn("powershell.exe", args, options);
+    case "/bin/sh":
+      return spawn("/bin/sh", args, options);
+    default:
+      throw new Error(`Refusing to spawn unlisted test command: ${command}`);
+  }
 };
 
 const captureProcessOutput = (child, onStdout) => {


### PR DESCRIPTION
## Context

Promote the `dev` branch to `main` after merging #275. This carries the Codex Autoresearch `2.5.1` patch metadata and the CodeQL alert fixes onto the default branch.

## What Changed

- Promotes `0783c84` from `dev`: `Resolve CodeQL alerts and bump to 2.5.1`.
- Includes fixes for code scanning alerts 24 (`js/polynomial-redos`) and 26 (`js/shell-command-injection-from-environment`).
- Includes the synchronized `2.5.1` package, lockfile, plugin manifest, and changelog update.

## How To Review

- Compare `dev` to `main`; this promotion should contain the single #275 squash commit.
- Confirm the main-source guard accepts `TheGreenCedar/codex-autoresearch:dev` as the source branch.
- Confirm CodeQL and CI remain green on the promotion PR.

## Verification

- #275 passed CodeQL, Workflow policy, macOS, Ubuntu, and Windows before merge to `dev`.
- Local package gate passed before #275: `npm run check` from `plugins/codex-autoresearch`.
- Local whitespace check passed before #275: `git diff --check`.

## Risk

- Low; this is a one-commit promotion from `dev` to `main` after green PR checks.
- Code-scanning alerts close only after GitHub processes the default branch update.
