### PR TITLE
Fix canonical installed runtime discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+### Fixed
+
+- Installed-runtime checks now resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions are ambiguous. The obsolete combined marketplace namespace remains a labelled fallback only.
+
 ## 2.6.0 - 2026-07-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ### Fixed
 
-- Installed-runtime checks now resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions are ambiguous. The obsolete combined marketplace namespace remains a labelled fallback only.
+- Installed-runtime checks now honor `CODEX_HOME`, resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions lack active-launcher proof. The obsolete combined marketplace namespace remains a labelled fallback only.
 - Finalization now preserves pre-existing review and verification branches during rollback, deletes only branches created by the current invocation, and fails visibly when branch restoration or cleanup cannot complete.
 
 ## 2.6.0 - 2026-07-09

--- a/plugins/codex-autoresearch/docs/troubleshooting.md
+++ b/plugins/codex-autoresearch/docs/troubleshooting.md
@@ -7,7 +7,7 @@ Find the broken layer before repeating the command. A retry with the same precon
 | Symptom | Failing layer | What to do |
 | --- | --- | --- |
 | Source checkout missing `dist/` | Source launcher hydration | Install `gh`, confirm GitHub network access, then run `node scripts/autoresearch.mjs --help` from the plugin directory. Hydration stops if checksum, release attestation, or archive validation fails. |
-| Source behavior differs from Codex | Installed runtime drift | Inspect or refresh the active plugin cache before changing source again. |
+| Source behavior differs from Codex | Installed runtime drift | Run `doctor --check-installed --explain`. Read `installedRuntimePath`, `installedRuntimeShape`, and `installedRuntimeProvenance`; hydrate a source-shaped package, refresh a stale cache, or remove ambiguity between multiple canonical versions before changing source again. |
 | Setup wrapper calls itself | Scaffold health | Replace the recursive wrapper or rerun setup with the real `--benchmark-command`. |
 
 ## Benchmark and checks

