### PR TITLE
fix(finalize): revalidate accepted-current evidence before branch creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 ### Fixed
 
 - Installed-runtime checks now honor `CODEX_HOME`, resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions lack active-launcher proof. The obsolete combined marketplace namespace remains a labelled fallback only.
-- Finalization now revalidates accepted-current evidence immediately before review-branch creation and rejects stale plans when kept membership, exclusions, evidence status, ledger ordering, or product-claim inputs change.
+- Finalization now revalidates accepted-current evidence immediately before review-branch creation, uses validated Git hash prefixes consistently, ignores same-commit audit-only rows, and rejects stale plans when kept membership, exclusions, evidence status, ledger ordering, or product-claim inputs change.
 - Finalization now preserves pre-existing review and verification branches during rollback, deletes only branches created by the current invocation, and fails visibly when branch restoration or cleanup cannot complete.
 - Serialized and coalesced active packet progress writes so terminal cleanup cannot be undone by a delayed older snapshot; progress generations remain ordered across interrupted runs, cleanup also runs after writer or packet failures, and non-missing deletion errors are reported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 ### Fixed
 
 - Installed-runtime checks now honor `CODEX_HOME`, resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions lack active-launcher proof. The obsolete combined marketplace namespace remains a labelled fallback only.
+- Finalization now revalidates accepted-current evidence immediately before review-branch creation and rejects stale plans when kept membership, exclusions, evidence status, ledger ordering, or product-claim inputs change.
 - Finalization now preserves pre-existing review and verification branches during rollback, deletes only branches created by the current invocation, and fails visibly when branch restoration or cleanup cannot complete.
 - Serialized and coalesced active packet progress writes so terminal cleanup cannot be undone by a delayed older snapshot; progress generations remain ordered across interrupted runs, cleanup also runs after writer or packet failures, and non-missing deletion errors are reported.
 

--- a/plugins/codex-autoresearch/lib/evidence-registry.ts
+++ b/plugins/codex-autoresearch/lib/evidence-registry.ts
@@ -191,7 +191,7 @@ function normalizeEvidenceEntry(value: LooseObject): EvidenceRegistryEntry {
   };
 }
 
