### PR TITLE
Preserve finalization branches during rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+### Fixed
+
+- Finalization now preserves pre-existing review and verification branches during rollback, deletes only branches created by the current invocation, and fails visibly when branch restoration or cleanup cannot complete.
+
 ## 2.6.0 - 2026-07-09
 
 ### Changed

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -622,9 +622,15 @@ function renderReviewSummaryHeader({
     "",
     "## Review Branches",
     "",
-    "| # | Branch | Title | Files |",
-    "|---:|---|---|---|",
+    "| # | Branch | Provenance | Title | Files |",
+    "|---:|---|---|---|---|",
   ];
+}
+
+function branchProvenance(result?: BranchResult): string {
+  if (!result || (result.skipped && !result.createdThisRun)) return "not created";
+  if (result.skipped) return "created then removed";
+  return result.createdThisRun ? "created" : "reused";
 }
 
 function renderBranchRows(groups: CollectedGroup[], results: BranchResult[]): string[] {
@@ -635,7 +641,7 @@ function renderBranchRows(groups: CollectedGroup[], results: BranchResult[]): st
     const branch = result?.branch || "(not created)";
     const suffix = result?.skipped ? " (skipped empty)" : "";
     lines.push(
-      `| ${i + 1} | \`${markdownEscape(branch)}\`${suffix} | ${markdownEscape(group.title || "")} | ${markdownEscape(group.files.join(", ") || "(none)")} |`,
+      `| ${i + 1} | \`${markdownEscape(branch)}\`${suffix} | ${branchProvenance(result)} | ${markdownEscape(group.title || "")} | ${markdownEscape(group.files.join(", ") || "(none)")} |`,
     );
   }
   return lines;
@@ -769,10 +775,10 @@ function renderRunwayTextForConfig(
         ]),
     "",
     `Final file set: ${[...fileSet].sort().join(", ") || "(none)"}`,