--- a/plugins/codex-autoresearch/lib/runtime-drift-doctor.ts
+++ b/plugins/codex-autoresearch/lib/runtime-drift-doctor.ts
@@ -184,7 +184,9 @@ export async function inspectRuntimeDrift(input: {
   const installedRuntime = await inspectInstalledRuntime({
     packageRoot,
     sourceVersion: input.sourceVersion,
-    pluginCacheRoot: input.pluginCacheRoot || path.join(os.homedir(), ".codex", "plugins", "cache"),
+    pluginCacheRoot:
+      input.pluginCacheRoot ||
+      path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "plugins", "cache"),
   });
 
   return inspectRuntimeDriftFromFacts({
@@ -356,20 +358,12 @@ async function inspectInstalledRuntime(input: {
         canonical.paths.map((runtimePath) => runtimeCandidate(runtimePath, identity)),
       )
     ).filter((candidate): candidate is RuntimeCandidate => candidate !== null);
-    const matching = candidates.filter((candidate) => candidate.version === identity.version);
-    if (matching.length === 1) {
-      return selectedInspection(
-        matching[0],
-        "canonical-cache-layout",
-        "Selected the canonical cache version declared by the source plugin manifest.",
-      );
-    }
     if (candidates.length > 1) {
       return emptyInspection(
         "",
         "canonical-cache-layout",
         "ambiguous",
-        "Multiple canonical versions are metadata-valid and none matches the source plugin manifest.",
+        "Multiple canonical versions are metadata-valid and no launcher selected one.",
         candidates.map((candidate) => candidate.path),
       );
     }

--- a/plugins/codex-autoresearch/lib/runtime-drift-doctor.ts
+++ b/plugins/codex-autoresearch/lib/runtime-drift-doctor.ts
@@ -6,6 +6,29 @@ import path from "node:path";
 export type RuntimeAvailability = "fresh" | "stale" | "missing" | "unavailable";
 export type BuiltRuntimeStatus = "available" | "missing" | "unavailable";
 export type RuntimeTrustScope = "source-checkout" | "installed-plugin";
+export type RuntimePackageSurface =
+  | "source-checkout"
+  | "package-artifact"
+  | "active-installed-cache"
+  | "unavailable";
+export type InstalledRuntimeShape =
+  | "hydrated-runtime"
+  | "source-shaped-package"
+  | "package-artifact"
+  | "missing"
+  | "unavailable";
+
+export interface InstalledRuntimeProvenance {
+  source:
+    | "launcher-package-root"
+    | "canonical-cache-layout"
+    | "legacy-cache-fallback"
+    | "plugin-manifest";
+  status: "selected" | "ambiguous" | "missing" | "unavailable";
+  path: string;
+  candidates: string[];
+  detail: string;
+}
 
 export interface RuntimeStatus {
   status: string;
@@ -20,6 +43,9 @@ export interface RuntimeDriftFacts {
   installedRuntimePath: string;
   sourceRuntimeFingerprint?: string | null;
   installedRuntimeFingerprint?: string | null;
+  packageSurface?: RuntimePackageSurface;
+  installedRuntimeShape?: InstalledRuntimeShape;
+  installedRuntimeProvenance?: InstalledRuntimeProvenance;
 }
 
 export interface RuntimeDriftSummary {
@@ -30,6 +56,11 @@ export interface RuntimeDriftSummary {
   runtimeFingerprint: "matched" | "mismatched" | "unavailable";
   smokeCheck: string;
   nextActionHint: string;
+  packageSurface: RuntimePackageSurface;
+  installedRuntimePath: string;
+  installedRuntimeVersion: string | null;
+  installedRuntimeShape: InstalledRuntimeShape;
+  installedRuntimeProvenance: InstalledRuntimeProvenance;
 }
 
 export function summarizeRuntimeAuthority(input: {
@@ -105,6 +136,13 @@ export function inspectRuntimeDriftFromFacts(facts: RuntimeDriftFacts): RuntimeD
   const builtRuntime = classifyBuiltRuntime(facts.builtRuntimeExists);
   const smokeCheck = buildSmokeCheck(packageRoot, builtRuntime);
   const inspectionCommand = buildInspectionCommand(packageRoot);
+  const installedRuntimeProvenance = facts.installedRuntimeProvenance || {
+    source: "plugin-manifest",
+    status: "unavailable",
+    path: facts.installedRuntimePath,
+    candidates: [],
+    detail: "Installed runtime provenance was not inspected.",
+  };
 
   return {
     sourceVersion,
@@ -113,6 +151,11 @@ export function inspectRuntimeDriftFromFacts(facts: RuntimeDriftFacts): RuntimeD
     builtRuntime,
     runtimeFingerprint,
     smokeCheck,
+    packageSurface: facts.packageSurface || "unavailable",
+    installedRuntimePath: facts.installedRuntimePath,
+    installedRuntimeVersion: facts.installedRuntimeVersion,
+    installedRuntimeShape: facts.installedRuntimeShape || "unavailable",
+    installedRuntimeProvenance,
     nextActionHint: buildNextActionHint({
       sourceVersion,
       installedRuntime,
@@ -120,6 +163,8 @@ export function inspectRuntimeDriftFromFacts(facts: RuntimeDriftFacts): RuntimeD
       builtRuntime,
       runtimeFingerprint,
       installedRuntimePath: facts.installedRuntimePath,
+      installedRuntimeShape: facts.installedRuntimeShape || "unavailable",
+      installedRuntimeProvenance,
       inspectionCommand,
       smokeCheck,
     }),
@@ -129,13 +174,18 @@ export function inspectRuntimeDriftFromFacts(facts: RuntimeDriftFacts): RuntimeD
 export async function inspectRuntimeDrift(input: {
   packageRoot: string;
   sourceVersion: string;
+  pluginCacheRoot?: string;
 }): Promise<RuntimeDriftSummary> {
   const packageRoot = path.resolve(input.packageRoot);
   const builtRuntimePath = path.join(packageRoot, "dist", "scripts", "autoresearch.mjs");
   const builtRuntimeExists = await fileExists(builtRuntimePath);
   const sourceRuntimeFingerprint =
     builtRuntimeExists === true ? await fileFingerprint(builtRuntimePath) : null;
-  const installedRuntime = await inspectInstalledRuntime(input.sourceVersion);
+  const installedRuntime = await inspectInstalledRuntime({
+    packageRoot,
+    sourceVersion: input.sourceVersion,
+    pluginCacheRoot: input.pluginCacheRoot || path.join(os.homedir(), ".codex", "plugins", "cache"),
+  });
 
   return inspectRuntimeDriftFromFacts({
     sourceVersion: input.sourceVersion,
@@ -145,6 +195,9 @@ export async function inspectRuntimeDrift(input: {
     installedRuntimePath: installedRuntime.path,
     sourceRuntimeFingerprint,
     installedRuntimeFingerprint: installedRuntime.fingerprint,
+    packageSurface: await packageSurface(packageRoot, installedRuntime),
+    installedRuntimeShape: installedRuntime.shape,
+    installedRuntimeProvenance: installedRuntime.provenance,
   });
 }
 
@@ -199,6 +252,8 @@ function buildNextActionHint({
   builtRuntime,
   runtimeFingerprint,
   installedRuntimePath,
+  installedRuntimeShape,
+  installedRuntimeProvenance,
   inspectionCommand,
   smokeCheck,
 }: {
@@ -208,9 +263,16 @@ function buildNextActionHint({
   builtRuntime: BuiltRuntimeStatus;
   runtimeFingerprint: "matched" | "mismatched" | "unavailable";
   installedRuntimePath: string;
+  installedRuntimeShape: InstalledRuntimeShape;
+  installedRuntimeProvenance: InstalledRuntimeProvenance;
   inspectionCommand: string;
   smokeCheck: string;
 }): string {
+  if (installedRuntimeProvenance.status === "ambiguous") {
+    return `Installed runtime discovery is ambiguous across ${installedRuntimeProvenance.candidates.join(
+      ", ",
+    )}. Remove or disambiguate stale cache entries, then rerun: ${inspectionCommand}`;
+  }
   if (builtRuntime === "missing") {
     return `Build the local runtime with npm run build:node, then inspect installed runtime drift with: ${inspectionCommand}`;
   }
@@ -227,58 +289,349 @@ function buildNextActionHint({
     return `Installed runtime is missing at ${installedRuntimePath}. Inspect or refresh the runtime with: ${inspectionCommand}`;
   }
   if (installedRuntime === "unavailable") {
+    if (installedRuntimeShape === "source-shaped-package") {
+      return `The installed cache at ${installedRuntimePath} is source-shaped and not hydrated. Run its launcher once, then rerun: ${inspectionCommand}`;
+    }
     return `Installed runtime fingerprint evidence is unavailable. Inspect the runtime with: ${inspectionCommand}`;
   }
   return `Runtime surfaces look fresh; smoke check with: ${smokeCheck}`;
 }
 
-async function inspectInstalledRuntime(sourceVersion: string): Promise<{
+type PluginIdentity = { publisher: string; plugin: string; version: string };
+type RuntimeCandidate = {
+  path: string;
+  version: string;
+  fingerprint: string | null;
+  shape: InstalledRuntimeShape;
+};
+type InstalledRuntimeInspection = {
   path: string;
   version: string | null;
   fingerprint: string | null;
-}> {
-  const cacheRoot = path.join(
-    os.homedir(),
-    ".codex",
-    "plugins",
-    "cache",
-    "thegreencedar-autoresearch",
-    "codex-autoresearch",
-  );
+  shape: InstalledRuntimeShape;
+  provenance: InstalledRuntimeProvenance;
+};
 
-  let entries: string[];
-  try {
-    entries = (await fsp.readdir(cacheRoot, { withFileTypes: true }))
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
-  } catch (error) {
-    return isMissingPathError(error)
-      ? { path: cacheRoot, version: null, fingerprint: null }
-      : { path: "", version: null, fingerprint: null };
+const LEGACY_CACHE_NAMESPACE = "thegreencedar-autoresearch";
+
+async function inspectInstalledRuntime(input: {
+  packageRoot: string;
+  sourceVersion: string;
+  pluginCacheRoot: string;
+}): Promise<InstalledRuntimeInspection> {
+  const identity = await pluginIdentity(input.packageRoot, input.sourceVersion);
+  if (!identity) {
+    return emptyInspection("", "plugin-manifest", "unavailable", "Plugin identity is unavailable.");
   }
 
-  if (entries.length === 0) return { path: cacheRoot, version: null, fingerprint: null };
+  const launcherRelative = path.relative(input.pluginCacheRoot, input.packageRoot).split(path.sep);
+  if (
+    launcherRelative.length === 3 &&
+    launcherRelative[0] === identity.publisher &&
+    launcherRelative[1] === identity.plugin &&
+    launcherRelative[2] === identity.version
+  ) {
+    const launcher = await runtimeCandidate(input.packageRoot, identity);
+    return launcher
+      ? selectedInspection(
+          launcher,
+          "launcher-package-root",
+          "Selected the cache package that owns the running launcher.",
+        )
+      : emptyInspection(
+          "",
+          "launcher-package-root",
+          "unavailable",
+          "The running launcher does not match its package metadata.",
+        );
+  }
 
-  const preferred = entries.includes(sourceVersion)
-    ? sourceVersion
-    : sortVersionCandidates(entries)[0];
-  const installedRuntimePath = path.join(cacheRoot, preferred);
-  const installedVersion = await readPackageVersion(installedRuntimePath);
-  const fingerprint = await fileFingerprint(
-    path.join(installedRuntimePath, "dist", "scripts", "autoresearch.mjs"),
+  const canonical = await canonicalVersionPaths(input.pluginCacheRoot, identity);
+  if (canonical.status === "unavailable") {
+    return emptyInspection("", "canonical-cache-layout", "unavailable", canonical.detail);
+  }
+  if (canonical.status === "found") {
+    const candidates = (
+      await Promise.all(
+        canonical.paths.map((runtimePath) => runtimeCandidate(runtimePath, identity)),
+      )
+    ).filter((candidate): candidate is RuntimeCandidate => candidate !== null);
+    const matching = candidates.filter((candidate) => candidate.version === identity.version);
+    if (matching.length === 1) {
+      return selectedInspection(
+        matching[0],
+        "canonical-cache-layout",
+        "Selected the canonical cache version declared by the source plugin manifest.",
+      );
+    }
+    if (candidates.length > 1) {
+      return emptyInspection(
+        "",
+        "canonical-cache-layout",
+        "ambiguous",
+        "Multiple canonical versions are metadata-valid and none matches the source plugin manifest.",
+        candidates.map((candidate) => candidate.path),
+      );
+    }
+    if (candidates.length === 1) {
+      return selectedInspection(
+        candidates[0],
+        "canonical-cache-layout",
+        "Selected the only metadata-valid canonical cache version.",
+      );
+    }
+    if (canonical.paths.length > 0) {
+      return emptyInspection(
+        "",
+        "canonical-cache-layout",
+        "unavailable",
+        "Canonical version directories do not match package metadata.",
+        canonical.paths,
+      );
+    }
+  }
+
+  const legacyCandidates = await legacyRuntimeCandidates(input.pluginCacheRoot, identity);
+  if (legacyCandidates === null) {
+    return emptyInspection(
+      "",
+      "legacy-cache-fallback",
+      "unavailable",
+      "The legacy cache fallback could not be read.",
+    );
+  }
+  if (legacyCandidates.length > 1) {
+    return emptyInspection(
+      "",
+      "legacy-cache-fallback",
+      "ambiguous",
+      "Multiple legacy cache versions are metadata-valid.",
+      legacyCandidates.map((candidate) => candidate.path),
+    );
+  }
+  if (legacyCandidates.length === 1) {
+    return selectedInspection(
+      legacyCandidates[0],
+      "legacy-cache-fallback",
+      "Canonical discovery found no install; selected the only legacy cache version.",
+    );
+  }
+  return emptyInspection(
+    canonical.root,
+    "canonical-cache-layout",
+    "missing",
+    "No canonical install was found; the labelled legacy fallback was also empty.",
   );
-  return { path: installedRuntimePath, version: installedVersion, fingerprint };
 }
 
-async function readPackageVersion(installedRuntimePath: string): Promise<string | null> {
+async function runtimeCandidate(
+  runtimePath: string,
+  expected: PluginIdentity,
+): Promise<RuntimeCandidate | null> {
+  const version = path.basename(runtimePath);
+  const [identity, packageJson] = await Promise.all([
+    pluginIdentity(runtimePath, version),
+    readJson(path.join(runtimePath, "package.json")),
+  ]);
+  if (
+    !identity ||
+    identity.publisher !== expected.publisher ||
+    identity.plugin !== expected.plugin ||
+    packageJson?.name !== expected.plugin ||
+    packageJson?.version !== version
+  ) {
+    return null;
+  }
+
+  const fingerprint = await fileFingerprint(
+    path.join(runtimePath, "dist", "scripts", "autoresearch.mjs"),
+  );
+  const shape = fingerprint
+    ? "hydrated-runtime"
+    : (await fileExists(path.join(runtimePath, "scripts", "autoresearch.ts"))) === true
+      ? "source-shaped-package"
+      : (await fileExists(path.join(runtimePath, "scripts", "autoresearch.mjs"))) === true
+        ? "package-artifact"
+        : "unavailable";
+  return { path: runtimePath, version, fingerprint, shape };
+}
+
+async function pluginIdentity(
+  packageRoot: string,
+  expectedVersion: string,
+): Promise<PluginIdentity | null> {
+  const manifest = await readJson(path.join(packageRoot, ".codex-plugin", "plugin.json"));
+  if (
+    typeof manifest?.name !== "string" ||
+    manifest.version !== expectedVersion ||
+    typeof manifest.repository !== "string"
+  ) {
+    return null;
+  }
   try {
-    const parsed = JSON.parse(
-      await fsp.readFile(path.join(installedRuntimePath, "package.json"), "utf8"),
-    );
-    return typeof parsed.version === "string" && parsed.version.trim() ? parsed.version : null;
+    const repository = new URL(manifest.repository);
+    const [publisher, plugin] = repository.pathname.split("/").filter(Boolean);
+    if (
+      repository.hostname.toLowerCase() !== "github.com" ||
+      !publisher ||
+      plugin?.replace(/\.git$/i, "").toLowerCase() !== manifest.name.toLowerCase()
+    ) {
+      return null;
+    }
+    return { publisher, plugin: manifest.name, version: expectedVersion };
   } catch {
     return null;
   }
+}
+
+async function legacyRuntimeCandidates(
+  pluginCacheRoot: string,
+  identity: PluginIdentity,
+): Promise<RuntimeCandidate[] | null> {
+  const legacyRoot = path.join(pluginCacheRoot, LEGACY_CACHE_NAMESPACE);
+  const topLevel = await childDirectories(legacyRoot, true);
+  if (topLevel === null) return null;
+
+  const pluginRoots = [
+    path.join(legacyRoot, identity.plugin),
+    ...topLevel
+      .filter((entry) => path.basename(entry).startsWith("plugin-install-"))
+      .map((entry) => path.join(entry, identity.plugin)),
+  ];
+  const versionRoots = (
+    await Promise.all(pluginRoots.map((root) => childDirectories(root, true)))
+  ).flatMap((entries) => entries || []);
+  return (
+    await Promise.all(versionRoots.map((runtimePath) => runtimeCandidate(runtimePath, identity)))
+  ).filter((candidate): candidate is RuntimeCandidate => candidate !== null);
+}
+
+function selectedInspection(
+  candidate: RuntimeCandidate,
+  source: InstalledRuntimeProvenance["source"],
+  detail: string,
+): InstalledRuntimeInspection {
+  return {
+    ...candidate,
+    provenance: {
+      source,
+      status: "selected",
+      path: candidate.path,
+      candidates: [candidate.path],
+      detail,
+    },
+  };
+}
+
+function emptyInspection(
+  pathValue: string,
+  source: InstalledRuntimeProvenance["source"],
+  status: InstalledRuntimeProvenance["status"],
+  detail: string,
+  candidates: string[] = [],
+): InstalledRuntimeInspection {
+  return {
+    path: pathValue,
+    version: null,
+    fingerprint: null,
+    shape: status === "missing" ? "missing" : "unavailable",
+    provenance: { source, status, path: pathValue, candidates: [...candidates].sort(), detail },
+  };
+}
+
+async function canonicalVersionPaths(
+  pluginCacheRoot: string,
+  identity: PluginIdentity,
+): Promise<{
+  status: "found" | "missing" | "unavailable";
+  root: string;
+  paths: string[];
+  detail: string;
+}> {
+  const root = path.join(pluginCacheRoot, identity.publisher, identity.plugin);
+  try {
+    const publishers = await fsp.readdir(pluginCacheRoot, { withFileTypes: true });
+    const publisher = publishers.find(
+      (entry) => entry.isDirectory() && entry.name === identity.publisher,
+    );
+    if (!publisher) {
+      const wrongCase = publishers.some(
+        (entry) =>
+          entry.isDirectory() && entry.name.toLowerCase() === identity.publisher.toLowerCase(),
+      );
+      return {
+        status: wrongCase ? "unavailable" : "missing",
+        root,
+        paths: [],
+        detail: wrongCase ? `Publisher cache casing must be ${identity.publisher}.` : "",
+      };
+    }
+
+    const publisherRoot = path.join(pluginCacheRoot, publisher.name);
+    const plugins = await fsp.readdir(publisherRoot, { withFileTypes: true });
+    const plugin = plugins.find((entry) => entry.isDirectory() && entry.name === identity.plugin);
+    if (!plugin) {
+      const wrongCase = plugins.some(
+        (entry) =>
+          entry.isDirectory() && entry.name.toLowerCase() === identity.plugin.toLowerCase(),
+      );
+      return {
+        status: wrongCase ? "unavailable" : "missing",
+        root,
+        paths: [],
+        detail: wrongCase ? `Plugin cache casing must be ${identity.plugin}.` : "",
+      };
+    }
+    const paths = await childDirectories(root);
+    return paths === null
+      ? { status: "unavailable", root, paths: [], detail: "Version directories are unreadable." }
+      : { status: "found", root, paths, detail: "" };
+  } catch (error) {
+    return isMissingPathError(error)
+      ? { status: "missing", root, paths: [], detail: "" }
+      : { status: "unavailable", root, paths: [], detail: String(error) };
+  }
+}
+
+async function childDirectories(parent: string, missingIsEmpty = false): Promise<string[] | null> {
+  try {
+    return (await fsp.readdir(parent, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(parent, entry.name));
+  } catch (error) {
+    return missingIsEmpty && isMissingPathError(error) ? [] : null;
+  }
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = JSON.parse(await fsp.readFile(filePath, "utf8"));
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function packageSurface(
+  packageRoot: string,
+  installed: InstalledRuntimeInspection,
+): Promise<RuntimePackageSurface> {
+  if (installed.path && samePath(packageRoot, installed.path)) return "active-installed-cache";
+  if ((await fileExists(path.join(packageRoot, "scripts", "autoresearch.ts"))) === true) {
+    return "source-checkout";
+  }
+  if ((await fileExists(path.join(packageRoot, "scripts", "autoresearch.mjs"))) === true) {
+    return "package-artifact";
+  }
+  return "unavailable";
+}
+
+function samePath(left: string, right: string): boolean {
+  const a = path.resolve(left);
+  const b = path.resolve(right);
+  return process.platform === "win32" ? a.toLowerCase() === b.toLowerCase() : a === b;
 }
 
 async function fileExists(filePath: string): Promise<boolean | null> {
@@ -313,12 +666,6 @@ function classifyRuntimeFingerprint({
   const installed = installedRuntimeFingerprint?.trim();
   if (!source || !installed) return "unavailable";
   return source === installed ? "matched" : "mismatched";
-}
-
-function sortVersionCandidates(versions: string[]): string[] {
-  return [...versions].sort((left, right) =>
-    right.localeCompare(left, undefined, { numeric: true }),
-  );
 }
 
 function quoteCommandArg(value: string): string {

--- a/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
+++ b/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
@@ -1,15 +1,195 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 
 import {
+  inspectRuntimeDrift,
   inspectRuntimeDriftFromFacts,
   summarizeRuntimeAuthority,
 } from "../lib/runtime-drift-doctor.js";
+import { withAutoresearchTempDir, writeRuntimePackage } from "./helpers/cli-session.js";
 
 const DOCTOR_COMMAND = /node .*scripts[\\/]autoresearch\.mjs doctor .*--explain/;
 const ABSOLUTE_DOCTOR_COMMAND =
   /node ".*codex autoresearch.*scripts[\\/]autoresearch\.mjs" doctor --cwd ".*codex autoresearch" --explain/;
 const SOURCE_FINGERPRINT = "a".repeat(64);
+
+const FIXTURE_VERSION = "2.6.0";
+const RUNTIME_CONTENT = "export const runtimeFixture = true;\n";
+const runtimePath = (cacheRoot: string, version: string) =>
+  path.join(cacheRoot, "TheGreenCedar", "codex-autoresearch", version);
+
+async function writeSource(root: string, packageArtifact = false) {
+  await writeRuntimePackage(root, FIXTURE_VERSION, {
+    sourceShaped: !packageArtifact,
+    runtimeContent: RUNTIME_CONTENT,
+  });
+}
+
+test("canonical metadata finds the current cache and reports runtime surfaces", async () => {
+  await withAutoresearchTempDir("runtime-canonical", async (dir) => {
+    const sourceRoot = path.join(dir, "source");
+    const cacheRoot = path.join(dir, "cache");
+    const installedRoot = runtimePath(cacheRoot, FIXTURE_VERSION);
+    await writeSource(sourceRoot);
+    await writeRuntimePackage(installedRoot, FIXTURE_VERSION, {
+      runtimeContent: RUNTIME_CONTENT,
+    });
+
+    const summary = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: cacheRoot,
+    });
+
+    assert.equal(summary.installedRuntime, "fresh");
+    assert.equal(summary.packageSurface, "source-checkout");
+    assert.equal(summary.installedRuntimeShape, "hydrated-runtime");
+    assert.equal(summary.installedRuntimePath, installedRoot);
+    assert.equal(summary.installedRuntimeVersion, FIXTURE_VERSION);
+    assert.equal(summary.installedRuntimeProvenance.source, "canonical-cache-layout");
+    assert.equal(summary.installedRuntimeProvenance.status, "selected");
+    assert.deepEqual(summary.installedRuntimeProvenance.candidates, [installedRoot]);
+  });
+});
+
+test("multiple versions prefer the source version and fail closed when it is absent", async () => {
+  await withAutoresearchTempDir("runtime-ambiguous", async (dir) => {
+    const sourceRoot = path.join(dir, "source");
+    const cacheRoot = path.join(dir, "cache");
+    const activeRoot = runtimePath(cacheRoot, FIXTURE_VERSION);
+    await writeSource(sourceRoot);
+    await writeRuntimePackage(runtimePath(cacheRoot, "2.5.0"), "2.5.0", {
+      runtimeContent: RUNTIME_CONTENT,
+    });
+    await writeRuntimePackage(activeRoot, FIXTURE_VERSION, {
+      runtimeContent: RUNTIME_CONTENT,
+    });
+
+    const preferred = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: cacheRoot,
+    });
+    assert.equal(preferred.installedRuntime, "fresh");
+    assert.equal(preferred.installedRuntimePath, activeRoot);
+    assert.equal(preferred.installedRuntimeProvenance.source, "canonical-cache-layout");
+
+    const ambiguousCache = path.join(dir, "ambiguous-cache");
+    for (const version of ["2.4.0", "2.5.0"]) {
+      await writeRuntimePackage(runtimePath(ambiguousCache, version), version, {
+        runtimeContent: RUNTIME_CONTENT,
+      });
+    }
+    const ambiguous = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: ambiguousCache,
+    });
+    assert.equal(ambiguous.installedRuntime, "unavailable");
+    assert.equal(ambiguous.installedRuntimeProvenance.status, "ambiguous");
+    assert.equal(ambiguous.installedRuntimeProvenance.candidates.length, 2);
+    assert.match(ambiguous.nextActionHint, /ambiguous/i);
+
+    const selected = await inspectRuntimeDrift({
+      packageRoot: activeRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: cacheRoot,
+    });
+    assert.equal(selected.installedRuntime, "fresh");
+    assert.equal(selected.packageSurface, "active-installed-cache");
+    assert.equal(selected.installedRuntimeProvenance.source, "launcher-package-root");
+  });
+});
+
+test("source-shaped, package, missing, and stale surfaces stay distinct", async () => {
+  await withAutoresearchTempDir("runtime-shapes", async (dir) => {
+    const sourceRoot = path.join(dir, "source");
+    await writeSource(sourceRoot);
+
+    const sourceCache = path.join(dir, "source-cache");
+    await writeRuntimePackage(runtimePath(sourceCache, FIXTURE_VERSION), FIXTURE_VERSION, {
+      sourceShaped: true,
+    });
+    const sourceShaped = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: sourceCache,
+    });
+    assert.equal(sourceShaped.installedRuntime, "unavailable");
+    assert.equal(sourceShaped.installedRuntimeShape, "source-shaped-package");
+
+    const missing = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: path.join(dir, "missing-cache"),
+    });
+    assert.equal(missing.installedRuntime, "missing");
+
+    const staleCache = path.join(dir, "stale-cache");
+    await writeRuntimePackage(runtimePath(staleCache, "2.5.0"), "2.5.0", {
+      runtimeContent: RUNTIME_CONTENT,
+    });
+    const stale = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: staleCache,
+    });
+    assert.equal(stale.installedRuntime, "stale");
+    assert.equal(stale.installedRuntimeVersion, "2.5.0");
+
+    const packageRoot = path.join(dir, "package");
+    await writeSource(packageRoot, true);
+    const artifact = await inspectRuntimeDrift({
+      packageRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: path.join(dir, "artifact-cache"),
+    });
+    assert.equal(artifact.packageSurface, "package-artifact");
+  });
+});
+
+test("legacy discovery is labelled and wrong canonical casing is rejected", async () => {
+  await withAutoresearchTempDir("runtime-legacy-casing", async (dir) => {
+    const sourceRoot = path.join(dir, "source");
+    await writeSource(sourceRoot);
+
+    const legacyCache = path.join(dir, "legacy-cache");
+    const legacyRoot = path.join(
+      legacyCache,
+      "thegreencedar-autoresearch",
+      "plugin-install-fixture",
+      "codex-autoresearch",
+      FIXTURE_VERSION,
+    );
+    await writeRuntimePackage(legacyRoot, FIXTURE_VERSION, {
+      runtimeContent: RUNTIME_CONTENT,
+    });
+    const legacy = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: legacyCache,
+    });
+    assert.equal(legacy.installedRuntime, "fresh");
+    assert.equal(legacy.installedRuntimePath, legacyRoot);
+    assert.equal(legacy.installedRuntimeProvenance.source, "legacy-cache-fallback");
+
+    const wrongCaseCache = path.join(dir, "wrong-case-cache");
+    await writeRuntimePackage(
+      path.join(wrongCaseCache, "thegreencedar", "codex-autoresearch", FIXTURE_VERSION),
+      FIXTURE_VERSION,
+      { runtimeContent: RUNTIME_CONTENT },
+    );
+    const wrongCase = await inspectRuntimeDrift({
+      packageRoot: sourceRoot,
+      sourceVersion: FIXTURE_VERSION,
+      pluginCacheRoot: wrongCaseCache,
+    });
+    assert.equal(wrongCase.installedRuntime, "unavailable");
+    assert.equal(wrongCase.installedRuntimeProvenance.source, "canonical-cache-layout");
+    assert.match(wrongCase.installedRuntimeProvenance.detail, /TheGreenCedar/);
+  });
+});
 
 test("unavailable installed runtime asks the operator to inspect the runtime", () => {
   const summary = inspectRuntimeDriftFromFacts({

--- a/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
+++ b/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
@@ -53,7 +53,35 @@ test("canonical metadata finds the current cache and reports runtime surfaces", 
   });
 });
 
-test("multiple versions prefer the source version and fail closed when it is absent", async () => {
+test("production discovery honors CODEX_HOME without leaking environment state", async () => {
+  await withAutoresearchTempDir("runtime-codex-home", async (dir) => {
+    const sourceRoot = path.join(dir, "source");
+    const codexHome = path.join(dir, "custom-codex-home");
+    const installedRoot = runtimePath(path.join(codexHome, "plugins", "cache"), FIXTURE_VERSION);
+    await writeSource(sourceRoot);
+    await writeRuntimePackage(installedRoot, FIXTURE_VERSION, {
+      runtimeContent: RUNTIME_CONTENT,
+    });
+
+    const originalCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.CODEX_HOME = codexHome;
+      const summary = await inspectRuntimeDrift({
+        packageRoot: sourceRoot,
+        sourceVersion: FIXTURE_VERSION,
+      });
+      assert.equal(summary.installedRuntime, "fresh");
+      assert.equal(summary.installedRuntimePath, installedRoot);
+      assert.equal(summary.installedRuntimeProvenance.source, "canonical-cache-layout");
+    } finally {
+      if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = originalCodexHome;
+    }
+    assert.equal(process.env.CODEX_HOME, originalCodexHome);
+  });
+});
+
+test("multiple versions fail closed unless the running launcher selects one", async () => {
   await withAutoresearchTempDir("runtime-ambiguous", async (dir) => {
     const sourceRoot = path.join(dir, "source");
     const cacheRoot = path.join(dir, "cache");
@@ -66,25 +94,10 @@ test("multiple versions prefer the source version and fail closed when it is abs
       runtimeContent: RUNTIME_CONTENT,
     });
 
-    const preferred = await inspectRuntimeDrift({
-      packageRoot: sourceRoot,
-      sourceVersion: FIXTURE_VERSION,
-      pluginCacheRoot: cacheRoot,
-    });
-    assert.equal(preferred.installedRuntime, "fresh");
-    assert.equal(preferred.installedRuntimePath, activeRoot);
-    assert.equal(preferred.installedRuntimeProvenance.source, "canonical-cache-layout");
-
-    const ambiguousCache = path.join(dir, "ambiguous-cache");
-    for (const version of ["2.4.0", "2.5.0"]) {
-      await writeRuntimePackage(runtimePath(ambiguousCache, version), version, {
-        runtimeContent: RUNTIME_CONTENT,
-      });
-    }
     const ambiguous = await inspectRuntimeDrift({
       packageRoot: sourceRoot,
       sourceVersion: FIXTURE_VERSION,
-      pluginCacheRoot: ambiguousCache,
+      pluginCacheRoot: cacheRoot,
     });
     assert.equal(ambiguous.installedRuntime, "unavailable");
     assert.equal(ambiguous.installedRuntimeProvenance.status, "ambiguous");

--- a/plugins/codex-autoresearch/tests/helpers/cli-session.ts
+++ b/plugins/codex-autoresearch/tests/helpers/cli-session.ts
@@ -17,6 +17,7 @@ export const pathExists = async (target: string) => {
 export function isolatedRuntimeEnv(homeDir: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
+    CODEX_HOME: path.join(homeDir, ".codex"),
     HOME: homeDir,
     USERPROFILE: homeDir,
   };

--- a/plugins/codex-autoresearch/tests/helpers/cli-session.ts
+++ b/plugins/codex-autoresearch/tests/helpers/cli-session.ts
@@ -28,20 +28,52 @@ export async function writeInstalledRuntimeFixture(homeDir: string, status: stri
     ".codex",
     "plugins",
     "cache",
-    "thegreencedar-autoresearch",
+    "TheGreenCedar",
     "codex-autoresearch",
   );
-  const runtimeDir = path.join(cacheRoot, status === "stale" ? "0.0.0" : PLUGIN_VERSION);
-  await mkdir(runtimeDir, { recursive: true });
-  if (status === "stale") {
+  await mkdir(cacheRoot, { recursive: true });
+  if (status === "missing") return;
+  const version = status === "stale" ? "0.0.0" : PLUGIN_VERSION;
+  await writeRuntimePackage(path.join(cacheRoot, version), version, {
+    sourceShaped: status === "unavailable",
+  });
+}
+
+export async function writeRuntimePackage(
+  runtimeDir: string,
+  version: string,
+  options: { sourceShaped?: boolean; runtimeContent?: string } = {},
+) {
+  await mkdir(path.join(runtimeDir, ".codex-plugin"), { recursive: true });
+  await mkdir(path.join(runtimeDir, "scripts"), { recursive: true });
+  await writeFile(
+    path.join(runtimeDir, "package.json"),
+    JSON.stringify({
+      name: "codex-autoresearch",
+      version,
+      repository: {
+        type: "git",
+        url: "git+https://github.com/TheGreenCedar/codex-autoresearch.git",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(runtimeDir, ".codex-plugin", "plugin.json"),
+    JSON.stringify({
+      name: "codex-autoresearch",
+      version,
+      repository: "https://github.com/TheGreenCedar/codex-autoresearch",
+    }),
+  );
+  await writeFile(path.join(runtimeDir, "scripts", "autoresearch.mjs"), "export {};\n");
+  if (options.sourceShaped) {
+    await writeFile(path.join(runtimeDir, "scripts", "autoresearch.ts"), "export {};\n");
+  }
+  if (options.runtimeContent !== undefined) {
+    await mkdir(path.join(runtimeDir, "dist", "scripts"), { recursive: true });
     await writeFile(
-      path.join(runtimeDir, "package.json"),
-      JSON.stringify({ version: "0.0.0" }, null, 2),
-    );
-  } else if (status === "unavailable") {
-    await writeFile(
-      path.join(runtimeDir, "package.json"),
-      JSON.stringify({ version: PLUGIN_VERSION }, null, 2),
+      path.join(runtimeDir, "dist", "scripts", "autoresearch.mjs"),
+      options.runtimeContent,
     );
   }
 }


### PR DESCRIPTION
## Context

Issue #288 found that installed-runtime inspection still used the obsolete combined marketplace namespace, so `doctor --check-installed` missed the active `TheGreenCedar/codex-autoresearch/<version>` cache. Runtime trust also lacked enough provenance to distinguish source checkouts, package artifacts, hydrated runtimes, and installed cache selection.

Refs #288.

## What Changed

- derive publisher, plugin, and version identity from the plugin manifest
- honor `CODEX_HOME/plugins/cache` in production, with `~/.codex/plugins/cache` only as the unset fallback
- prefer a running canonical launcher root; outside that proven execution path, fail closed when multiple metadata-valid canonical versions exist
- select a lone canonical version as current or stale evidence without treating source-version equality as active-launcher proof
- expose installed path, version, runtime shape, package surface, and structured selection provenance
- keep the old combined namespace as an explicitly labelled fallback only after canonical discovery fails
- update runtime fixtures, troubleshooting guidance, and the changelog for the current cache topology

## How To Review

1. Review `lib/runtime-drift-doctor.ts` cache-root and selection precedence.
2. Review `tests/decision-guidance-runtime-drift.test.ts` for custom `CODEX_HOME`, environment restoration, canonical casing, ambiguous `2.5 + 2.6` source-checkout discovery, launcher precedence, source-shaped hydration, stale/missing states, and legacy fallback.
3. Confirm the existing CLI authority behavior still blocks non-fresh installed runtime verification.

## Verification

- `node --test dist/tests/decision-guidance-runtime-drift.test.mjs` — 17/17 passed
- focused `doctor` CLI tests — 2/2 passed
- `node scripts/autoresearch.mjs --help` — source-checkout launcher smoke passed
- live Windows readback selected `C:\Users\alber\.codex\plugins\cache\TheGreenCedar\codex-autoresearch\2.6.0` via `canonical-cache-layout`, version `2.6.0`, shape `source-shaped-package`, one candidate, and correctly blocked installed-runtime trust because it is not hydrated
- `npm run check` — passed, including 15/15 product checks, compiled CLI/dashboard/finalizer/core suites, 314 core tests, package artifact, and package runtime smoke
- `git diff --check` — passed

## Risk

The locator intentionally understands the current canonical hierarchy plus the known legacy namespace only. Publisher identity currently comes from the GitHub repository URL in `.codex-plugin/plugin.json`; unreadable or inconsistent metadata fails closed. Multiple valid canonical versions require active launcher-root proof and otherwise remain ambiguous by design. No dashboard-visible UI changed, so visual evidence is not applicable.