-function evidenceStatusForRun(run: LooseObject): EvidenceStatus {
+export function evidenceStatusForRun(run: LooseObject): EvidenceStatus {
   const evidenceStatus = normalizeEvidenceStatus(
     run.evidenceStatus,
     defaultEvidenceStatusForRun(run),

--- a/plugins/codex-autoresearch/lib/finalization-plan.ts
+++ b/plugins/codex-autoresearch/lib/finalization-plan.ts
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
-import { evidenceStatusForRun, isAcceptedCurrentRun } from "./evidence-registry.js";
+import {
+  evidenceStatusForRun,
+  isAcceptedCurrentRun,
+  isKeepRun,
+  isRejectedRun,
+} from "./evidence-registry.js";
 import {
   buildProductClaimCoverage,
   evidenceTextFromRun,
@@ -41,6 +46,8 @@ export type FinalizationEvidenceState = {
   fingerprint: FinalizationEvidenceFingerprint;
   productClaimCoverage: ProductClaimCoverage;
 };
+
+const MINIMUM_COMMIT_REFERENCE_LENGTH = 7;
 
 export async function readAutoresearchLedger(
   cwd: string,
@@ -105,7 +112,11 @@ export function buildFinalizationEvidenceState(
     let ledgerIndex = -1;
     for (let index = 0; index < ledgerEntries.length; index += 1) {
       const candidate = ledgerEntries[index];
-      if (!commitRefsMatch(candidate?.commit, commit)) continue;
+      if (
+        !isFinalizationEvidenceTransition(candidate) ||
+        !commitReferencesMatch(candidate?.commit, commit)
+      )
+        continue;
       entry = candidate;
       ledgerIndex = index;
     }
@@ -128,7 +139,10 @@ export function buildFinalizationEvidenceState(
       .map((entry, ledgerIndex) => ({ commit: "", entry, ledgerIndex }))
       .filter(
         ({ entry }) =>
-          entry?.run != null && !String(entry.commit || "").trim() && isAcceptedCurrentRun(entry),
+          entry?.run != null &&
+          !String(entry.commit || "").trim() &&
+          isFinalizationEvidenceTransition(entry) &&
+          isAcceptedCurrentRun(entry),
       ),
   ].sort((left, right) => left.ledgerIndex - right.ledgerIndex);
   const acceptedCommits = commitStates
@@ -203,6 +217,33 @@ export function normalizeFinalizationEvidenceFingerprint(value: unknown): LooseO
       FINALIZATION_EVIDENCE_COMPONENT_KEYS.map((key) => [key, String(components[key] || "")]),
     ),
   };
+}
+
+export function commitReferencesMatch(left: unknown, right: unknown): boolean {
+  const a = String(left || "")
+    .trim()
+    .toLowerCase();
+  const b = String(right || "")
+    .trim()
+    .toLowerCase();
+  const valid = (value: string) =>
+    value.length >= MINIMUM_COMMIT_REFERENCE_LENGTH &&
+    value.length <= 64 &&
+    /^[0-9a-f]+$/.test(value);
+  if (!valid(a) || !valid(b)) return false;
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  if (longer.length !== 40 && longer.length !== 64) return false;
+  if ((shorter.length === 40 || shorter.length === 64) && shorter.length !== longer.length)
+    return false;
+  return longer.startsWith(shorter);
+}
+
+export function isFinalizationEvidenceTransition(entry: LooseObject | null | undefined): boolean {
+  const type = String(entry?.type || "")
+    .trim()
+    .toLowerCase();
+  if (type && type !== "run") return false;
+  return isKeepRun(entry) || isRejectedRun(entry);
 }
 
 export function finalizationPlanFingerprintMaterial(plan: LooseObject): LooseObject {
@@ -286,11 +327,6 @@ function finalizationEvidenceStatusLabel(entry: LooseObject | null): string {
   if (!entry) return "unlogged";
   if (String(entry.status || "") === "keep") return evidenceStatusForRun(entry);
   return String(entry.status || "unlogged");
-}
-
-function commitRefsMatch(value: unknown, commit: string): boolean {
-  const ref = String(value || "").trim();
-  return Boolean(ref && (commit === ref || commit.startsWith(ref) || ref.startsWith(commit)));
 }
 
 function latestSessionGoal(entries: LooseObject[]): string {

--- a/plugins/codex-autoresearch/lib/finalization-plan.ts
+++ b/plugins/codex-autoresearch/lib/finalization-plan.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
-import { productClaimCoverageFingerprintMaterial } from "./product-claim-coverage.js";
+import { evidenceStatusForRun, isAcceptedCurrentRun } from "./evidence-registry.js";
+import {
+  buildProductClaimCoverage,
+  evidenceTextFromRun,
+  productClaimCoverageFingerprintMaterial,
+  type ProductClaimCoverage,
+} from "./product-claim-coverage.js";
 import { jsonlPath } from "./session-records.js";
 
 export type LooseObject = Record<string, any>;
@@ -11,6 +17,29 @@ export type NormalizedExcludedCommit = {
   commit: string;
   status: string;
   subject: string;
+};
+
+export const FINALIZATION_EVIDENCE_COMPONENT_KEYS = [
+  "accepted_commit_membership",
+  "excluded_commit_statuses",
+  "evidence_statuses",
+  "accepted_ledger_order",
+  "product_claim_coverage_inputs",
+] as const;
+
+export type FinalizationEvidenceComponent = (typeof FINALIZATION_EVIDENCE_COMPONENT_KEYS)[number];
+
+export type FinalizationEvidenceFingerprint = {
+  schema_version: 1;
+  fingerprint: string;
+  components: Record<FinalizationEvidenceComponent, string>;
+};
+
+export type FinalizationEvidenceState = {
+  acceptedCommits: string[];
+  acceptedRuns: LooseObject[];
+  fingerprint: FinalizationEvidenceFingerprint;
+  productClaimCoverage: ProductClaimCoverage;
 };
 
 export async function readAutoresearchLedger(
@@ -64,6 +93,118 @@ export function normalizeCurrentTreeCoverage(coverage: LooseObject = {}): LooseO
   };
 }
 
+export function buildFinalizationEvidenceState(
+  commitOrder: string[],
+  ledgerEntries: LooseObject[],
+): FinalizationEvidenceState {
+  const commits = [
+    ...new Set((commitOrder || []).map((commit) => String(commit || "").trim()).filter(Boolean)),
+  ];
+  const commitStates = commits.map((commit) => {
+    let entry: LooseObject | null = null;
+    let ledgerIndex = -1;
+    for (let index = 0; index < ledgerEntries.length; index += 1) {
+      const candidate = ledgerEntries[index];
+      if (!commitRefsMatch(candidate?.commit, commit)) continue;
+      entry = candidate;
+      ledgerIndex = index;
+    }
+    return {
+      commit,
+      entry,
+      ledgerIndex,
+      accepted: isAcceptedCurrentRun(entry),
+    };
+  });
+  const acceptedRecords = [
+    ...commitStates
+      .filter((state) => state.accepted && state.entry)
+      .map((state) => ({
+        commit: state.commit,
+        entry: state.entry!,
+        ledgerIndex: state.ledgerIndex,
+      })),
+    ...ledgerEntries
+      .map((entry, ledgerIndex) => ({ commit: "", entry, ledgerIndex }))
+      .filter(
+        ({ entry }) =>
+          entry?.run != null && !String(entry.commit || "").trim() && isAcceptedCurrentRun(entry),
+      ),
+  ].sort((left, right) => left.ledgerIndex - right.ledgerIndex);
+  const acceptedCommits = commitStates
+    .filter((state) => state.accepted)
+    .map((state) => state.commit);
+  const goal = latestSessionGoal(ledgerEntries);
+  const claimInputs = acceptedRecords.map(({ commit, entry }) => ({
+    commit,
+    run: entry.run ?? null,
+    evidence: evidenceTextFromRun(entry),
+  }));
+  const productClaimCoverage = buildProductClaimCoverage({
+    goal,
+    acceptedEvidence: claimInputs.flatMap((input) => input.evidence),
+  });
+  const materials: Record<FinalizationEvidenceComponent, unknown> = {
+    accepted_commit_membership: acceptedCommits,
+    excluded_commit_statuses: commitStates
+      .filter((state) => !state.accepted)
+      .map((state) => ({
+        commit: state.commit,
+        status: finalizationEvidenceStatusLabel(state.entry),
+      })),
+    evidence_statuses: commitStates.map((state) => ({
+      commit: state.commit,
+      status: state.entry ? String(state.entry.status || "") : "unlogged",
+      declared_evidence_status: state.entry ? String(state.entry.evidenceStatus || "") : "unlogged",
+      effective_evidence_status: state.entry ? evidenceStatusForRun(state.entry) : "unlogged",
+      quarantined: state.entry?.quarantined === true,
+    })),
+    accepted_ledger_order: acceptedRecords.map(({ commit, entry }) => ({
+      commit,
+      run: entry.run ?? null,
+    })),
+    product_claim_coverage_inputs: {
+      goal,
+      accepted_evidence: claimInputs,
+      coverage: productClaimCoverageFingerprintMaterial(productClaimCoverage),
+    },
+  };
+  const components = Object.fromEntries(
+    FINALIZATION_EVIDENCE_COMPONENT_KEYS.map((key) => [
+      key,
+      hashFingerprintMaterial(materials[key]),
+    ]),
+  ) as Record<FinalizationEvidenceComponent, string>;
+  return {
+    acceptedCommits,
+    acceptedRuns: acceptedRecords.map((record) => record.entry),
+    productClaimCoverage,
+    fingerprint: {
+      schema_version: 1,
+      fingerprint: hashFingerprintMaterial(materials),
+      components,
+    },
+  };
+}
+
+export function normalizeFinalizationEvidenceFingerprint(value: unknown): LooseObject {
+  const fingerprint =
+    value && typeof value === "object" && !Array.isArray(value) ? (value as LooseObject) : {};
+  const components =
+    fingerprint.components &&
+    typeof fingerprint.components === "object" &&
+    !Array.isArray(fingerprint.components)
+      ? fingerprint.components
+      : {};
+  return {
+    schema_version: Number(fingerprint.schema_version || 0),
+    fingerprint: String(fingerprint.fingerprint || ""),
+    components: Object.fromEntries(
+      FINALIZATION_EVIDENCE_COMPONENT_KEYS.map((key) => [key, String(components[key] || "")]),
+    ),
+  };
+}
+
 export function finalizationPlanFingerprintMaterial(plan: LooseObject): LooseObject {
   return {
     mode: plan.mode || "",
@@ -78,6 +219,9 @@ export function finalizationPlanFingerprintMaterial(plan: LooseObject): LooseObj
     excluded_commit_count: plan.excluded_commit_count || 0,
     overlap_files: plan.overlap_files || [],
     current_tree_coverage: normalizeCurrentTreeCoverage(plan.current_tree_coverage),
+    accepted_evidence_fingerprint: normalizeFinalizationEvidenceFingerprint(
+      plan.accepted_evidence_fingerprint,
+    ),
     product_claim_coverage: productClaimCoverageFingerprintMaterial(plan.product_claim_coverage),
     product_grade_ready: Boolean(
       plan.product_grade_ready ?? plan.product_claim_coverage?.productGradeReady,
@@ -131,4 +275,34 @@ export function assertGeneratedPlanMetadata(config: LooseObject): void {
       "Stale finalization plan: generated plan fingerprint is missing. Rerun finalizer plan.",
     );
   }
+  if (looksGenerated && !config.accepted_evidence_fingerprint) {
+    throw new Error(
+      "Stale finalization plan: accepted-current evidence fingerprint is missing. Rerun finalizer plan.",
+    );
+  }
+}
+
+function finalizationEvidenceStatusLabel(entry: LooseObject | null): string {
+  if (!entry) return "unlogged";
+  if (String(entry.status || "") === "keep") return evidenceStatusForRun(entry);
+  return String(entry.status || "unlogged");
+}
+
+function commitRefsMatch(value: unknown, commit: string): boolean {
+  const ref = String(value || "").trim();
+  return Boolean(ref && (commit === ref || commit.startsWith(ref) || ref.startsWith(commit)));
+}
+
+function latestSessionGoal(entries: LooseObject[]): string {
+  let goal = "";
+  for (const entry of entries) {
+    if (entry?.type === "config" && Object.hasOwn(entry, "goal")) {
+      goal = String(entry.goal || "").trim();
+    }
+  }
+  return goal;
+}
+
+function hashFingerprintMaterial(material: unknown): string {
+  return createHash("sha256").update(JSON.stringify(material)).digest("hex");
 }

--- a/plugins/codex-autoresearch/lib/finalize-preview.ts
+++ b/plugins/codex-autoresearch/lib/finalize-preview.ts
@@ -8,6 +8,7 @@ import { productGradeFinalizationIssue } from "./finalization-acceptance.js";
 import { classifyFinalizationRunwayFromFacts } from "./finalization-runway.js";
 import {
   buildFinalizationEvidenceState,
+  commitReferencesMatch,
   finalizationPlanFingerprint,
   readAutoresearchLedger,
 } from "./finalization-plan.js";
@@ -829,7 +830,7 @@ async function buildSemanticSafety({
         (run) =>
           run.run > group.run &&
           run.commit &&
-          commitRefsMayMatch(run.commit, group.commit) &&
+          commitReferencesMatch(run.commit, group.commit) &&
           run.status !== "keep" &&
           explicitEvidenceInvalidationText(run),
       );
@@ -882,12 +883,6 @@ async function keptCommitWasReverted(workDir: string, group: RunGroup): Promise<
       const [, subject = ""] = line.split("\x1f");
       return /^Revert\s+/i.test(subject) || subject.includes(group.shortCommit);
     });
-}
-
-function commitRefsMayMatch(left: unknown, right: unknown): boolean {
-  const a = String(left || "");
-  const b = String(right || "");
-  return Boolean(a && b && (a.startsWith(b) || b.startsWith(a)));
 }
 
 function explicitEvidenceInvalidationText(run: LooseObject): string {

--- a/plugins/codex-autoresearch/lib/finalize-preview.ts
+++ b/plugins/codex-autoresearch/lib/finalize-preview.ts
@@ -6,7 +6,11 @@ import { renderShellCommand } from "./command-rendering.js";
 import { isAcceptedCurrentRun } from "./evidence-registry.js";
 import { productGradeFinalizationIssue } from "./finalization-acceptance.js";
 import { classifyFinalizationRunwayFromFacts } from "./finalization-runway.js";
-import { finalizationPlanFingerprint, readAutoresearchLedger } from "./finalization-plan.js";
+import {
+  buildFinalizationEvidenceState,
+  finalizationPlanFingerprint,
+  readAutoresearchLedger,
+} from "./finalization-plan.js";
 import { buildFinalizationProductClaimCoverageFromLedger } from "./product-claim-coverage.js";
 import { resolvePackageRoot } from "./runtime-paths.js";
 import { isAutoresearchSessionArtifact } from "./session-artifacts.js";
@@ -554,7 +558,9 @@ export async function finalizeCurrentTree(args: LooseObject) {
   const ready = Boolean(base && branch && branch !== trunk && !dirty && files.length);
   const planOutput = await defaultCurrentTreePlanOutput(workDir, branch || "autoresearch");
   const ledgerEntries = await readLedgerEntries(workDir);
-  const productClaimCoverage = buildFinalizationProductClaimCoverageFromLedger(ledgerEntries);
+  const commitOrder = base ? await commitHashesBetween(base, "HEAD", workDir) : [];
+  const evidenceState = buildFinalizationEvidenceState(commitOrder, ledgerEntries);
+  const productClaimCoverage = evidenceState.productClaimCoverage;
   const productGradeIssue = productGradeFinalizationIssue(productClaimCoverage);
   const currentTreeFingerprint = currentTreeFingerprintFor({
     base,
@@ -575,6 +581,7 @@ export async function finalizeCurrentTree(args: LooseObject) {
     excluded_commits: [] as CommitSummary[],
     excluded_commit_count: 0,
     overlap_files: [] as string[],
+    accepted_evidence_fingerprint: evidenceState.fingerprint,
     current_tree_coverage: {
       covered: ready,
       review_unit: "current_tree",
@@ -792,6 +799,14 @@ async function changedFilesBetween(
     .filter(Boolean)
     .filter((file) => !filterSession || !isAutoresearchSessionArtifact(file, "source-checkout"))
     .sort((a, b) => a.localeCompare(b));
+}
+
+async function commitHashesBetween(left: string, right: string, cwd: string): Promise<string[]> {
+  const result = await git(["log", "--reverse", "--format=%H", `${left}..${right}`], cwd);
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 async function buildSemanticSafety({

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -11,7 +11,9 @@ import {
   FINALIZATION_EVIDENCE_COMPONENT_KEYS,
   assertGeneratedPlanMetadata,
   buildFinalizationEvidenceState,
+  commitReferencesMatch,
   finalizationPlanFingerprint,
+  isFinalizationEvidenceTransition,
   normalizeFinalizationEvidenceFingerprint,
   readAutoresearchLedger,
   type FinalizationEvidenceFingerprint,
@@ -494,18 +496,12 @@ function markdownEscape(text: string): string {
 function runEvidenceForCommit(entries: RunEntry[], hash: string): RunEntry | null {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const run = entries[index];
-    const commit = String(run.commit || "");
-    if (commitMatchesHash(commit, hash)) {
+    if (!isFinalizationEvidenceTransition(run)) continue;
+    if (commitReferencesMatch(run.commit, hash)) {
       return isAcceptedCurrentRun(run) ? run : null;
     }
   }
   return null;
-}
-
-function commitMatchesHash(commit: unknown, hash: string): boolean {
-  if (!commit) return false;
-  const text = String(commit);
-  return hash.startsWith(text) || text.startsWith(hash.slice(0, 12));
 }
 
 async function readAutoresearchJsonl(cwd: string): Promise<RunEntry[]> {
@@ -536,8 +532,8 @@ async function commitParent(hash: string, base: string, cwd: string): Promise<st
 function parseCommitStatus(entries: RunEntry[], hash: string): RunEntry | null {
   const matching: RunEntry[] = [];
   for (const entry of entries) {
-    const commit = String(entry.commit || "");
-    if (commitMatchesHash(commit, hash)) matching.push(entry);
+    if (isFinalizationEvidenceTransition(entry) && commitReferencesMatch(entry.commit, hash))
+      matching.push(entry);
   }
   return matching.at(-1) || null;
 }

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -8,9 +8,13 @@ import { isAcceptedCurrentRun } from "../lib/evidence-registry.js";
 import { productGradeFinalizationIssue } from "../lib/finalization-acceptance.js";
 import { classifyFinalizationRunwayFromFacts } from "../lib/finalization-runway.js";
 import {
+  FINALIZATION_EVIDENCE_COMPONENT_KEYS,
   assertGeneratedPlanMetadata,
+  buildFinalizationEvidenceState,
   finalizationPlanFingerprint,
+  normalizeFinalizationEvidenceFingerprint,
   readAutoresearchLedger,
+  type FinalizationEvidenceFingerprint,
 } from "../lib/finalization-plan.js";
 import { buildFinalizationProductClaimCoverageFromLedger } from "../lib/product-claim-coverage.js";
 import {
@@ -67,6 +71,7 @@ type ExcludedCommit = {
   subject?: string;
 };
 type FinalizePlan = LooseObject & {
+  accepted_evidence_fingerprint?: FinalizationEvidenceFingerprint;
   base: string;
   excluded_commits?: ExcludedCommit[];
   final_tree: string;
@@ -1060,8 +1065,12 @@ async function draftGroupsPlan(args: CliArgs, cwd: string): Promise<FinalizePlan
   const goal = safeSlug(args.goal || sourceBranch.replace(/^.*\//, "") || "autoresearch");
   const history = await commitHistory(base, cwd);
   const entries = await readAutoresearchJsonl(cwd);
-  const keptRuns = entries.filter(isAcceptedCurrentRun);
-  const productClaimCoverage = buildFinalizationProductClaimCoverageFromLedger(entries);
+  const evidenceState = buildFinalizationEvidenceState(
+    history.map((item) => item.hash),
+    entries,
+  );
+  const keptRuns = evidenceState.acceptedRuns;
+  const productClaimCoverage = evidenceState.productClaimCoverage;
   const productGradeIssue = productGradeFinalizationIssue(productClaimCoverage);
   const groups: PlanGroup[] = [];
   const excludedCommits: ExcludedCommit[] = [];
@@ -1102,6 +1111,7 @@ async function draftGroupsPlan(args: CliArgs, cwd: string): Promise<FinalizePlan
     excluded_commits: excludedCommits,
     excluded_commit_count: excludedCommits.length,
     overlap_files: overlapAnalysis.files,
+    accepted_evidence_fingerprint: evidenceState.fingerprint,
     overlap_count: overlapAnalysis.files.length,
     collapse_overlap_recommended: overlapAnalysis.files.length > 0,
     warnings: buildPlanWarnings({ excludedCommits, overlapAnalysis }),
@@ -1273,6 +1283,14 @@ async function main() {
     },
   );
 
+  await withPhase(
+    "evidence revalidation",
+    "Regenerate the finalizer plan from the current accepted evidence, then retry.",
+    async () => {
+      await assertPlanAcceptedEvidenceCurrent(config, cwd);
+    },
+  );
+
   const createdBranches: string[] = [];
   const reviewBranches: string[] = [];
   const results: BranchResult[] = [];
@@ -1395,10 +1413,38 @@ function planFingerprint(plan: FinalizePlan): string {
   return finalizationPlanFingerprint(plan);
 }
 
+async function assertPlanAcceptedEvidenceCurrent(config: FinalizePlan, cwd: string): Promise<void> {
+  if (!config.accepted_evidence_fingerprint) return;
+  const planned = normalizeFinalizationEvidenceFingerprint(config.accepted_evidence_fingerprint);
+  const history = await commitHistory(config.base, cwd);
+  const entries = await readAutoresearchJsonl(cwd);
+  const current = buildFinalizationEvidenceState(
+    history.map((item) => item.hash),
+    entries,
+  ).fingerprint;
+  if (planned.fingerprint === current.fingerprint && planned.schema_version === 1) return;
+  const labels: Record<string, string> = {
+    accepted_commit_membership: "accepted commit membership",
+    excluded_commit_statuses: "excluded commit status",
+    evidence_statuses: "evidence status",
+    accepted_ledger_order: "accepted ledger ordering",
+    product_claim_coverage_inputs: "product-claim coverage inputs",
+  };
+  const changed = FINALIZATION_EVIDENCE_COMPONENT_KEYS.filter(
+    (key) => planned.components[key] !== current.components[key],
+  ).map((key) => labels[key]);
+  if (planned.schema_version !== 1) changed.unshift("fingerprint schema");
+  if (!changed.length) changed.push("canonical evidence fingerprint");
+  throw new Error(
+    `Stale finalization plan: accepted-current evidence changed in ${changed.join(", ")}. No review branches were created. Regenerate the finalizer plan from the current ledger and retry.`,
+  );
+}
+
 async function hydratePlanProductClaimCoverage(
   config: FinalizePlan,
   cwd: string,
 ): Promise<FinalizePlan> {
+  if (config.accepted_evidence_fingerprint && config.product_claim_coverage) return config;
   const entries = await readAutoresearchJsonl(cwd);
   const derived = buildFinalizationProductClaimCoverageFromLedger(entries);
   const productGradeIssue = productGradeFinalizationIssue(derived);

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { finalizationPlanFingerprint, readAutoresearchLedger } from "../lib/finalization-plan.js";
+import {
+  commitReferencesMatch,
+  finalizationPlanFingerprint,
+  readAutoresearchLedger,
+} from "../lib/finalization-plan.js";
 import { finalizePreview } from "../lib/finalize-preview.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 import { isAutoresearchSessionArtifact } from "../lib/session-artifacts.js";
@@ -92,6 +96,13 @@ testWithTempRoot(
   "finalization plan helpers keep fingerprint and ledger contracts stable",
   "autoresearch-finalization-plan-",
   async (root) => {
+    const fullHash = "0123456789abcdef0123456789abcdef01234567";
+    assert.equal(commitReferencesMatch(fullHash.slice(0, 12), fullHash), true);
+    assert.equal(commitReferencesMatch(fullHash.slice(0, 12).toUpperCase(), fullHash), true);
+    assert.equal(commitReferencesMatch(fullHash.slice(0, 6), fullHash), false);
+    assert.equal(commitReferencesMatch(`${fullHash.slice(0, 12)}not-a-hash`, fullHash), false);
+    assert.equal(commitReferencesMatch(`${fullHash}abcd`, fullHash), false);
+
     const plan = {
       source_branch: "codex/autoresearch",
       planned_at: "ignored",
@@ -1986,21 +1997,56 @@ testWithTempRoot(
     assert.match(staleResult.stderr, /product-claim coverage inputs/i);
 
     const audit = await createEvidencePlanFixture(root, "audit-only");
+    const malformedCommit = `${audit.commit.slice(0, 12)}not-a-hash`;
     await fsp.appendFile(
       path.join(audit.repo, "autoresearch.jsonl"),
       [
-        JSON.stringify({ type: "diagnostic", note: "Audit context only" }),
-        JSON.stringify({ run: 99, status: "measure", metric: 1, description: "Audit probe" }),
+        JSON.stringify({
+          type: "diagnostic",
+          status: "discard",
+          commit: audit.commit,
+          note: "Audit context only",
+        }),
+        JSON.stringify({
+          type: "context",
+          status: "keep",
+          evidenceStatus: "rejected",
+          commit: audit.commit,
+          note: "Context only",
+        }),
+        JSON.stringify({
+          type: "run",
+          run: 99,
+          status: "measure",
+          commit: audit.commit,
+          metric: 1,
+          description: "Audit probe",
+        }),
+        JSON.stringify({
+          type: "run",
+          run: 100,
+          status: "keep",
+          evidenceStatus: "rejected",
+          commit: malformedCommit,
+          description: "Malformed rejection reference",
+        }),
         "",
       ].join("\n"),
       "utf8",
     );
     const auditResult = await run(process.execPath, [finalizer, audit.output], audit.repo);
     assert.match(auditResult.stdout, /Review branches:/);
+
+    const malformedKeep = await createEvidencePlanFixture(root, "malformed-keep", {
+      commitRef: (commit) => `${commit.slice(0, 12)}not-a-hash`,
+    });
+    assert.deepEqual(malformedKeep.plan.kept_commits, []);
+    assert.deepEqual(malformedKeep.plan.groups, []);
+    assert.equal(malformedKeep.plan.excluded_commits[0]?.status, "unlogged");
   },
 );
 
-async function createEvidencePlanFixture(root, name) {
+async function createEvidencePlanFixture(root, name, options = {}) {
   const repo = path.join(root, name);
   await fsp.mkdir(repo, { recursive: true });
   await git(["init", "-b", "main"], repo);
@@ -2027,7 +2073,7 @@ async function createEvidencePlanFixture(root, name) {
         status: "keep",
         evidenceStatus: "accepted",
         metric: 1,
-        commit,
+        commit: options.commitRef ? options.commitRef(commit) : commit,
         description: "Accepted change",
         evidence: "correctness checks passed",
       }),
@@ -2038,7 +2084,7 @@ async function createEvidencePlanFixture(root, name) {
   await run(process.execPath, [finalizer, "plan", "--output", output, "--goal", name], repo);
   const plan = JSON.parse(await fsp.readFile(output, "utf8"));
   assert.ok(plan.accepted_evidence_fingerprint?.fingerprint);
-  return { commit, output, repo };
+  return { commit, output, plan, repo };
 }
 
 testWithTempRoot(

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -1306,6 +1306,7 @@ testWithTempRoot(
     const plan = JSON.parse(await fsp.readFile(payload.planOutput, "utf8"));
     assert.equal(plan.mode, "current-final-tree");
     assert.ok(plan.plan_fingerprint);
+    assert.ok(plan.accepted_evidence_fingerprint?.fingerprint);
     assert.equal(plan.current_tree_coverage.exclude_session_artifacts, true);
     assert.equal(plan.current_tree_coverage.review_unit, "current_tree");
     assert.deepEqual(plan.current_tree_coverage.excluded_session_artifacts.sort(), [
@@ -1888,6 +1889,157 @@ testWithTempRoot(
     );
   },
 );
+
+testWithTempRoot(
+  "finalizer rejects plans after hostile accepted-current evidence changes",
+  "autoresearch-finalize-stale-evidence-",
+  async (root) => {
+    const variants = [
+      {
+        name: "rejected",
+        entry: (commit) => ({
+          run: 2,
+          status: "keep",
+          evidenceStatus: "rejected",
+          commit,
+          description: "Rejected after review",
+        }),
+      },
+      {
+        name: "superseded",
+        entry: (commit) => ({
+          run: 2,
+          status: "keep",
+          evidenceStatus: "superseded",
+          commit,
+          description: "Superseded by later evidence",
+        }),
+      },
+      {
+        name: "invalidated",
+        entry: (commit) => ({
+          run: 2,
+          status: "discard",
+          commit,
+          description: "Invalidated after evaluator contamination",
+          asi: { rollback_reason: "Evaluator contamination invalidated the keep." },
+        }),
+      },
+      {
+        name: "reverted",
+        entry: (commit) => ({
+          run: 2,
+          status: "discard",
+          commit,
+          description: "Reverted after verification",
+          asi: { rollback_reason: "Reverted the accepted change." },
+        }),
+      },
+    ];
+
+    for (const variant of variants) {
+      const { commit, output, repo } = await createEvidencePlanFixture(root, variant.name);
+      const plannedHead = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+      await fsp.appendFile(
+        path.join(repo, "autoresearch.jsonl"),
+        `${JSON.stringify(variant.entry(commit))}\n`,
+        "utf8",
+      );
+
+      const result = await run(process.execPath, [finalizer, output], repo, true);
+      assert.notEqual(result.code, 0, variant.name);
+      assert.match(result.stderr, /accepted-current evidence changed/i, variant.name);
+      assert.match(result.stderr, /accepted commit membership/i, variant.name);
+      assert.match(result.stderr, /evidence status/i, variant.name);
+      assert.match(result.stderr, /Regenerate the finalizer plan/i, variant.name);
+      assert.equal((await git(["rev-parse", "HEAD"], repo)).stdout.trim(), plannedHead);
+      assert.equal(
+        (await git(["branch", "--list", "autoresearch-review/*"], repo)).stdout.trim(),
+        "",
+        variant.name,
+      );
+    }
+  },
+);
+
+testWithTempRoot(
+  "finalizer fingerprints accepted ordering and product-claim inputs but ignores audit-only rows",
+  "autoresearch-finalize-evidence-fingerprint-",
+  async (root) => {
+    const stale = await createEvidencePlanFixture(root, "claim-inputs");
+    await fsp.appendFile(
+      path.join(stale.repo, "autoresearch.jsonl"),
+      `${JSON.stringify({
+        run: 2,
+        status: "keep",
+        evidenceStatus: "accepted",
+        commit: stale.commit,
+        metric: 0.9,
+        description: "Accepted with revised claim evidence",
+        evidence: "correctness checks passed",
+      })}\n`,
+      "utf8",
+    );
+    const staleResult = await run(process.execPath, [finalizer, stale.output], stale.repo, true);
+    assert.notEqual(staleResult.code, 0);
+    assert.match(staleResult.stderr, /accepted ledger ordering/i);
+    assert.match(staleResult.stderr, /product-claim coverage inputs/i);
+
+    const audit = await createEvidencePlanFixture(root, "audit-only");
+    await fsp.appendFile(
+      path.join(audit.repo, "autoresearch.jsonl"),
+      [
+        JSON.stringify({ type: "diagnostic", note: "Audit context only" }),
+        JSON.stringify({ run: 99, status: "measure", metric: 1, description: "Audit probe" }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const auditResult = await run(process.execPath, [finalizer, audit.output], audit.repo);
+    assert.match(auditResult.stdout, /Review branches:/);
+  },
+);
+
+async function createEvidencePlanFixture(root, name) {
+  const repo = path.join(root, name);
+  await fsp.mkdir(repo, { recursive: true });
+  await git(["init", "-b", "main"], repo);
+  await git(["config", "user.email", "codex@example.invalid"], repo);
+  await git(["config", "user.name", "Codex Test"], repo);
+  await writeFile(path.join(repo, ".gitignore"), "autoresearch.jsonl\n");
+  await writeFile(path.join(repo, "src", "value.txt"), "base\n");
+  await git(["add", "-A"], repo);
+  await git(["commit", "-m", "base"], repo);
+  await git(["switch", "-c", `codex/${name}`], repo);
+  await writeFile(path.join(repo, "src", "value.txt"), "accepted\n");
+  await git(["add", "src/value.txt"], repo);
+  await git(["commit", "-m", "accepted change"], repo);
+  const commit = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+  await writeFile(
+    path.join(repo, "autoresearch.jsonl"),
+    [
+      JSON.stringify({
+        type: "config",
+        goal: "Deliver a shippable correctness improvement.",
+      }),
+      JSON.stringify({
+        run: 1,
+        status: "keep",
+        evidenceStatus: "accepted",
+        metric: 1,
+        commit,
+        description: "Accepted change",
+        evidence: "correctness checks passed",
+      }),
+      "",
+    ].join("\n"),
+  );
+  const output = path.join(root, `${name}.groups.json`);
+  await run(process.execPath, [finalizer, "plan", "--output", output, "--goal", name], repo);
+  const plan = JSON.parse(await fsp.readFile(output, "utf8"));
+  assert.ok(plan.accepted_evidence_fingerprint?.fingerprint);
+  return { commit, output, repo };
+}
 
 testWithTempRoot(
   "finalizer plan recommends collapsing overlap and can collapse on request",


### PR DESCRIPTION
## Context

A generated finalization plan could remain executable after the ledger changed which commit evidence was accepted-current. The existing preflight validated branch, HEAD, merge-base, and plan contents, but did not recompute the evidence set immediately before review-branch creation.

Addresses #285.

## What Changed

- Added a canonical, componentized accepted-current evidence fingerprint covering accepted commit membership, excluded commit statuses, effective and declared evidence status, accepted ledger ordering, and product-claim coverage inputs.
- Unified commit-reference matching behind one validated Git-object helper: references must be hexadecimal, at least seven characters, and a true prefix of a 40- or 64-character object ID. Malformed prefix-plus-suffix values cannot select or reclassify commits.
- Embedded the evidence fingerprint in generated commit and current-tree plans and included it in the plan fingerprint.
- Recomputed the evidence fingerprint after group analysis and immediately before review-branch creation. Drift now fails with the exact changed evidence classes, confirms no review branches were created, and tells the operator to regenerate the plan.
- Preserved compatibility for hand-authored plans that do not claim generated-plan metadata; generated plans without the new fingerprint fail closed.
- Added hostile fixtures for later rejection, supersession, invalidation, revert, accepted ordering/claim-input drift, malformed keep/reject references, and same-commit measure/diagnostic/context rows that must remain audit-only.
- Updated the Unreleased changelog.

```mermaid
flowchart LR
  A["Generate plan"] --> B["Store accepted-current fingerprint"]
  B --> C["Preflight and group analysis"]
  C --> D["Recompute evidence fingerprint"]
  D -->|match| E["Create review branches"]
  D -->|drift| F["Reject and regenerate"]
```

## How To Review

1. Review the canonical evidence material and component hashing in `lib/finalization-plan.ts`.
2. Review the new execution gate in `scripts/finalize-autoresearch.ts`; it runs after group analysis and before any branch mutation.
3. Review the hostile and control fixtures in `tests/finalize-report.test.ts`.

## Verification

- `npm run test:finalize` — 35/35 finalizer tests passed.
- `npm run check` — typecheck, lint, format, source hygiene, dashboard parity, dogfood, 15/15 product benchmark (`quality_gap=0`), all CLI shards, 119/119 dashboard tests, 35/35 finalizer tests, 309/309 core tests, package artifact, and runtime smoke passed.
- `git diff --check` — passed.
- CodeStory local index refreshed successfully and the affected-path walk covered all five changed package source/test files; packet/search remained unavailable because the agent retrieval manifest is missing.

## Risk

The gate is deliberately conservative: changes to accepted evidence text or accepted ordering require plan regeneration even when the final coverage label remains the same. Unrelated diagnostic or measure-only audit additions are excluded from the canonical accepted-current material and do not invalidate the plan. No finalizer branch-construction or cleanup structure was refactored.