-    `Review branches created: ${
+    `Review branches: ${
       results
         .filter((result) => result && !result.skipped)
-        .map((result) => result.branch)
+        .map((result) => `${result.branch} (${branchProvenance(result)})`)
         .join(", ") || "(none)"
     }`,
   ];
@@ -1362,8 +1368,10 @@ async function main() {
   }
 
   console.log("");
-  console.log("Created review branches:");
-  for (const branch of reviewBranches) console.log(`  ${branch}`);
+  console.log("Review branches:");
+  for (const result of results.filter((result) => !result.skipped)) {
+    console.log(`  ${result.branch} (${branchProvenance(result)})`);
+  }
   console.log("");
   if (productGradeFinalizationIssue(config.product_claim_coverage)) {
     console.log("Experimental review branch only: product-grade proof is missing.");

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
 
@@ -81,11 +82,13 @@ type FinalizePlan = LooseObject & {
 };
 type BranchResult = {
   branch: string;
+  createdThisRun: boolean;
   deleted?: boolean;
   runway?: LooseObject;
   skipped?: boolean;
   stat: string;
 };
+type RecoveryFailure = { error: unknown; label: string };
 type OverlapAnalysis = {
   files: string[];
   groups: string[];
@@ -289,8 +292,31 @@ async function isDirty(cwd: string): Promise<boolean> {
 }
 
 async function restoreSourceBranch(sourceBranch: string, cwd: string): Promise<void> {
-  await git(["switch", sourceBranch], cwd, true);
-  await git(["reset", "--hard", "HEAD"], cwd, true);
+  await git(["switch", sourceBranch], cwd);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function withRecoveryFailures(error: unknown, failures: RecoveryFailure[]): Error {
+  const original =
+    error instanceof Error
+      ? error
+      : new Error(error == null ? "Finalization operation failed." : String(error));
+  if (!failures.length) return original;
+  const recovery = failures
+    .map((failure) => `${failure.label}: ${errorMessage(failure.error)}`)
+    .join("\n");
+  return new Error(`${original.message}\nFinalizer recovery failed:\n${recovery}`, {
+    cause: original,
+  });
+}
+
+async function restoreSourceBranchIfNeeded(sourceBranch: string, cwd: string): Promise<void> {
+  if ((await currentBranch(cwd)) !== sourceBranch) {
+    await restoreSourceBranch(sourceBranch, cwd);
+  }
 }
 
 async function changedFiles(fromRef: string, toRef: string, cwd: string): Promise<string[]> {
@@ -799,7 +825,8 @@ async function createBranchForGroup(
   cwd: string,
 ): Promise<BranchResult> {
   const branch = branchName(config, group, index);
-  if (!group.files.length) return { branch, skipped: true, deleted: true, stat: "" };
+  if (!group.files.length)
+    return { branch, createdThisRun: false, skipped: true, deleted: true, stat: "" };
   if (await branchExists(branch, cwd)) {
     return await reuseExistingBranchForGroup(config, group, branch, cwd);
   }
@@ -810,16 +837,32 @@ async function createBranchForGroup(
     await git(["add", "-A"], cwd);
     const diff = await git(["diff", "--cached", "--quiet"], cwd, true);
     if (diff.code === 0) {
-      await git(["switch", "--detach", config.base], cwd, true);
-      await git(["branch", "-D", branch], cwd, true);
-      return { branch, skipped: true, deleted: true, stat: "" };
+      await git(["switch", "--detach", config.base], cwd);
+      await git(["branch", "-D", branch], cwd);
+      return { branch, createdThisRun: true, skipped: true, deleted: true, stat: "" };
     }
     await git(["commit", "-m", group.title || "Autoresearch change", "-m", group.body || ""], cwd);
-    return { branch, skipped: false, deleted: false, stat: await branchStat(branch, cwd) };
+    return {
+      branch,
+      createdThisRun: true,
+      skipped: false,
+      deleted: false,
+      stat: await branchStat(branch, cwd),
+    };
   } catch (error) {
-    await git(["switch", "--detach", config.base], cwd, true);
-    await git(["branch", "-D", branch], cwd, true);
-    throw error;
+    const failures: RecoveryFailure[] = [];
+    for (const [label, args] of [
+      ["Created branch worktree cleanup failed", ["reset", "--hard", "HEAD"]],
+      ["Base restoration failed", ["switch", "--detach", config.base]],
+      ["Created branch cleanup failed", ["branch", "-D", branch]],
+    ] as Array<[string, string[]]>) {
+      try {
+        await git(args, cwd);
+      } catch (recoveryError) {
+        failures.push({ error: recoveryError, label });
+      }
+    }
+    throw withRecoveryFailures(error, failures);
   }
 }
 
@@ -861,6 +904,7 @@ async function reuseExistingBranchForGroup(
   }
   return {
     branch,
+    createdThisRun: false,
     skipped: false,
     deleted: false,
     runway,
@@ -900,7 +944,7 @@ async function existingBranchMatchesPlannedGroup(
       return diff.code === 0;
     },
     async () => {
-      await git(["switch", "--detach", config.base], cwd, true);
+      await git(["switch", "--detach", config.base], cwd);
     },
   );
 }
@@ -909,7 +953,7 @@ async function verifyUnion(
   config: FinalizePlan,
   groups: CollectedGroup[],
   sourceBranch: string,
-  createdBranches: string[],
+  reviewBranches: string[],
   cwd: string,
 ): Promise<void> {
   let nonSession: string[] = [];
@@ -934,7 +978,7 @@ async function verifyUnion(
   );
   if (nonSession.length > 0) {
     throw new Error(
-      `Union of groups differs from final tree:\n${nonSession.join("\n")}\nCreated branches were left intact:\n${createdBranches.join("\n")}`,
+      `Union of groups differs from final tree:\n${nonSession.join("\n")}\nReview branches were left intact:\n${reviewBranches.join("\n")}`,
     );
   }
 }
@@ -946,30 +990,50 @@ async function withTemporaryVerificationBranch<T>(
   runOnBranch: (verifyBranch: string) => Promise<T>,
   restoreAfter: () => Promise<void>,
 ): Promise<T> {
-  const verifyBranch = `autoresearch-review/${safeSlug(config.goal)}/${suffix}`;
-  if (await branchExists(verifyBranch, cwd)) {
-    await git(["branch", "-D", verifyBranch], cwd, true);
-  }
+  const verifyBranch = `autoresearch-review/${safeSlug(config.goal)}/${suffix}-${randomUUID()}`;
+  const failures: RecoveryFailure[] = [];
+  let createdThisRun = false;
+  let result!: T;
+  let runError: unknown;
   try {
     await git(["switch", "--detach", config.base], cwd);
     await git(["switch", "-c", verifyBranch], cwd);
-    return await runOnBranch(verifyBranch);
-  } finally {
+    createdThisRun = true;
+    result = await runOnBranch(verifyBranch);
+  } catch (error) {
+    runError = error;
+  }
+
+  if (runError && createdThisRun) {
     try {
-      await restoreAfter();
-    } finally {
-      await git(["branch", "-D", verifyBranch], cwd, true);
+      await git(["reset", "--hard", "HEAD"], cwd);
+    } catch (error) {
+      failures.push({ error, label: "Temporary branch worktree cleanup failed" });
     }
   }
+  try {
+    await restoreAfter();
+  } catch (error) {
+    failures.push({ error, label: "Verification state restoration failed" });
+  }
+  if (createdThisRun) {
+    try {
+      await git(["branch", "-D", verifyBranch], cwd);
+    } catch (error) {
+      failures.push({ error, label: "Temporary branch cleanup failed" });
+    }
+  }
+  if (runError || failures.length) throw withRecoveryFailures(runError, failures);
+  return result;
 }
 
 async function verifyNoSessionArtifacts(
-  createdBranches: string[],
+  reviewBranches: string[],
   cwd: string,
   excludeSessionArtifacts = true,
 ): Promise<void> {
   if (!excludeSessionArtifacts) return;
-  for (const branch of createdBranches) {
+  for (const branch of reviewBranches) {
     const result = await git(["diff-tree", "--no-commit-id", "--name-only", "-r", branch], cwd);
     const sessionFiles = cleanLines(result.stdout).filter((file) =>
       isAutoresearchSessionArtifact(file, "finalization"),
@@ -1203,7 +1267,8 @@ async function main() {
     },
   );
 
-  const created: string[] = [];
+  const createdBranches: string[] = [];
+  const reviewBranches: string[] = [];
   const results: BranchResult[] = [];
   let summaryPath = "";
   try {
@@ -1214,7 +1279,8 @@ async function main() {
         for (let i = 0; i < groups.length; i += 1) {
           const result = await createBranchForGroup(config, groups[i], i, cwd);
           results.push(result);
-          if (!result.skipped) created.push(result.branch);
+          if (!result.skipped) reviewBranches.push(result.branch);
+          if (result.createdThisRun && !result.skipped) createdBranches.push(result.branch);
           console.log(`${String(i + 1).padStart(2, "0")}. ${groups[i].title}`);
           console.log(`    branch: ${result.branch}${result.skipped ? " (skipped empty)" : ""}`);
           console.log(`    files: ${groups[i].files.join(", ") || "(none)"}`);
@@ -1222,11 +1288,23 @@ async function main() {
       },
     );
   } catch (error) {
-    for (const branch of created) {
-      await git(["branch", "-D", branch], cwd, true);
+    const failures: RecoveryFailure[] = [];
+    try {
+      await restoreSourceBranchIfNeeded(sourceBranch, cwd);
+    } catch (recoveryError) {
+      failures.push({ error: recoveryError, label: "Source branch restoration failed" });
     }
-    await restoreSourceBranch(sourceBranch, cwd);
-    throw error;
+    for (const branch of createdBranches) {
+      try {
+        await git(["branch", "-D", branch], cwd);
+      } catch (recoveryError) {
+        failures.push({
+          error: recoveryError,
+          label: `Created branch cleanup failed (${branch})`,
+        });
+      }
+    }
+    throw withRecoveryFailures(error, failures);
   }
 
   summaryPath = await reviewSummaryPath(config, cwd);
@@ -1245,17 +1323,16 @@ async function main() {
       "union verification",
       "Inspect the generated review summary and the listed file differences before changing groups.json.",
       async () => {
-        await verifyUnion(config, groups, sourceBranch, created, cwd);
+        await verifyUnion(config, groups, sourceBranch, reviewBranches, cwd);
       },
     );
     await withPhase(
       "session artifact verification",
       "Remove autoresearch.* files from review branches, then rerun finalization.",
       async () => {
-        await verifyNoSessionArtifacts(created, cwd, planExcludesSessionArtifacts(config));
+        await verifyNoSessionArtifacts(reviewBranches, cwd, planExcludesSessionArtifacts(config));
       },
     );
-    await restoreSourceBranch(sourceBranch, cwd);
     await writeReviewSummary(summaryPath, {
       config,
       groups,
@@ -1264,23 +1341,29 @@ async function main() {
       status: "verified",
     });
   } catch (error) {
-    await restoreSourceBranch(sourceBranch, cwd);
+    const failures: RecoveryFailure[] = [];
+    try {
+      await restoreSourceBranchIfNeeded(sourceBranch, cwd);
+    } catch (recoveryError) {
+      failures.push({ error: recoveryError, label: "Source branch restoration failed" });
+    }
+    const failure = withRecoveryFailures(error, failures);
     await writeReviewSummary(summaryPath, {
       config,
       groups,
       results,
       sourceBranch,
       status: "failed",
-      error,
+      error: failure,
     });
     console.error("");
     console.error(`Review summary: ${summaryPath}`);
-    throw error;
+    throw failure;
   }
 
   console.log("");
   console.log("Created review branches:");
-  for (const branch of created) console.log(`  ${branch}`);
+  for (const branch of reviewBranches) console.log(`  ${branch}`);
   console.log("");
   if (productGradeFinalizationIssue(config.product_claim_coverage)) {
     console.log("Experimental review branch only: product-grade proof is missing.");

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -654,6 +654,160 @@ testWithTempRoot(
 );
 
 testWithTempRoot(
+  "finalizer rollback preserves pre-existing equivalent, divergent, and verification branches",
+  "finalize-owned-branches-",
+  async (root) => {
+    const repo = path.join(root, "repo");
+    await fsp.mkdir(repo, { recursive: true });
+
+    await git(["init", "-b", "main"], repo);
+    await writeFile(path.join(repo, "src", "a.txt"), "base a\n");
+    await writeFile(path.join(repo, "src", "b.txt"), "base b\n");
+    await git(["add", "-A"], repo);
+    await git(["commit", "-m", "base"], repo);
+    const base = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    await git(["switch", "-c", "codex/ownership-test"], repo);
+    await writeFile(path.join(repo, "src", "a.txt"), "planned a\n");
+    await git(["commit", "-am", "planned a"], repo);
+    const first = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+    await writeFile(path.join(repo, "src", "b.txt"), "planned b\n");
+    await git(["commit", "-am", "planned b"], repo);
+    const finalTree = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    const equivalent = "autoresearch-review/ownership-test/01-planned-a";
+    await git(["switch", "--detach", base], repo);
+    await git(["switch", "-c", equivalent], repo);
+    await writeFile(path.join(repo, "src", "a.txt"), "planned a\n");
+    await git(["commit", "-am", "existing equivalent review"], repo);
+    const equivalentHead = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    const divergent = "autoresearch-review/ownership-test/02-planned-b";
+    await git(["switch", "--detach", base], repo);
+    await git(["switch", "-c", divergent], repo);
+    await writeFile(path.join(repo, "src", "b.txt"), "wrong b\n");
+    await git(["commit", "-am", "existing divergent review"], repo);
+    const divergentHead = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    const verificationCollision = "autoresearch-review/ownership-test/verify-planned-a";
+    await git(["branch", verificationCollision, base], repo);
+    const verificationHead = (await git(["rev-parse", verificationCollision], repo)).stdout.trim();
+    await git(["switch", "codex/ownership-test"], repo);
+
+    const groupsPath = path.join(root, "groups.json");
+    await fsp.writeFile(
+      groupsPath,
+      JSON.stringify(
+        {
+          base,
+          trunk: "main",
+          final_tree: finalTree,
+          goal: "ownership-test",
+          groups: [
+            {
+              title: "Planned a",
+              body: "Reuse the equivalent branch.",
+              last_commit: first,
+              slug: "planned-a",
+            },
+            {
+              title: "Planned b",
+              body: "Reject the divergent branch.",
+              last_commit: finalTree,
+              slug: "planned-b",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = await run(process.execPath, [finalizer, groupsPath], repo, true);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /divergent/i);
+    assert.equal((await git(["rev-parse", equivalent], repo)).stdout.trim(), equivalentHead);
+    assert.equal((await git(["rev-parse", divergent], repo)).stdout.trim(), divergentHead);
+    assert.equal(
+      (await git(["rev-parse", verificationCollision], repo)).stdout.trim(),
+      verificationHead,
+    );
+    const verificationBranches = (
+      await git(["branch", "--list", "autoresearch-review/ownership-test/verify-*"], repo)
+    ).stdout
+      .trim()
+      .replace(/^\*?\s*/, "");
+    assert.equal(verificationBranches, verificationCollision);
+    assert.equal(
+      (await git(["branch", "--show-current"], repo)).stdout.trim(),
+      "codex/ownership-test",
+    );
+  },
+);
+
+testWithTempRoot(
+  "finalizer makes source restoration and temporary cleanup failures blocking",
+  "finalize-restore-failure-",
+  async (root) => {
+    const repo = path.join(root, "repo");
+    await fsp.mkdir(repo, { recursive: true });
+
+    await git(["init", "-b", "main"], repo);
+    await writeFile(path.join(repo, "src", "value.txt"), "base\n");
+    await git(["add", "-A"], repo);
+    await git(["commit", "-m", "base"], repo);
+    const base = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    const sourceBranch = "codex/restore-test";
+    await git(["switch", "-c", sourceBranch], repo);
+    await writeFile(path.join(repo, "src", "value.txt"), "planned\n");
+    await git(["commit", "-am", "planned value"], repo);
+    const finalTree = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+
+    const hooks = path.join(root, "hooks");
+    const postCommit = path.join(hooks, "post-commit");
+    await writeFile(
+      postCommit,
+      `#!/bin/sh\ngit branch -D ${sourceBranch} >/dev/null 2>&1 || true\n`,
+    );
+    await fsp.chmod(postCommit, 0o755);
+    await git(["config", "core.hooksPath", hooks.replace(/\\/g, "/")], repo);
+
+    const groupsPath = path.join(root, "groups.json");
+    await fsp.writeFile(
+      groupsPath,
+      JSON.stringify(
+        {
+          base,
+          trunk: "main",
+          final_tree: finalTree,
+          goal: "restore-test",
+          groups: [
+            {
+              title: "Planned value",
+              body: "Force source restoration failure after branch creation.",
+              last_commit: finalTree,
+              slug: "planned-value",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = await run(process.execPath, [finalizer, groupsPath], repo, true);
+    const output = result.stderr + result.stdout;
+    assert.notEqual(result.code, 0);
+    assert.match(output, /Source branch restoration failed|Verification state restoration failed/);
+    assert.match(output, /git switch codex\/restore-test failed/);
+    assert.match(output, /Temporary branch cleanup failed/);
+  },
+);
+
+testWithTempRoot(
   "finalize preview blocks unlogged non-session commits from the final tree",
   "autoresearch-finalize-preview-",
   async (root) => {

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -410,7 +410,8 @@ testWithTempRoot(
 
     const result = await run(process.execPath, [finalizer, groupsPath], repo);
     assert.match(result.stdout, /Review summary: .+autoresearch-finalize.+\.md/);
-    assert.match(result.stdout, /Created review branches:/);
+    assert.match(result.stdout, /Review branches:/);
+    assert.match(result.stdout, /autoresearch-review\/ux-test\/01-value-change \(created\)/);
     assert.match(result.stdout, /Cleanup after verified merge/);
     assert.doesNotMatch(result.stdout, /git branch -D/);
     assert.doesNotMatch(result.stdout, /Remove-Item/);
@@ -423,6 +424,8 @@ testWithTempRoot(
     const summary = await fsp.readFile(summaryPath, "utf8");
 
     assert.match(summary, /Status: verified/);
+    assert.match(summary, /\| # \| Branch \| Provenance \| Title \| Files \|/);
+    assert.match(summary, /\| 1 \| `autoresearch-review\/ux-test\/01-value-change` \| created \|/);
     assert.match(summary, /autoresearch-review\/ux-test\/01-value-change/);
     assert.match(summary, /git show --stat 'autoresearch-review\/ux-test\/01-value-change'/);
     assert.match(summary, /git diff [^\n]+ -- 'scripts\/autoresearch\.ts' 'src\/space path\.txt'/);
@@ -467,6 +470,20 @@ testWithTempRoot(
     ).stdout;
     assert.doesNotMatch(branchFiles, /autoresearch\.research/);
     assert.doesNotMatch(branchFiles, /autoresearch-dashboard\.html/);
+
+    const reusedResult = await run(process.execPath, [finalizer, groupsPath], repo);
+    assert.match(reusedResult.stdout, /autoresearch-review\/ux-test\/01-value-change \(reused\)/);
+    const reusedSummaryLine = reusedResult.stdout
+      .split(/\r?\n/)
+      .find((line) => line.startsWith("Review summary: "));
+    const reusedSummary = await fsp.readFile(
+      reusedSummaryLine.slice("Review summary: ".length).trim(),
+      "utf8",
+    );
+    assert.match(
+      reusedSummary,
+      /\| 1 \| `autoresearch-review\/ux-test\/01-value-change` \| reused \|/,
+    );
 
     const status = (await run("git", ["status", "--porcelain"], repo)).stdout.trim();
     assert.equal(status, "");
@@ -1300,7 +1317,7 @@ testWithTempRoot(
     assert.deepEqual(plan.groups[0].files.sort(), ["src/guardrails.txt", "src/value.txt"]);
 
     const finalizeResult = await run(process.execPath, [finalizer, payload.planOutput], repo);
-    assert.match(finalizeResult.stdout, /Created review branches:/);
+    assert.match(finalizeResult.stdout, /Review branches:/);
   },
 );
 
@@ -1970,7 +1987,7 @@ testWithTempRoot(
     assert.equal(collapsed.groups[0].parent_commit, collapsed.base);
 
     const finalizeResult = await run(process.execPath, [finalizer, collapsedOutput], repo);
-    assert.match(finalizeResult.stdout, /Created review branches/);
+    assert.match(finalizeResult.stdout, /Review branches/);
     const summaryLine = finalizeResult.stdout
       .split(/\r?\n/)
       .find((line) => line.startsWith("Review summary: "));


### PR DESCRIPTION
## Context

Finalization could reuse an equivalent pre-existing review branch, record it with current-run branches, and delete it when a later group failed. Temporary verification refs also used deterministic names and force-deleted collisions, while source restoration and cleanup errors were ignored. This PR addresses #284 without changing accepted-evidence revalidation from #285.

## What Changed

- Added explicit `createdThisRun` ownership to every finalization branch result.
- Separated all review branches from the smaller set of refs owned by the current invocation; rollback deletes only the owned set.
- Replaced deterministic verification refs with UUID-suffixed refs and removed collision deletion.
- Made source restoration and branch cleanup strict, blocking failures while preserving the original error and recovery details.
- Labeled every active review branch as `created` or `reused` in the generated summary, runway, and terminal output.
- Added hostile regressions for equivalent and divergent pre-existing review branches, a pre-existing verification-name collision, forced source-restoration failure, and truthful created/reused output.
- Recorded the user-facing fix in `CHANGELOG.md`.

## How To Review

1. Check ownership assignment in `createBranchForGroup` and `reuseExistingBranchForGroup`.
2. Check rollback routing in `main`: reused refs remain in verification but never enter `createdBranches`.
3. Check `withTemporaryVerificationBranch` for unique names, strict restoration, and current-run-only cleanup.
4. Check `branchProvenance` and the focused test that runs finalization twice to prove `created` then `reused` output.
5. Read the hostile temporary-repository tests in `finalize-report.test.ts`.

## Verification

- `npm run test:finalize` - passed 33/33 tests across 11 shards on the implementation commit.
- `node --test --test-concurrency=1 --test-name-pattern "finalizer (rollback preserves|makes source restoration)" dist\tests\finalize-report.test.mjs` - passed 2/2 hostile regressions.
- `npm run check` - passed typecheck, lint, format, product checks (15/15), CLI/dashboard/finalizer/core suites, package artifact, and runtime smoke on the implementation commit.
- Current HEAD amendment: `node --test --test-concurrency=1 --test-name-pattern "finalizer writes an ignored review summary and preserves verification" dist\tests\finalize-report.test.mjs` - passed 1/1.
- Current HEAD amendment: focused `oxfmt --check` and `git diff --check` passed.

## Risk

The change is confined to finalizer branch lifecycle, recovery, and truthful provenance labels. Review branches intentionally remain after successful finalization; only rollback cleanup is ownership-gated. No stale accepted-evidence revalidation is included.