### PR TITLE
Promote shell fixture removal to main

### DIFF
--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -23,7 +23,7 @@ import {
   writeDecisionCapsule,
 } from "./helpers/git-fixtures.js";
 import { parseLedger, writeLedger } from "./helpers/ledger.js";
-import { runNode, runShellCommand } from "./helpers/process-fixtures.js";
+import { runNode } from "./helpers/process-fixtures.js";
 import {
   cliPayload,
   isolatedRuntimeEnv,
@@ -6412,9 +6412,17 @@ test("stale packet compact state recommends replacement next command", async () 
     assert.equal(recommendPayload.commands.primary, statePayload.commands.replaceLast);
     assert.match(recommendPayload.commands.primary, /\bnext\b/);
 
-    const replacement = await runShellCommand(statePayload.commands.replaceLast, {
-      cwd: pluginRoot,
-    });
+    const replacement = await runCli([
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      command,
+      "--checks-policy",
+      "always",
+      "--checks-command",
+      checksCommand,
+    ]);
     assert.equal(replacement.code, 0, replacement.stderr);
     const replacementPayload = JSON.parse(replacement.stdout);
     assert.equal(replacementPayload.decision.metric, 3);

--- a/plugins/codex-autoresearch/tests/helpers/process-fixtures.ts
+++ b/plugins/codex-autoresearch/tests/helpers/process-fixtures.ts
@@ -11,15 +11,3 @@ export async function runNode(args, { cwd = pluginRoot, env = process.env } = {}
     env: childEnv,
   });
 }
-
-export async function runShellCommand(command, { cwd = pluginRoot } = {}) {
-  const shell = process.platform === "win32" ? "powershell.exe" : "sh";
-  const args =
-    process.platform === "win32"
-      ? ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command]
-      : ["-c", command];
-  return await runProcess(shell, args, {
-    cwd,
-    env: process.env,
-  });
-}

--- a/plugins/codex-autoresearch/tests/helpers/process.ts
+++ b/plugins/codex-autoresearch/tests/helpers/process.ts
@@ -27,10 +27,6 @@ const spawnTestProcess = (command, args, cwd, stdio, env) => {
       return spawn("git", args, options);
     case "tar":
       return spawn("tar", args, options);
-    case "powershell.exe":
-      return spawn("powershell.exe", args, options);
-    case "sh":
-      return spawn("sh", args, options);
     default:
       throw new Error(`Refusing to spawn unlisted test command: ${command}`);
   }


### PR DESCRIPTION
## Context

Promote #279 from `dev` to `main` to close the final CodeQL follow-up alert 29 from the test process helper.

## What Changed

- Promotes `7f49822`: `Remove shell process fixture`.
- Removes the test-only shell fixture and its shared process-helper command cases.
- Keeps the stale-packet replacement test exercising equivalent CLI args directly.

## How To Review

- Compare `dev` to `main`; this should contain the single #279 squash commit.
- Confirm the main-source guard accepts `dev` as the source branch.
- Confirm CodeQL remains green on the promotion PR.

## Verification

- #279 passed CodeQL, Workflow policy, macOS, Ubuntu, and Windows before merge to `dev`.
- Targeted stale-packet/process-helper tests passed locally.
- The slow finalization shard range passed locally when rerun alone after the full gate timeout.
- `git diff --check` passed locally.

## Risk

- Low; test helper cleanup only.
- No package version bump; no shipped runtime/package behavior changed.
