### PR TITLE
Serialize active progress writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 - Installed-runtime checks now honor `CODEX_HOME`, resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions lack active-launcher proof. The obsolete combined marketplace namespace remains a labelled fallback only.
 - Finalization now preserves pre-existing review and verification branches during rollback, deletes only branches created by the current invocation, and fails visibly when branch restoration or cleanup cannot complete.
+- Serialized and coalesced active packet progress writes so terminal cleanup cannot be undone by a delayed older snapshot; progress generations remain ordered across interrupted runs, cleanup also runs after writer or packet failures, and non-missing deletion errors are reported.
 
 ## 2.6.0 - 2026-07-09
 

--- a/plugins/codex-autoresearch/lib/active-progress-writer.ts
+++ b/plugins/codex-autoresearch/lib/active-progress-writer.ts
@@ -1,0 +1,80 @@
+type ProgressSnapshot = object;
+type GeneratedSnapshot<Snapshot extends ProgressSnapshot> = Snapshot & { generation: number };
+
+export function createCoalescingProgressWriter<Snapshot extends ProgressSnapshot>({
+  initialGeneration = 0,
+  minWriteIntervalMs = 50,
+  write,
+}: {
+  initialGeneration?: number;
+  minWriteIntervalMs?: number;
+  write: (snapshot: GeneratedSnapshot<Snapshot>) => Promise<void>;
+}) {
+  let generation = safeGeneration(initialGeneration);
+  let pending: GeneratedSnapshot<Snapshot> | null = null;
+  let active: Promise<void> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastWriteStartedAt = 0;
+  let failure: unknown = null;
+  let closed = false;
+
+  const startWrite = () => {
+    if (active || !pending || failure) return;
+    const snapshot = pending;
+    pending = null;
+    lastWriteStartedAt = Date.now();
+    active = Promise.resolve()
+      .then(() => write(snapshot))
+      .catch((error) => {
+        failure = error;
+      })
+      .finally(() => {
+        active = null;
+        if (pending && !closed && !failure) schedule();
+      });
+  };
+
+  const schedule = () => {
+    if (active || timer || !pending || failure) return;
+    const delay = Math.max(0, minWriteIntervalMs - (Date.now() - lastWriteStartedAt));
+    if (delay === 0) return startWrite();
+    timer = setTimeout(() => {
+      timer = null;
+      startWrite();
+    }, delay);
+  };
+
+  const flush = async () => {
+    for (;;) {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (failure) throw failure;
+      if (!active && pending) startWrite();
+      const current = active;
+      if (!current) return;
+      await current;
+    }
+  };
+
+  return {
+    queue(snapshot: Snapshot): GeneratedSnapshot<Snapshot> {
+      if (closed) throw new Error("Active progress writer is closed.");
+      const generated = { ...snapshot, generation: ++generation };
+      pending = generated;
+      schedule();
+      return generated;
+    },
+    flush,
+    async close() {
+      closed = true;
+      await flush();
+    },
+  };
+}
+
+function safeGeneration(value: unknown): number {
+  const generation = Number(value);
+  return Number.isSafeInteger(generation) && generation >= 0 ? generation : 0;
+}

--- a/plugins/codex-autoresearch/lib/runner-progress.ts
+++ b/plugins/codex-autoresearch/lib/runner-progress.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 type LooseObject = Record<string, any>;
 
 export interface RunnerProgressSnapshot {
+  generation: number;
   packetId: string;
   commandClass: string;
   startedAt: string;
@@ -52,6 +53,7 @@ export function createProgressSnapshot({
   artifactRoot = "",
 }: LooseObject = {}): RunnerProgressSnapshot {
   return {
+    generation: 0,
     packetId: packetId || progressId(command, startedAt),
     commandClass: commandClass || commandClassFor(command),
     startedAt: isoTime(startedAt),

--- a/plugins/codex-autoresearch/lib/runtime-drift-doctor.ts
+++ b/plugins/codex-autoresearch/lib/runtime-drift-doctor.ts
@@ -292,7 +292,7 @@ function buildNextActionHint({
   }
   if (installedRuntime === "unavailable") {
     if (installedRuntimeShape === "source-shaped-package") {
-      return `The installed cache at ${installedRuntimePath} is source-shaped and not hydrated. Run its launcher once, then rerun: ${inspectionCommand}`;
+      return `The installed runtime cache at ${installedRuntimePath} is source-shaped and not hydrated. Run its launcher once, then rerun: ${inspectionCommand}`;
     }
     return `Installed runtime fingerprint evidence is unavailable. Inspect the runtime with: ${inspectionCommand}`;
   }

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -63,6 +63,7 @@ import { createCliCommandHandlers, runCliCommand } from "../lib/cli-handlers.js"
 import { buildDriftReport } from "../lib/drift-doctor.js";
 import { inspectRuntimeDrift } from "../lib/runtime-drift-doctor.js";
 import { analyzeExperimentEconomics } from "../lib/experiment-economics.js";
+import { createCoalescingProgressWriter } from "../lib/active-progress-writer.js";
 import { buildSourceCleanliness } from "../lib/source-cleanliness.js";
 import { buildTerminalReport } from "../lib/terminal-report.js";
 import {
@@ -147,6 +148,7 @@ import {
   createProgressSnapshot,
   progressSnapshotFromRun,
   staleProgressReason,
+  type RunnerProgressSnapshot,
   updateProgressSnapshot,
 } from "../lib/runner-progress.js";
 import {
@@ -703,6 +705,40 @@ function resolveOutputInside(workDir: string, output?: string) {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+async function runWithRequiredCleanup<T>(
+  action: () => Promise<T>,
+  cleanup: () => Promise<void>,
+  cleanupLabel: string,
+): Promise<T> {
+  let value!: T;
+  let actionFailed = false;
+  let primaryError: unknown;
+  let cleanupFailed = false;
+  let cleanupError: unknown;
+  try {
+    value = await action();
+  } catch (error) {
+    actionFailed = true;
+    primaryError = error;
+  } finally {
+    try {
+      await cleanup();
+    } catch (error) {
+      cleanupFailed = true;
+      cleanupError = error;
+    }
+  }
+  if (cleanupFailed) {
+    if (!actionFailed) throw cleanupError;
+    throw new AggregateError(
+      [primaryError, cleanupError],
+      `${errorMessage(primaryError)}\n${cleanupLabel}: ${errorMessage(cleanupError)}`,
+    );
+  }
+  if (actionFailed) throw primaryError;
+  return value;
 }
 
 function errorCodeOrMessage(error: unknown): string {
@@ -6023,6 +6059,19 @@ async function initExperiment(args: LooseObject) {
 }
 
 async function runExperiment(args: LooseObject) {
+  const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
+  const progressWriter = await createActiveProgressWriter(workDir);
+  return await runWithRequiredCleanup(
+    () => runExperimentWithProgressWriter(args, progressWriter),
+    () => progressWriter.close(),
+    "Failed to close active progress writer",
+  );
+}
+
+async function runExperimentWithProgressWriter(
+  args: LooseObject,
+  progressWriter: Awaited<ReturnType<typeof createActiveProgressWriter>>,
+) {
   const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
   const state = currentState(workDir);
   const limit = iterationLimitInfo(state, config);
@@ -6056,7 +6105,8 @@ async function runExperiment(args: LooseObject) {
     timeoutSeconds,
     artifactRoot: ".",
   });
-  await writeActiveProgressSnapshot(workDir, progressSnapshot);
+  progressSnapshot = progressWriter.queue(progressSnapshot);
+  await progressWriter.flush();
   const updateProgress = ({ observedAt, output }: { observedAt: string; output: string }) => {
     progressSnapshot = updateProgressSnapshot(progressSnapshot, { output, observedAt });
     progressSnapshot = {
@@ -6069,7 +6119,7 @@ async function runExperiment(args: LooseObject) {
         ),
       }),
     };
-    void writeActiveProgressSnapshot(workDir, progressSnapshot).catch(() => {});
+    progressSnapshot = progressWriter.queue(progressSnapshot);
   };
   const benchmark = await runShell(command, workDir, timeoutSeconds, {
     env: commandInput.env,
@@ -6178,8 +6228,8 @@ async function runExperiment(args: LooseObject) {
       result: benchmark,
     }),
     startedAt: benchmark.startedAt,
-    finishedAt: benchmark.finishedAt,
-    lastOutputAt: benchmark.lastOutputAt,
+    finishedAt: checks?.finishedAt || benchmark.finishedAt,
+    lastOutputAt: checks?.lastOutputAt || benchmark.lastOutputAt,
     progressSnapshot,
     exitCode: benchmark.exitCode,
     timedOut: benchmark.timedOut || Boolean(checks?.timedOut),
@@ -6705,6 +6755,8 @@ async function writeLastRunPacket(workDir: string, packet: any, filePath: string
 
 async function writeActiveProgressSnapshot(workDir: string, snapshot: LooseObject) {
   const target = await resolveProgressPath(workDir);
+  const generation = activeProgressGeneration(snapshot);
+  if (generation <= activeProgressGeneration(readProgressSnapshot(target))) return target;
   await checkedAtomicWriteFile(
     await privateStateWriteRoot(workDir, target),
     target,
@@ -6718,28 +6770,50 @@ async function writeActiveProgressSnapshot(workDir: string, snapshot: LooseObjec
 
 async function readActiveProgressSnapshot(workDir: string, config: LooseObject = {}) {
   const target = await resolveProgressPath(workDir);
+  const snapshot = readProgressSnapshot(target);
+  if (!snapshot || snapshot.exitState !== "running") return snapshot;
+  return {
+    ...snapshot,
+    staleProgressReason: staleProgressReason(snapshot as RunnerProgressSnapshot, {
+      staleAfterSeconds: numberOption(
+        config.staleProgressSeconds ?? config.progressStaleSeconds,
+        300,
+      ),
+    }),
+  };
+}
+
+async function createActiveProgressWriter(workDir: string) {
+  const current = await readActiveProgressSnapshot(workDir);
+  return createCoalescingProgressWriter<RunnerProgressSnapshot>({
+    initialGeneration: activeProgressGeneration(current),
+    write: async (snapshot) => {
+      await writeActiveProgressSnapshot(workDir, snapshot);
+    },
+  });
+}
+
+function readProgressSnapshot(target: string): LooseObject | null {
   if (!fs.existsSync(target)) return null;
   try {
     const snapshot = JSON.parse(fs.readFileSync(target, "utf8"));
-    if (!snapshot || typeof snapshot !== "object" || snapshot.exitState !== "running") {
-      return snapshot || null;
-    }
-    return {
-      ...snapshot,
-      staleProgressReason: staleProgressReason(snapshot, {
-        staleAfterSeconds: numberOption(
-          config.staleProgressSeconds ?? config.progressStaleSeconds,
-          300,
-        ),
-      }),
-    };
+    return snapshot && typeof snapshot === "object" && !Array.isArray(snapshot) ? snapshot : null;
   } catch {
     return null;
   }
 }
 
+function activeProgressGeneration(snapshot: LooseObject | null): number {
+  const generation = Number(snapshot?.generation);
+  return Number.isSafeInteger(generation) && generation >= 0 ? generation : 0;
+}
+
 async function deleteActiveProgressSnapshot(workDir: string) {
-  await fsp.rm(await resolveProgressPath(workDir), { force: true }).catch(() => {});
+  try {
+    await fsp.rm(await resolveProgressPath(workDir));
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+  }
 }
 
 function redactLastRunPacketForStorage(packet: LooseObject): LooseObject {
@@ -8681,8 +8755,17 @@ function promotionStateForLoggedDecision({
 }
 
 async function nextExperiment(args: any) {
+  const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
+  return await runWithRequiredCleanup(
+    () => nextExperimentWithActiveProgress(args),
+    () => deleteActiveProgressSnapshot(workDir),
+    "Failed to remove active progress snapshot",
+  );
+}
+
+async function nextExperimentWithActiveProgress(args: any) {
   const { workDir, config } = resolveWorkDir(args.working_dir || args.cwd);
-  await writeNextPreflightProgressSnapshot(workDir, args, config).catch(() => {});
+  await writeNextPreflightProgressSnapshot(workDir, args, config);
   const doctor = await doctorSession({
     ...args,
     check_benchmark: false,
@@ -8701,7 +8784,6 @@ async function nextExperiment(args: any) {
     ) {
       const state = currentState(doctor.workDir);
       const capsule = state.sessionDecisionCapsule || null;
-      await deleteActiveProgressSnapshot(workDir).catch(() => {});
       return {
         ok: false,
         workDir: doctor.workDir,
@@ -8737,7 +8819,6 @@ async function nextExperiment(args: any) {
         }),
       };
     }
-    await deleteActiveProgressSnapshot(workDir).catch(() => {});
     return {
       ok: false,
       workDir: doctor.workDir,
@@ -8783,7 +8864,6 @@ async function nextExperiment(args: any) {
     !boundedNextAllowed &&
     !stalePacketReplacementAllowed
   ) {
-    await deleteActiveProgressSnapshot(workDir).catch(() => {});
     return {
       ok: false,
       workDir,
@@ -8826,7 +8906,6 @@ async function nextExperiment(args: any) {
     args,
   );
   if (fixedControlBlock) {
-    await deleteActiveProgressSnapshot(workDir).catch(() => {});
     const nextAction =
       fixedControlBlock.message ||
       "A fixed control artifact is active; reuse it instead of rerunning the control command.";
@@ -8853,7 +8932,6 @@ async function nextExperiment(args: any) {
     error: error.message || String(error),
   }));
   if (gitSnapshotContainsDirtyFingerprintTruncation(preRunGit)) {
-    await deleteActiveProgressSnapshot(workDir).catch(() => {});
     const nextAction =
       "Clean or narrow the dirty tree before running next; dirty file fingerprints were truncated before packet freshness could be proven.";
     return {
@@ -8959,8 +9037,16 @@ async function nextExperiment(args: any) {
     }),
   };
   await writeLastRunPacket(run.workDir, packet, lastRunFile);
-  await deleteActiveProgressSnapshot(run.workDir);
   return boolOption(args.compact, false) ? compactNextExperimentPacket(packet) : packet;
+}
+
+async function runStandaloneExperiment(args: LooseObject) {
+  const { workDir } = resolveWorkDir(args.working_dir || args.cwd);
+  return await runWithRequiredCleanup(
+    () => runExperiment(args),
+    () => deleteActiveProgressSnapshot(workDir),
+    "Failed to remove active progress snapshot",
+  );
 }
 
 async function writeNextPreflightProgressSnapshot(
@@ -8978,16 +9064,22 @@ async function writeNextPreflightProgressSnapshot(
     args.timeout_seconds ?? args.timeoutSeconds,
     DEFAULT_TIMEOUT_SECONDS,
   );
-  await writeActiveProgressSnapshot(
-    workDir,
-    createProgressSnapshot({
-      packetId: `packet-${state.results.length + 1}-active`,
-      command: commandSource?.command || "autoresearch next preflight",
-      commandClass: "autoresearch preflight",
-      startedAt: new Date().toISOString(),
-      timeoutSeconds,
-      artifactRoot: ".",
-    }),
+  const progressWriter = await createActiveProgressWriter(workDir);
+  await runWithRequiredCleanup(
+    async () => {
+      progressWriter.queue(
+        createProgressSnapshot({
+          packetId: `packet-${state.results.length + 1}-active`,
+          command: commandSource?.command || "autoresearch next preflight",
+          commandClass: "autoresearch preflight",
+          startedAt: new Date().toISOString(),
+          timeoutSeconds,
+          artifactRoot: ".",
+        }),
+      );
+    },
+    () => progressWriter.close(),
+    "Failed to close active progress writer",
   );
 }
 
@@ -9166,7 +9258,7 @@ async function executeAutoresearchCli(
       recipeCommand,
       researchFanout,
       laneRunner,
-      runExperiment,
+      runExperiment: runStandaloneExperiment,
       serveDashboard,
       setupPlan,
       researchStart,

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../lib/partial-results.js";
 import { commandForDecisionCapsule } from "../lib/commands/session-forensics.js";
 import { analyzeLedgerHealth, repairLedgerRecords } from "../lib/ledger-health.js";
+import { createCoalescingProgressWriter } from "../lib/active-progress-writer.js";
 import { renderExportedDashboard } from "./helpers/dashboard-export.js";
 import {
   prepareCurrentTreeFinalizationBlocker,
@@ -949,12 +950,209 @@ test("state surfaces active runner progress while next is still executing", asyn
     }
     await writeFile(releaseFile, "go\n", "utf8");
     assert.equal(progress?.exitState, "running");
+    assert.equal(Number.isSafeInteger(progress?.generation), true);
     assert.match(progress?.packetId || "", /active/);
 
     const exitCode = await new Promise((resolve) => child.on("close", resolve));
     assert.equal(exitCode, 0, stderr);
     const packetPayload = JSON.parse(stdout);
     assert.equal(packetPayload.packetEvidence.progressSnapshot.exitState, "completed");
+    await assert.rejects(access(path.join(dir, "autoresearch.progress.json")));
+  });
+});
+
+test("active progress writer serializes delayed writes and coalesces newer generations", async () => {
+  const writes: number[] = [];
+  let releaseFirstWrite = () => {};
+  let markFirstWriteStarted = () => {};
+  const firstWriteStarted = new Promise<void>((resolve) => {
+    markFirstWriteStarted = resolve;
+  });
+  const firstWriteReleased = new Promise<void>((resolve) => {
+    releaseFirstWrite = resolve;
+  });
+  const writer = createCoalescingProgressWriter({
+    initialGeneration: 4,
+    minWriteIntervalMs: 0,
+    write: async (snapshot) => {
+      if (snapshot.generation === 5) {
+        markFirstWriteStarted();
+        await firstWriteReleased;
+      }
+      writes.push(snapshot.generation);
+    },
+  });
+
+  assert.equal(writer.queue({ exitState: "running" }).generation, 5);
+  await firstWriteStarted;
+  assert.equal(writer.queue({ exitState: "running" }).generation, 6);
+  assert.equal(writer.queue({ exitState: "running" }).generation, 7);
+  const closing = writer.close();
+  releaseFirstWrite();
+  await closing;
+
+  assert.deepEqual(writes, [5, 7]);
+  assert.throws(() => writer.queue({ exitState: "running" }), /closed/);
+});
+
+test("active progress writer closes after rejection without replaying pending generations", async () => {
+  const writes: number[] = [];
+  let markWriteStarted = () => {};
+  let releaseWrite = () => {};
+  const writeStarted = new Promise<void>((resolve) => {
+    markWriteStarted = resolve;
+  });
+  const writeReleased = new Promise<void>((resolve) => {
+    releaseWrite = resolve;
+  });
+  const writer = createCoalescingProgressWriter({
+    minWriteIntervalMs: 0,
+    write: async (snapshot) => {
+      writes.push(snapshot.generation);
+      markWriteStarted();
+      await writeReleased;
+      throw new Error("hostile progress write rejection");
+    },
+  });
+
+  writer.queue({ exitState: "running" });
+  await writeStarted;
+  writer.queue({ exitState: "running" });
+  const closing = writer.close();
+  releaseWrite();
+
+  await assert.rejects(closing, /hostile progress write rejection/);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.deepEqual(writes, [1]);
+  assert.throws(() => writer.queue({ exitState: "running" }), /closed/);
+});
+
+test("standalone run removes active progress after an exception before writer close", async () => {
+  await withTempDir("standalone-progress-cleanup", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "cleanup", "--metric-name", "seconds"]);
+    const progressPath = path.join(dir, "autoresearch.progress.json");
+    await writeFile(
+      progressPath,
+      JSON.stringify({ exitState: "running", generation: 7, packetId: "stale-active" }),
+    );
+
+    const result = await runCli([
+      "run",
+      "--cwd",
+      dir,
+      "--command-file",
+      "missing-command-file.txt",
+    ]);
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /ENOENT/);
+    assert.equal(await pathExists(progressPath), false);
+  });
+});
+
+test("active progress deletion propagates wrong-entry-type failures", async () => {
+  await withTempDir("progress-delete-failure", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "delete failure", "--metric-name", "seconds"]);
+    const progressPath = path.join(dir, "autoresearch.progress.json");
+    await mkdir(progressPath);
+
+    const result = await runCli([
+      "run",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} -e ${quoteForShell("console.log('METRIC seconds=1')")}`,
+    ]);
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /Write target must be a regular file/);
+    assert.match(result.stderr, /Failed to remove active progress snapshot/);
+    assert.equal((await stat(progressPath)).isDirectory(), true);
+  });
+});
+
+test("next removes active progress when terminal packet persistence fails", async () => {
+  await withTempDir("terminal-packet-progress-cleanup", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "terminal cleanup", "--metric-name", "seconds"]);
+    await mkdir(path.join(dir, "autoresearch.last-run.json"));
+
+    const result = await runCli([
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} -e ${quoteForShell("console.log('METRIC seconds=1')")}`,
+    ]);
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /Write target must be a regular file/);
+    assert.equal(await pathExists(path.join(dir, "autoresearch.progress.json")), false);
+  });
+});
+
+test("chatty completion and failure cannot resurrect active progress", async () => {
+  for (const [name, exitCode, expectedState] of [
+    ["completed", 0, "completed"],
+    ["failed", 7, "failed"],
+  ] as const) {
+    await withTempDir(`chatty-progress-${name}`, async (dir) => {
+      await runCli(["init", "--cwd", dir, "--name", name, "--metric-name", "seconds"]);
+      const script = path.join(dir, "chatty.mjs");
+      await writeFile(
+        script,
+        [
+          "for (let index = 0; index < 2000; index += 1) process.stdout.write(`row-${index}\\n`);",
+          "console.log('METRIC seconds=1');",
+          `process.exitCode = ${exitCode};`,
+        ].join("\n"),
+      );
+
+      const result = await runCli([
+        "next",
+        "--cwd",
+        dir,
+        "--command",
+        `${quoteForShell(process.execPath)} ${quoteForShell(script)}`,
+      ]);
+      assert.equal(result.code, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.packetEvidence.progressSnapshot.exitState, expectedState);
+      assert.ok(payload.packetEvidence.progressSnapshot.generation >= 2);
+      assert.equal(await pathExists(path.join(dir, "autoresearch.progress.json")), false);
+    });
+  }
+});
+
+test("checks-phase timeout flushes its newest generation before cleanup", async () => {
+  await withTempDir("checks-progress-timeout", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "checks timeout", "--metric-name", "seconds"]);
+    const checks = path.join(dir, "checks.mjs");
+    await writeFile(
+      checks,
+      [
+        "for (let index = 0; index < 200; index += 1) process.stdout.write(`check-${index}\\n`);",
+        "setTimeout(() => {}, 5000);",
+      ].join("\n"),
+    );
+
+    const result = await runCli([
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} -e ${quoteForShell("console.log('METRIC seconds=1')")}`,
+      "--checks-command",
+      `${quoteForShell(process.execPath)} ${quoteForShell(checks)}`,
+      "--checks-timeout-seconds",
+      "1",
+    ]);
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    const progress = payload.packetEvidence.progressSnapshot;
+    assert.equal(progress.exitState, "timed_out");
+    assert.equal(progress.timeoutPhase, "checks");
+    assert.ok(progress.generation >= 4);
+    assert.equal(await pathExists(path.join(dir, "autoresearch.progress.json")), false);
   });
 });
 


### PR DESCRIPTION
## Context

Progress callbacks wrote every stdout/stderr chunk with unawaited atomic writes. A slow older write could therefore land after terminal packet persistence deleted active progress, resurrecting a completed packet as `running`. The same fire-and-forget path also allowed snapshots to reach disk out of order.

Closes #286.

## What Changed

- Added one serialized, coalescing active-progress writer with persisted monotonic generations.
- Carries generation forward from interrupted active state and refuses to overwrite a newer on-disk generation.
- Forces the initial write and terminal flush, then closes the writer before terminal packet persistence and active-state deletion.
- Uses the later checks timestamps when checks outlive the benchmark.
- Cleans up standalone `run` progress on both success and failure.
- Added delayed-write, chatty completion/failure, live-state, and checks-timeout regressions.
- Recorded the user-facing fix in `CHANGELOG.md`.

```mermaid
flowchart LR
  output["Benchmark and checks output"] --> queue["Generation queue"]
  queue --> coalesce["One active write plus latest pending"]
  coalesce --> disk["Atomic active snapshot"]
  disk --> flush["Await terminal flush"]
  flush --> packet["Persist terminal packet"]
  packet --> cleanup["Delete active progress"]
```

## How To Review

1. Review `lib/active-progress-writer.ts` for serialization, latest-only coalescing, and close/flush behavior.
2. Review the progress integration in `scripts/autoresearch.ts`, especially generation carry-forward and terminal ordering.
3. Review the focused regressions in `tests/autoresearch-cli.test.ts`.

## Verification

- Focused progress regressions: 4/4 passed.
- `npm run test:compiled:cli`: 233 CLI tests, 20 full-product tests, and the perfection benchmark passed.
- `npm run test:compiled:core`: 309 tests passed.
- `npm run check`: passed typecheck, lint, format, source hygiene, dashboard parity, 15/15 product checks, all compiled suites, package artifact, and runtime smoke.
- `git diff --check`: passed.

## Risk

Progress writes are rate-limited to one start per 50 ms and retain only the latest pending snapshot while I/O is active. Intermediate generation numbers may be skipped by design, but persisted generations only move forward. Initial visibility and the terminal barrier are forced, so responsiveness and cleanup do not depend on the timer.