### PR TITLE
Make Git path trust checks NUL-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ### Fixed
 
+- Git-derived trust paths now use NUL-delimited porcelain, name-status, and tracked-file output, preserving hostile filenames and both sides of renames across protected benchmark checks, dirty/write scopes, fingerprints, source hygiene, runtime freshness, and finalization.
 - State, terminal report, `recommend-next`, and dashboard readouts now agree on one strongest next action and command; stale progress, stale packets, artifact recovery, setup, and failed-check decisions remain distinct, weaker portfolio advice is suppressed while blocked, session continuation is separated from packet permission, and absent or metricless kept evidence no longer masquerades as an incumbent.
 - Autoresearch and finalizer CLI parsing now rejects unknown root and command options, validates explicit boolean values, supports root and command `-h`/`--help`, preserves camel/kebab aliases plus repeated list and `--` passthrough behavior, and reports expected usage failures without stack traces unless `--debug` is explicit.
 - Dashboard exports and live readouts now reject missing, malformed, or version-incompatible payloads instead of substituting polished demo evidence. Demo data requires an explicit development/showcase marker, failure states show safe recovery guidance and provenance, and failed live refreshes visibly retain only the last validated readout.

--- a/plugins/codex-autoresearch/lib/checks/source-checkout-launcher.ts
+++ b/plugins/codex-autoresearch/lib/checks/source-checkout-launcher.ts
@@ -1,5 +1,6 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { displayGitPath, parseNulPathList } from "../git-paths.js";
 import { indent, REPO_ROOT, ROOT, runCommand } from "./check-common.js";
 
 const sourceCheckoutLauncherPaths = [
@@ -43,6 +44,7 @@ export async function runSourceCheckoutLauncherCheck() {
       "-C",
       REPO_ROOT,
       "ls-files",
+      "-z",
       "--cached",
       "--others",
       "--exclude-standard",
@@ -57,7 +59,7 @@ export async function runSourceCheckoutLauncherCheck() {
     if (output) console.log(indent(output));
     return false;
   }
-  const committablePaths = new Set(committable.stdout.split(/\r?\n/).filter(Boolean));
+  const committablePaths = new Set(parseNulPathList(committable.stdout));
   const ignoredOrInvisible = sourceCheckoutLauncherPaths.filter(
     (file) => !committablePaths.has(file),
   );
@@ -75,7 +77,7 @@ export async function runSourceCheckoutLauncherCheck() {
   const trackedDist = await runCommand([
     "source-dist-untracked",
     "git",
-    ["-C", REPO_ROOT, "ls-files", "--", "plugins/codex-autoresearch/dist"],
+    ["-C", REPO_ROOT, "ls-files", "-z", "--", "plugins/codex-autoresearch/dist"],
   ]);
   if (trackedDist.code !== 0) {
     console.log("ok source-launcher-files");
@@ -85,11 +87,16 @@ export async function runSourceCheckoutLauncherCheck() {
     if (output) console.log(indent(output));
     return false;
   }
-  if (trackedDist.stdout.trim()) {
+  const trackedDistPaths = parseNulPathList(trackedDist.stdout);
+  if (trackedDistPaths.length) {
     console.log("ok source-launcher-files");
     console.log("ok source-launcher-committable");
     console.log("fail source-dist-untracked");
-    console.log(indent(`Generated dist files are still tracked:\n${trackedDist.stdout.trim()}`));
+    console.log(
+      indent(
+        `Generated dist files are still tracked:\n${trackedDistPaths.map(displayGitPath).join("\n")}`,
+      ),
+    );
     return false;
   }
 

--- a/plugins/codex-autoresearch/lib/checks/source-hygiene.ts
+++ b/plugins/codex-autoresearch/lib/checks/source-hygiene.ts
@@ -1,5 +1,6 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { parseNulPathList } from "../git-paths.js";
 import {
   findLooseObjectCompatibilityOffenders,
   findSourceHygieneOffenders,
@@ -55,7 +56,7 @@ export async function runSourceHygieneCheck(
   const tracked = await runCommand([
     "source-hygiene:tracked-files",
     "git",
-    ["-C", REPO_ROOT, "ls-files"],
+    ["-C", REPO_ROOT, "ls-files", "-z"],
   ]);
   if (tracked.code !== 0) {
     console.log("fail source-hygiene");
@@ -64,7 +65,7 @@ export async function runSourceHygieneCheck(
     return false;
   }
 
-  return reportSourceHygieneResult(tracked.stdout.split(/\r?\n/), {
+  return reportSourceHygieneResult(parseNulPathList(tracked.stdout), {
     sourceFiles: options.sourceFiles,
   });
 }

--- a/plugins/codex-autoresearch/lib/commands/lane-runner.ts
+++ b/plugins/codex-autoresearch/lib/commands/lane-runner.ts
@@ -434,7 +434,7 @@ async function hardenedScoutStatus(
     deps,
     {
       executable: "git",
-      args: hardenedReadOnlyGitArgs("status", ["--porcelain", "--untracked-files=all"]),
+      args: hardenedReadOnlyGitArgs("status", ["--porcelain=v1", "-z", "--untracked-files=all"]),
     },
     cwd,
     timeoutSeconds,

--- a/plugins/codex-autoresearch/lib/finalize-preview.ts
+++ b/plugins/codex-autoresearch/lib/finalize-preview.ts
@@ -2,10 +2,12 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { renderShellCommand } from "./command-rendering.js";
 import { isAcceptedCurrentRun } from "./evidence-registry.js";
 import { productGradeFinalizationIssue } from "./finalization-acceptance.js";
 import { classifyFinalizationRunwayFromFacts } from "./finalization-runway.js";
+import { parseNameStatusZ } from "./git-paths.js";
 import {
   buildFinalizationEvidenceState,
   commitReferencesMatch,
@@ -82,7 +84,7 @@ export async function finalizePreview(args: LooseObject) {
   }
 
   const branch = (await git(["branch", "--show-current"], workDir)).stdout.trim();
-  const dirty = (await git(["status", "--porcelain"], workDir)).stdout.trim();
+  const dirty = (await git(["status", "--porcelain=v1", "-z"], workDir)).stdout;
   emitProgress(args, "finalize-preview", "reading autoresearch ledger and kept commits");
   const ledgerEntries = await readLedgerEntries(workDir);
   const ledgerRuns = ledgerEntries.filter((entry: LooseObject) => entry.run != null) as KeptRun[];
@@ -548,7 +550,7 @@ export async function finalizeCurrentTree(args: LooseObject) {
   emitProgress(args, "finalize-current-tree", "classifying session artifacts and review files");
   const fileSelection = selectCurrentTreeFiles(allFiles, Boolean(excludeSessionArtifacts));
   const files = fileSelection.includedFiles;
-  const dirty = (await git(["status", "--porcelain"], workDir)).stdout.trim();
+  const dirty = (await git(["status", "--porcelain=v1", "-z"], workDir)).stdout;
   if (dirty)
     warnings.push("Working tree is dirty; current-tree plan requires a clean source branch.");
   if (!branch)
@@ -779,12 +781,10 @@ async function readLedgerEntries(cwd: string): Promise<LooseObject[]> {
 }
 
 async function changedFilesForCommit(hash: string, cwd: string): Promise<string[]> {
-  const result = await git(["show", "--name-only", "--format=", hash], cwd);
-  return result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .filter((file) => !isAutoresearchSessionArtifact(file, "source-checkout"));
+  const result = await git(["show", "--name-status", "-z", "-M", "--format=", hash], cwd);
+  return uniqueSortedGitPaths(result.stdout).filter(
+    (file) => !isAutoresearchSessionArtifact(file, "source-checkout"),
+  );
 }
 
 async function changedFilesBetween(
@@ -793,13 +793,16 @@ async function changedFilesBetween(
   cwd: string,
   filterSession = true,
 ): Promise<string[]> {
-  const result = await git(["diff", "--name-only", `${left}..${right}`], cwd);
-  return result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
+  const result = await git(["diff", "--name-status", "-z", "-M", `${left}..${right}`], cwd);
+  return uniqueSortedGitPaths(result.stdout)
     .filter((file) => !filterSession || !isAutoresearchSessionArtifact(file, "source-checkout"))
     .sort((a, b) => a.localeCompare(b));
+}
+
+function uniqueSortedGitPaths(output: string): string[] {
+  return [...new Set(parseNameStatusZ(output).flatMap((entry) => entry.paths))].sort((a, b) =>
+    a.localeCompare(b),
+  );
 }
 
 async function commitHashesBetween(left: string, right: string, cwd: string): Promise<string[]> {
@@ -961,16 +964,22 @@ async function gitOk(args: string[], cwd: string): Promise<GitResult> {
     const child = spawn("git", args, { cwd, windowsHide: true, stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
+      stdout += stdoutDecoder.write(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
+      stderr += stderrDecoder.write(chunk);
     });
     child.on("error", (error) =>
       resolve({ code: -1, stdout, stderr: String(error.message || error) }),
     );
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("close", (code) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
+      resolve({ code, stdout, stderr });
+    });
   });
   return { ...result, ok: result.code === 0 };
 }

--- a/plugins/codex-autoresearch/lib/git-paths.ts
+++ b/plugins/codex-autoresearch/lib/git-paths.ts
@@ -1,0 +1,80 @@
+export type GitPorcelainEntry = {
+  status: string;
+  path: string;
+  originalPath?: string;
+  paths: string[];
+};
+
+type GitPathOutput = string | Uint8Array;
+
+function decodeGitPathOutput(output: GitPathOutput): string {
+  return typeof output === "string"
+    ? output
+    : new TextDecoder("utf-8", { fatal: true }).decode(output);
+}
+
+export function parseNulPathList(output: GitPathOutput): string[] {
+  const text = decodeGitPathOutput(output);
+  if (!text) return [];
+  if (!text.endsWith("\0")) throw new Error("Malformed Git path output: missing NUL terminator.");
+  const paths = text.slice(0, -1).split("\0");
+  if (paths.some((path) => !path)) throw new Error("Malformed Git path output: empty path.");
+  return paths;
+}
+
+export function parsePorcelainV1Z(output: GitPathOutput): GitPorcelainEntry[] {
+  const fields = parseNulPathList(output);
+  const entries: GitPorcelainEntry[] = [];
+  for (let index = 0; index < fields.length; index += 1) {
+    const record = fields[index];
+    if (record.length < 4 || record[2] !== " ") {
+      throw new Error("Malformed Git porcelain v1 -z record.");
+    }
+    const status = record.slice(0, 2);
+    const currentPath = record.slice(3);
+    if (status.includes("R") || status.includes("C")) {
+      const originalPath = fields[index + 1];
+      if (!originalPath) throw new Error("Malformed Git porcelain rename/copy record.");
+      index += 1;
+      entries.push({
+        status,
+        path: currentPath,
+        originalPath,
+        paths: [originalPath, currentPath],
+      });
+    } else {
+      entries.push({ status, path: currentPath, paths: [currentPath] });
+    }
+  }
+  return entries;
+}
+
+export function parseNameStatusZ(output: GitPathOutput): GitPorcelainEntry[] {
+  const fields = parseNulPathList(output);
+  const entries: GitPorcelainEntry[] = [];
+  for (let index = 0; index < fields.length; ) {
+    const status = fields[index++];
+    if (!/^[ACDMRTUXB][0-9]*$/.test(status)) {
+      throw new Error("Malformed Git --name-status -z record.");
+    }
+    const originalPath = fields[index++];
+    if (!originalPath) throw new Error("Malformed Git --name-status -z path.");
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const currentPath = fields[index++];
+      if (!currentPath) throw new Error("Malformed Git rename/copy destination.");
+      entries.push({
+        status,
+        path: currentPath,
+        originalPath,
+        paths: [originalPath, currentPath],
+      });
+    } else {
+      entries.push({ status, path: originalPath, paths: [originalPath] });
+    }
+  }
+  return entries;
+}
+
+export function displayGitPath(value: string): string {
+  return JSON.stringify(value);
+}

--- a/plugins/codex-autoresearch/lib/runner.ts
+++ b/plugins/codex-autoresearch/lib/runner.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 
 const DENIED_METRIC_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 const OUTPUT_MAX_LINES = 20;
@@ -360,6 +361,8 @@ export async function runProcess(
     });
     let stdout = "";
     let stderr = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     let stdoutTruncated = false;
     let stderrTruncated = false;
     let lastOutputAt: string | null = null;
@@ -422,10 +425,10 @@ export async function runProcess(
       Math.max(1, Number(timeoutSeconds) || 1) * 1000,
     );
     child.stdout.on("data", (chunk) => {
-      appendOutput("stdout", chunk.toString("utf8"));
+      appendOutput("stdout", stdoutDecoder.write(chunk));
     });
     child.stderr.on("data", (chunk) => {
-      appendOutput("stderr", chunk.toString("utf8"));
+      appendOutput("stderr", stderrDecoder.write(chunk));
     });
     child.on("error", (error) => {
       finish({
@@ -435,6 +438,8 @@ export async function runProcess(
       });
     });
     child.on("close", (code) => {
+      appendOutput("stdout", stdoutDecoder.end());
+      appendOutput("stderr", stderrDecoder.end());
       finish({ exitCode: code, stdout, stderr });
     });
   });

--- a/plugins/codex-autoresearch/lib/session-artifacts.ts
+++ b/plugins/codex-autoresearch/lib/session-artifacts.ts
@@ -17,7 +17,8 @@ export const CLEANUP_SESSION_PATHS = [RESEARCH_DIR, ...SESSION_FILES].sort((a, b
 );
 
 export function isAutoresearchSessionArtifact(file: string, mode: SessionArtifactMode): boolean {
-  const normalized = String(file || "").replace(/\\/g, "/");
+  const value = String(file || "");
+  const normalized = process.platform === "win32" ? value.replace(/\\/g, "/") : value;
   return shouldExcludeSessionArtifact(normalized, { mode });
 }
 

--- a/plugins/codex-autoresearch/lib/truth-signals.ts
+++ b/plugins/codex-autoresearch/lib/truth-signals.ts
@@ -2,7 +2,9 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { isAcceptedCurrentRun, isRejectedRun } from "./evidence-registry.js";
+import { parsePorcelainV1Z } from "./git-paths.js";
 import { isAutoresearchSessionArtifact } from "./session-artifacts.js";
 import { finiteMetric, isPromotionGradeRun, promotionGradeValue } from "./session-core.js";
 
@@ -369,14 +371,13 @@ async function gitIndexLockHealth(workDir: string) {
 }
 
 async function classifyDirtyFiles(workDir: string, config: LooseObject = {}) {
-  const status = await gitOk(["status", "--porcelain=v1", "-uall"], workDir);
+  const status = await gitOk(["status", "--porcelain=v1", "-z", "-uall"], workDir);
   if (!status.ok) return null;
   const commitPaths = listOption(config.commitPaths ?? config.commit_paths).map(slashPath);
   const sessionArtifacts: string[] = [];
   const scopedExperimentFiles: string[] = [];
   const unrelatedFiles: string[] = [];
-  for (const line of status.stdout.split(/\r?\n/).filter(Boolean)) {
-    const file = slashPath(line.slice(3).replace(/^"|"$/g, ""));
+  for (const file of parsePorcelainV1Z(status.stdout).flatMap((entry) => entry.paths)) {
     if (isAutoresearchSessionArtifact(file, "dirty-tree")) sessionArtifacts.push(file);
     else if (commitPaths.some((scope) => file === scope || file.startsWith(`${scope}/`))) {
       scopedExperimentFiles.push(file);
@@ -484,16 +485,22 @@ async function gitOk(args: string[], cwd: string) {
     const child = spawn("git", args, { cwd, windowsHide: true, stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
+      stdout += stdoutDecoder.write(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
+      stderr += stderrDecoder.write(chunk);
     });
     child.on("error", (error) =>
       resolve({ code: -1, ok: false, stdout, stderr: String(error.message || error) }),
     );
-    child.on("close", (code) => resolve({ code, ok: code === 0, stdout, stderr }));
+    child.on("close", (code) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
+      resolve({ code, ok: code === 0, stdout, stderr });
+    });
   });
 }
 

--- a/plugins/codex-autoresearch/scripts/autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/autoresearch.ts
@@ -107,6 +107,7 @@ import {
 import { isPathInside, resolvePathInsideRootSync } from "../lib/path-containment.js";
 import { resolveSafeResearchPath } from "../lib/research-path-guard.js";
 import { buildExperimentMemory } from "../lib/experiment-memory.js";
+import { displayGitPath, parseNulPathList, parsePorcelainV1Z } from "../lib/git-paths.js";
 import {
   buildGoalContract,
   buildGoalFrame,
@@ -241,7 +242,9 @@ type ProgressStageResult = {
 interface LocalProcessResult {
   code: number | null;
   stderr: string;
+  stderrTruncated?: boolean;
   stdout: string;
+  stdoutTruncated?: boolean;
 }
 
 const SESSION_FILES: readonly string[] = AUTORESEARCH_SESSION_FILES;
@@ -3948,13 +3951,20 @@ async function runProcess(
 ): Promise<LocalProcessResult> {
   const result = await runBoundedProcess(command, args, {
     cwd,
+    maxOutputBytes: options.maxOutputBytes,
     timeoutSeconds: options.timeoutMs ? Math.max(1, Number(options.timeoutMs) / 1000) : 600,
   });
-  return { code: result.code, stdout: result.stdout, stderr: result.stderr };
+  return {
+    code: result.code,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    stdoutTruncated: result.stdoutTruncated,
+    stderrTruncated: result.stderrTruncated,
+  };
 }
 
 async function git(args: any, cwd: string): Promise<LocalProcessResult> {
-  return await runProcess("git", args, cwd);
+  return await runProcess("git", args, cwd, { maxOutputBytes: 16 * 1024 * 1024 });
 }
 
 function gitOutput(result: any, fallback: any) {
@@ -4153,36 +4163,21 @@ async function hasStagedChangesInPaths(cwd: string, paths: string[]) {
 
 async function gitDirtyPathDetails(cwd: string) {
   if (!(await insideGitRepo(cwd))) return [];
-  const result = await git(["status", "--porcelain=v1", "-uall"], cwd);
-  if (result.code !== 0) return [];
-  return result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trimEnd())
-    .filter(Boolean)
-    .map((line) => {
-      const status = line.slice(0, 2);
-      const rawPath = line.slice(3).trim();
-      const normalizedPath = rawPath.includes(" -> ")
-        ? rawPath.split(" -> ").pop() || rawPath
-        : rawPath;
-      return {
-        status,
-        path: normalizeGitStatusPath(normalizedPath),
-        raw: line,
-      };
-    })
-    .filter((entry) => entry.path);
-}
-
-function normalizeGitStatusPath(value: string) {
-  const trimmed = String(value || "").trim();
-  const unquoted =
-    trimmed.startsWith('"') && trimmed.endsWith('"') ? trimmed.slice(1, -1) : trimmed;
-  return unquoted.replace(/\\\\/g, "/").replace(/\\/g, "/");
+  const result = await git(["status", "--porcelain=v1", "-z", "-uall"], cwd);
+  if (result.code !== 0)
+    throw new Error(`Git status failed: ${gitOutput(result, "unknown error")}`);
+  assertCompleteGitPathOutput(result);
+  return parsePorcelainV1Z(result.stdout).flatMap((entry) =>
+    entry.paths.map((gitPath) => ({
+      status: entry.status,
+      path: gitPath,
+      raw: `${entry.status} ${displayGitPath(gitPath)}`,
+    })),
+  );
 }
 
 function isAutoresearchOwnedDirtyPath(relativePath: string) {
-  const normalized = normalizeGitStatusPath(relativePath);
+  const normalized = relativePath;
   return (
     SESSION_FILES.includes(normalized) ||
     AUTORESEARCH_OWNED_FILES.includes(normalized) ||
@@ -4231,15 +4226,24 @@ async function assertCommitPathsExist(workDir: string, commitPaths: any[]) {
 }
 
 async function gitPathIsTracked(workDir: string, relativePath: string) {
-  const result = await git(["--literal-pathspecs", "ls-files", "--", relativePath], workDir);
-  return result.code === 0 && result.stdout.trim().length > 0;
+  const result = await git(["--literal-pathspecs", "ls-files", "-z", "--", relativePath], workDir);
+  return result.code === 0 && result.stdout.length > 0;
 }
 
 async function gitStatusShort(cwd: string) {
-  const result = await git(["status", "--porcelain=v1", "-uall"], cwd);
+  const result = await git(["status", "--porcelain=v1", "-z", "-uall"], cwd);
   if (result.code !== 0)
     throw new Error(`Git status failed: ${gitOutput(result, "unknown error")}`);
-  return result.stdout.trim();
+  assertCompleteGitPathOutput(result);
+  return result.stdout;
+}
+
+function assertCompleteGitPathOutput(result: LocalProcessResult) {
+  if (result.stdoutTruncated) {
+    throw new Error(
+      "Git path output exceeded the capture limit; refusing an incomplete trust check.",
+    );
+  }
 }
 
 function hashText(value: any) {
@@ -4255,13 +4259,10 @@ async function scopedFileFingerprints(
 ) {
   const safePaths = normalizeRelativePaths(paths, "commitPaths");
   if (safePaths.length === 0) return [];
-  const result = await git(["--literal-pathspecs", "ls-files", "--", ...safePaths], workDir);
+  const result = await git(["--literal-pathspecs", "ls-files", "-z", "--", ...safePaths], workDir);
   if (result.code !== 0) return [];
-  const files = result.stdout
-    .split(/\r?\n/)
-    .map((file: any) => file.trim())
-    .filter(Boolean)
-    .sort((a: any, b: any) => a.localeCompare(b));
+  assertCompleteGitPathOutput(result);
+  const files = parseNulPathList(result.stdout).sort((a, b) => a.localeCompare(b));
   const fingerprints = [];
   for (const file of files) {
     if (fingerprints.length >= DIRECTORY_FINGERPRINT_ENTRY_LIMIT) {
@@ -4291,20 +4292,8 @@ async function scopedFileFingerprints(
 }
 
 function dirtyPathsFromStatus(statusShort: string) {
-  return String(statusShort || "")
-    .split(/\r?\n/)
-    .map((line: string) => line.trimEnd())
-    .filter(Boolean)
-    .map((line: string) => {
-      const rawPath = /^.. /.test(line)
-        ? line.slice(3).trim()
-        : line.replace(/^[ MADRCU?!]{1,2}\s+/, "").trim();
-      const renamedPath = rawPath.includes(" -> ")
-        ? rawPath.split(" -> ").at(-1) || rawPath
-        : rawPath;
-      return renamedPath.replace(/^"|"$/g, "").replace(/\\"/g, '"').replace(/\\/g, "/");
-    })
-    .filter(Boolean)
+  return parsePorcelainV1Z(statusShort)
+    .flatMap((entry) => entry.paths)
     .sort((a: any, b: any) => a.localeCompare(b));
 }
 
@@ -4650,9 +4639,7 @@ async function protectedBenchmarkGuardForWorkDir(
   config: LooseObject,
   state: LooseObject,
 ) {
-  const dirtyPaths = (await gitDirtyPathDetails(workDir).catch((): LooseObject[] => [])).map(
-    (entry: LooseObject) => entry.path,
-  );
+  const dirtyPaths = (await gitDirtyPathDetails(workDir)).map((entry: LooseObject) => entry.path);
   return await buildProtectedBenchmarkGuard({ workDir, config, state, dirtyPaths });
 }
 
@@ -4807,7 +4794,7 @@ async function discardCleanupPlan(workDir: string, args: any, config: any) {
 }
 
 function pathIsCoveredByScope(filePath: string, scopePath: any) {
-  const file = slashPath(filePath);
+  const file = process.platform === "win32" ? slashPath(filePath) : filePath;
   const scope = slashPath(scopePath);
   return file === scope || file.startsWith(`${scope}/`);
 }
@@ -8088,8 +8075,7 @@ async function resolveLaneWorktree(workDir: string, worktreePath: string) {
 }
 
 function dirtyPathWithinScope(relativePath: string, writeScope: string[]) {
-  const normalized = normalizeGitStatusPath(relativePath);
-  return writeScope.some((scope) => normalized === scope || normalized.startsWith(`${scope}/`));
+  return writeScope.some((scope) => relativePath === scope || relativePath.startsWith(`${scope}/`));
 }
 
 async function assertDirtyPathsWithinWriteScope(workDir: string, writeScope: string[]) {
@@ -8102,7 +8088,10 @@ async function assertDirtyPathsWithinWriteScope(workDir: string, writeScope: str
     .filter((relativePath: string) => !dirtyPathWithinScope(relativePath, writeScope));
   if (outside.length) {
     throw new Error(
-      `Implementation lane changed files outside --write-scope: ${outside.slice(0, 8).join(", ")}`,
+      `Implementation lane changed files outside --write-scope: ${outside
+        .slice(0, 8)
+        .map(displayGitPath)
+        .join(", ")}`,
     );
   }
 }
@@ -8117,7 +8106,10 @@ async function assertNoDirtyPathsOutsideWriteScope(workDir: string, writeScope: 
     .filter((relativePath: string) => !dirtyPathWithinScope(relativePath, writeScope));
   if (outside.length) {
     throw new Error(
-      `Implementation lane --write-scope cannot start with dirty files outside scope: ${outside.slice(0, 8).join(", ")}`,
+      `Implementation lane --write-scope cannot start with dirty files outside scope: ${outside
+        .slice(0, 8)
+        .map(displayGitPath)
+        .join(", ")}`,
     );
   }
 }

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { pipeline } from "node:stream/promises";
+import { StringDecoder } from "node:string_decoder";
 import { parseSha256Manifest } from "./release-integrity.mjs";
 
 const DOWNLOAD_TIMEOUT_MS = 120_000;
@@ -528,14 +529,18 @@ function runCapture(command, args, options = {}) {
     });
     let stdout = "";
     let stderr = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString("utf8");
+      stdout += stdoutDecoder.write(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
+      stderr += stderrDecoder.write(chunk);
     });
     child.on("error", reject);
     child.on("close", (code) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
       resolve({ code, stdout, stderr });
     });
   });
@@ -560,27 +565,28 @@ async function fileMtime(file) {
 
 async function sourceRuntimeFreshByGit(pluginRoot, targetMtime) {
   if (!(targetMtime > 0)) return false;
-  const [metadata, status] = await Promise.all([
-    runCapture(
-      "git",
-      [
-        "rev-parse",
-        "--show-toplevel",
-        "--path-format=absolute",
-        "--git-path",
-        "HEAD",
-        "--git-path",
-        "index",
-      ],
-      {
-        cwd: pluginRoot,
-      },
-    ).catch(() => null),
+  let parsePorcelainV1Z;
+  try {
+    ({ parsePorcelainV1Z } = await import(
+      pathToFileURL(path.join(pluginRoot, "dist", "lib", "git-paths.mjs")).href
+    ));
+  } catch {
+    return false;
+  }
+  const [repoRootResult, headPathResult, indexPathResult, status] = await Promise.all([
+    runCapture("git", ["rev-parse", "--show-toplevel"], { cwd: pluginRoot }).catch(() => null),
+    runCapture("git", ["rev-parse", "--path-format=absolute", "--git-path", "HEAD"], {
+      cwd: pluginRoot,
+    }).catch(() => null),
+    runCapture("git", ["rev-parse", "--path-format=absolute", "--git-path", "index"], {
+      cwd: pluginRoot,
+    }).catch(() => null),
     runCapture(
       "git",
       [
         "status",
         "--porcelain=v1",
+        "-z",
         "-uall",
         "--",
         "package.json",
@@ -595,16 +601,26 @@ async function sourceRuntimeFreshByGit(pluginRoot, targetMtime) {
       },
     ).catch(() => null),
   ]);
-  if (!metadata || metadata.code !== 0 || !status || status.code !== 0) return false;
+  if (
+    !repoRootResult ||
+    repoRootResult.code !== 0 ||
+    !headPathResult ||
+    headPathResult.code !== 0 ||
+    !indexPathResult ||
+    indexPathResult.code !== 0 ||
+    !status ||
+    status.code !== 0
+  )
+    return false;
 
-  const [repoRootText, headPathText, indexPathText] = metadata.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const repoRootText = gitScalar(repoRootResult.stdout);
+  const headPathText = gitScalar(headPathResult.stdout);
+  const indexPathText = gitScalar(indexPathResult.stdout);
   if (!repoRootText || !headPathText || !indexPathText) return false;
 
   const dirty = dirtyRuntimeSourcePaths({
     pluginRoot,
+    parsePorcelainV1Z,
     repoRoot: repoRootText,
     stdout: status.stdout,
   });
@@ -618,13 +634,10 @@ async function sourceRuntimeFreshByGit(pluginRoot, targetMtime) {
   return Math.max(0, ...markerMtimes) < targetMtime;
 }
 
-function dirtyRuntimeSourcePaths({ pluginRoot, repoRoot, stdout }) {
+function dirtyRuntimeSourcePaths({ parsePorcelainV1Z, pluginRoot, repoRoot, stdout }) {
   const paths = [];
-  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
-    if (!rawLine.trim()) continue;
-    const status = rawLine.slice(0, 2);
-    const parsed = parsePorcelainPath(rawLine.slice(3));
-    if (!parsed) continue;
+  for (const entry of parsePorcelainV1Z(stdout)) {
+    const { status } = entry;
     if (
       status.includes("D") ||
       status.includes("R") ||
@@ -633,25 +646,21 @@ function dirtyRuntimeSourcePaths({ pluginRoot, repoRoot, stdout }) {
     ) {
       return { fullScanRequired: true, paths };
     }
-    const absolutePath = path.resolve(repoRoot, parsed.replace(/\//g, path.sep));
-    const relativePath = slashPath(path.relative(pluginRoot, absolutePath));
-    if (!isRuntimeSourcePath(relativePath)) continue;
-    paths.push(absolutePath);
+    for (const gitPath of entry.paths) {
+      const absolutePath = path.resolve(repoRoot, gitPath.replace(/\//g, path.sep));
+      const relativePath = slashPath(path.relative(pluginRoot, absolutePath));
+      if (!isRuntimeSourcePath(relativePath)) continue;
+      paths.push(absolutePath);
+    }
   }
   return { fullScanRequired: false, paths };
 }
 
-function parsePorcelainPath(text) {
-  const value = String(text || "").trim();
-  if (!value) return "";
-  const renamed = value.lastIndexOf(" -> ");
-  const pathText = renamed >= 0 ? value.slice(renamed + 4) : value;
-  if (!pathText.startsWith('"')) return pathText;
-  try {
-    return JSON.parse(pathText);
-  } catch {
-    return pathText.slice(1, -1);
-  }
+function gitScalar(stdout) {
+  const text = String(stdout || "");
+  if (text.endsWith("\r\n")) return text.slice(0, -2);
+  if (text.endsWith("\n")) return text.slice(0, -1);
+  return text;
 }
 
 export function isRuntimeSourcePath(relativePath) {

--- a/plugins/codex-autoresearch/scripts/check-runner.ts
+++ b/plugins/codex-autoresearch/scripts/check-runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { killProcess } from "../lib/runner.js";
+import { StringDecoder } from "node:string_decoder";
 
 export type CommandSpec = [label: string, command: string, args: string[]];
 
@@ -48,6 +49,8 @@ export function runCommand(
     });
     let stdout = "";
     let stderr = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     let settled = false;
     let timedOut = false;
     let timeoutFallback: NodeJS.Timeout | undefined;
@@ -71,21 +74,23 @@ export function runCommand(
       Math.max(1, timeoutSeconds) * 1000,
     );
     child.stdout.on("data", (chunk) => {
-      const text = chunk.toString("utf8");
+      const text = stdoutDecoder.write(chunk);
       stdout += text;
       if (streamOutput) process.stdout.write(text);
     });
     child.stderr.on("data", (chunk) => {
-      const text = chunk.toString("utf8");
+      const text = stderrDecoder.write(chunk);
       stderr += text;
       if (streamOutput) process.stderr.write(text);
     });
     child.on("error", (error) =>
       finish({ label, code: -1, stdout, stderr: `${stderr}${error.message}\n`, timedOut }),
     );
-    child.on("close", (code) =>
-      finish({ label, code: timedOut ? null : code, stdout, stderr, timedOut }),
-    );
+    child.on("close", (code) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
+      finish({ label, code: timedOut ? null : code, stdout, stderr, timedOut });
+    });
   });
 }
 

--- a/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
+++ b/plugins/codex-autoresearch/scripts/finalize-autoresearch.ts
@@ -3,10 +3,12 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 import { isAcceptedCurrentRun } from "../lib/evidence-registry.js";
 import { productGradeFinalizationIssue } from "../lib/finalization-acceptance.js";
 import { classifyFinalizationRunwayFromFacts } from "../lib/finalization-runway.js";
+import { parseNameStatusZ } from "../lib/git-paths.js";
 import {
   FINALIZATION_EVIDENCE_COMPONENT_KEYS,
   assertGeneratedPlanMetadata,
@@ -168,16 +170,22 @@ async function run(
     });
     let stdout = "";
     let stderr = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
+      stdout += stdoutDecoder.write(chunk);
     });
     child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
+      stderr += stderrDecoder.write(chunk);
     });
     child.on("error", (error: Error) =>
       resolve({ code: -1, stdout, stderr: String(error.message || error) }),
     );
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.on("close", (code) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
+      resolve({ code, stdout, stderr });
+    });
   });
   if (!allowFailure && result.code !== 0) {
     throw new Error(`${command} ${args.join(" ")} failed:\n${result.stdout}${result.stderr}`);
@@ -197,9 +205,8 @@ function cleanLines(text: string): string[] {
 }
 
 function validateRepoRelativePath(file: unknown, cwd: string): string {
-  const normalized = String(file || "")
-    .trim()
-    .replace(/\\/g, "/");
+  const value = String(file ?? "");
+  const normalized = process.platform === "win32" ? value.replace(/\\/g, "/") : value;
   if (!normalized) throw new Error("Unsafe finalizer file path: empty path.");
   if (normalized.includes("\0"))
     throw new Error(`Unsafe finalizer file path contains NUL: ${file}`);
@@ -303,8 +310,8 @@ async function branchExists(branch: string, cwd: string): Promise<boolean> {
 }
 
 async function isDirty(cwd: string): Promise<boolean> {
-  const result = await git(["status", "--porcelain"], cwd);
-  return result.stdout.trim().length > 0;
+  const result = await git(["status", "--porcelain=v1", "-z"], cwd);
+  return result.stdout.length > 0;
 }
 
 async function restoreSourceBranch(sourceBranch: string, cwd: string): Promise<void> {
@@ -336,8 +343,12 @@ async function restoreSourceBranchIfNeeded(sourceBranch: string, cwd: string): P
 }
 
 async function changedFiles(fromRef: string, toRef: string, cwd: string): Promise<string[]> {
-  const result = await git(["diff", "--name-only", fromRef, toRef], cwd);
-  return normalizePlanFiles(cleanLines(result.stdout), cwd);
+  const result = await git(["diff", "--name-status", "-z", "-M", fromRef, toRef], cwd);
+  return normalizePlanFiles(gitChangedPaths(result.stdout), cwd);
+}
+
+function gitChangedPaths(output: string): string[] {
+  return [...new Set(parseNameStatusZ(output).flatMap((entry) => entry.paths))];
 }
 
 function planExcludesSessionArtifacts(config: FinalizePlan): boolean {
@@ -983,8 +994,8 @@ async function verifyUnion(
       }
       await git(["add", "-A"], cwd);
       await git(["commit", "--allow-empty", "-m", "verify: union of autoresearch groups"], cwd);
-      const diff = await git(["diff", "--name-only", "HEAD", config.final_tree], cwd);
-      nonSession = cleanLines(diff.stdout).filter(
+      const diff = await git(["diff", "--name-status", "-z", "-M", "HEAD", config.final_tree], cwd);
+      nonSession = gitChangedPaths(diff.stdout).filter(
         (file) => !isAutoresearchSessionArtifact(file, "finalization"),
       );
     },
@@ -1050,8 +1061,11 @@ async function verifyNoSessionArtifacts(
 ): Promise<void> {
   if (!excludeSessionArtifacts) return;
   for (const branch of reviewBranches) {
-    const result = await git(["diff-tree", "--no-commit-id", "--name-only", "-r", branch], cwd);
-    const sessionFiles = cleanLines(result.stdout).filter((file) =>
+    const result = await git(
+      ["diff-tree", "--no-commit-id", "--name-status", "-z", "-M", "-r", branch],
+      cwd,
+    );
+    const sessionFiles = gitChangedPaths(result.stdout).filter((file) =>
       isAutoresearchSessionArtifact(file, "finalization"),
     );
     if (sessionFiles.length > 0) {

--- a/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
+++ b/plugins/codex-autoresearch/tests/autoresearch-cli.test.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  rename,
   rm,
   stat,
   symlink,
@@ -4384,6 +4385,43 @@ test("lane-runner refuses write-scope when unrelated dirty files already exist",
   });
 });
 
+test("lane-runner treats the source of a hostile rename as dirty outside write scope", async () => {
+  await withTempDir("lane-runner-write-scope-hostile-rename", async (dir) => {
+    await runCli(["init", "--cwd", dir, "--name", "lane runner", "--metric-name", "quality_gap"]);
+    await mkdir(path.join(dir, "src"), { recursive: true });
+    await writeFile(path.join(dir, "src", "owned.txt"), "before\n", "utf8");
+    const original = process.platform === "win32" ? "outside 雪.txt" : "outside -> 雪.txt";
+    const current = process.platform === "win32" ? "src/inside 雪.txt" : "src/inside -> 雪.txt";
+    await writeFile(path.join(dir, original), "move me\n", "utf8");
+    await git(dir, ["init"]);
+    await git(dir, ["config", "user.email", "codex@example.test"]);
+    await git(dir, ["config", "user.name", "Codex Test"]);
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-m", "initial"]);
+    await rename(path.join(dir, original), path.join(dir, current));
+
+    const result = await runCli([
+      "lane-runner",
+      "--cwd",
+      dir,
+      "--lane-id",
+      "implementation-candidate",
+      "--mode",
+      "implementation",
+      "--write-scope",
+      "src",
+      "--command",
+      "node -e \"require('fs').writeFileSync('src/owned.txt','after')\"",
+      "--summary",
+      "Owned write.",
+      "--yes",
+    ]);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /dirty files outside scope/);
+    assert.match(result.stderr, /outside(?: ->)? 雪\.txt/);
+  });
+});
+
 test("lane-runner ignores completed lane results from older segments", async () => {
   await withTempDir("lane-runner-segment-results", async (dir) => {
     await runCli(["init", "--cwd", dir, "--name", "first segment", "--metric-name", "quality_gap"]);
@@ -5802,6 +5840,59 @@ test("stale last-run packets are rejected when dirty file contents change withou
       "keep",
       "--description",
       "Old packet after dirty content edit",
+      "--allow-add-all",
+    ]);
+    assert.notEqual(stale.code, 0);
+    assert.match(stale.stderr, /dirty file contents changed/);
+  });
+});
+
+test("dirty fingerprints preserve hostile Git filenames", async () => {
+  await withTempDir("stale-last-run-hostile-dirty-path", async (dir) => {
+    const file = process.platform === "win32" ? "tracked 雪.txt" : ' tracked " -> 雪\\line\n.txt ';
+    await git(dir, ["init"]);
+    await git(dir, ["config", "user.email", "codex@example.test"]);
+    await git(dir, ["config", "user.name", "Codex Test"]);
+    await writeFile(path.join(dir, file), "base\n", "utf8");
+    await git(dir, ["add", file]);
+    await git(dir, ["commit", "-m", "initial"]);
+    await runCli([
+      "init",
+      "--cwd",
+      dir,
+      "--name",
+      "hostile dirty path",
+      "--metric-name",
+      "seconds",
+    ]);
+    await git(dir, ["add", "autoresearch.jsonl"]);
+    await git(dir, ["commit", "-m", "session"]);
+    await writeFile(path.join(dir, file), "dirty before packet\n", "utf8");
+
+    const next = await runCli([
+      "next",
+      "--cwd",
+      dir,
+      "--command",
+      `${quoteForShell(process.execPath)} -e "console.log('METRIC seconds=3')"`,
+      "--checks-policy",
+      "manual",
+    ]);
+    assert.equal(next.code, 0, next.stderr);
+    const packet = JSON.parse(next.stdout);
+    const lastRun = JSON.parse(await readFile(packet.lastRunPath, "utf8"));
+    assert.ok(lastRun.history.git.dirtyFileFingerprints.some((entry) => entry.path === file));
+
+    await writeFile(path.join(dir, file), "dirty after packet\n", "utf8");
+    const stale = await runCli([
+      "log",
+      "--cwd",
+      dir,
+      "--from-last",
+      "--status",
+      "keep",
+      "--description",
+      "Hostile dirty path changed",
       "--allow-add-all",
     ]);
     assert.notEqual(stale.code, 0);

--- a/plugins/codex-autoresearch/tests/finalize-report.test.ts
+++ b/plugins/codex-autoresearch/tests/finalize-report.test.ts
@@ -1341,6 +1341,68 @@ testWithTempRoot(
 );
 
 testWithTempRoot(
+  "finalization preserves both hostile paths in a rename",
+  "autoresearch-finalize-hostile-rename-",
+  async (root) => {
+    const repo = path.join(root, "repo");
+    await fsp.mkdir(path.join(repo, "src"), { recursive: true });
+    const original =
+      process.platform === "win32" ? "src/old 雪.txt" : 'src/ old " -> 雪\\line\n.txt ';
+    const current =
+      process.platform === "win32" ? "src/new 雪.txt" : 'src/ new " -> 雪\\line\n.txt ';
+
+    await git(["init", "-b", "main"], repo);
+    await git(["config", "user.email", "codex@example.invalid"], repo);
+    await git(["config", "user.name", "Codex Test"], repo);
+    await writeFile(path.join(repo, original), "kept\n");
+    await git(["add", "-A"], repo);
+    await git(["commit", "-m", "base"], repo);
+
+    await git(["switch", "-c", "codex/autoresearch-hostile-rename"], repo);
+    await fsp.rename(path.join(repo, original), path.join(repo, current));
+    await git(["add", "-A"], repo);
+    await git(["commit", "-m", "rename hostile path"], repo);
+    const kept = (await git(["rev-parse", "HEAD"], repo)).stdout.trim();
+    await writeFile(
+      path.join(repo, "autoresearch.jsonl"),
+      [
+        JSON.stringify({
+          type: "config",
+          name: "hostile rename",
+          metricName: "score",
+          bestDirection: "higher",
+        }),
+        JSON.stringify({
+          run: 1,
+          status: "keep",
+          metric: 1,
+          description: "rename hostile path",
+          commit: kept.slice(0, 12),
+        }),
+        "",
+      ].join("\n"),
+    );
+    await git(["add", "autoresearch.jsonl"], repo);
+    await git(["commit", "-m", "log kept rename"], repo);
+
+    const preview = await run(process.execPath, [cli, "finalize-preview", "--cwd", repo], repo);
+    const payload = JSON.parse(preview.stdout);
+    assert.deepEqual(payload.groups[0].files, [current, original].sort());
+    assert.equal(payload.finalTreeCoverage.covered, true);
+
+    const planPath = path.join(repo, "groups.json");
+    const planned = await run(
+      process.execPath,
+      [finalizer, "plan", "--cwd", repo, "--output", planPath],
+      repo,
+    );
+    assert.equal(planned.code, 0, planned.stderr);
+    const plan = JSON.parse(await fsp.readFile(planPath, "utf8"));
+    assert.deepEqual(plan.groups[0].files, [current, original].sort());
+  },
+);
+
+testWithTempRoot(
   "finalize-current-tree packages the current non-session diff",
   "autoresearch-finalize-current-tree-",
   async (root) => {

--- a/plugins/codex-autoresearch/tests/hostile-workflow.test.ts
+++ b/plugins/codex-autoresearch/tests/hostile-workflow.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
 import { buildProtectedBenchmarkGuard } from "../lib/benchmark/contract-guards.js";
+import { parseNameStatusZ, parsePorcelainV1Z } from "../lib/git-paths.js";
 import { resolvePackageRoot } from "../lib/runtime-paths.js";
 import {
   createCliRunner,
   quoteForShell,
   runGit,
+  runProcess,
+  testGitArgs,
   withTempDir as withNamedTempDir,
 } from "./helpers/process.js";
 
@@ -16,6 +19,65 @@ const pluginRoot = resolvePackageRoot(import.meta.url);
 const cli = path.join(pluginRoot, "scripts", "autoresearch.mjs");
 const runCli = createCliRunner(cli, pluginRoot);
 const withTempDir = (name, fn) => withNamedTempDir("autoresearch-hostile", name, fn);
+
+test("Git -z path parsers round-trip hostile names and both sides of renames", async (t) => {
+  await withTempDir("git-path-round-trip", async (dir) => {
+    await initGit(dir);
+    const portablePaths = ["literal arrow 雪.txt", " leading 雪.txt"];
+    const posixOnlyPaths = [
+      "trailing 雪.txt ",
+      "line\nbreak.txt",
+      'quote"name.txt',
+      "back\\slash.txt",
+    ];
+    if (process.platform === "win32") {
+      t.diagnostic(
+        "Literal arrow, trailing-space, newline, quote, and backslash filenames are omitted because Win32 forbids them.",
+      );
+    }
+    const hostilePaths = [
+      ...portablePaths,
+      ...(process.platform === "win32" ? [] : ["literal -> arrow 雪.txt", ...posixOnlyPaths]),
+    ];
+    for (const file of hostilePaths) await writeFile(path.join(dir, file), "before\n", "utf8");
+    const original = process.platform === "win32" ? "rename old 雪.txt" : "rename old -> 雪.txt";
+    const current = process.platform === "win32" ? "rename new 雪.txt" : "rename new -> 雪.txt";
+    await writeFile(path.join(dir, original), "rename me\n", "utf8");
+    await runGit(dir, ["add", "-A"]);
+    await runGit(dir, ["commit", "-m", "hostile paths"]);
+
+    for (const file of hostilePaths) await writeFile(path.join(dir, file), "after\n", "utf8");
+    await rename(path.join(dir, original), path.join(dir, current));
+    await runGit(dir, ["add", "-A"]);
+
+    const status = await runProcess(
+      "git",
+      testGitArgs(["status", "--porcelain=v1", "-z", "-uall"]),
+      dir,
+    );
+    assert.equal(status.code, 0, status.stderr);
+    const statusEntries = parsePorcelainV1Z(status.stdout);
+    assert.deepEqual(
+      new Set(statusEntries.flatMap((entry) => entry.paths)),
+      new Set([...hostilePaths, original, current]),
+    );
+    assert.deepEqual(statusEntries.find((entry) => entry.status.includes("R"))?.paths, [
+      original,
+      current,
+    ]);
+
+    const diff = await runProcess(
+      "git",
+      testGitArgs(["diff", "--cached", "--name-status", "-z", "-M", "HEAD"]),
+      dir,
+    );
+    assert.equal(diff.code, 0, diff.stderr);
+    assert.deepEqual(
+      parseNameStatusZ(diff.stdout).find((entry) => entry.status.startsWith("R"))?.paths,
+      [original, current],
+    );
+  });
+});
 
 test("protected benchmark edits block next and keep until a new segment", async () => {
   await withTempDir("protected-benchmark-mutation", async (dir) => {
@@ -158,6 +220,56 @@ test("dirty protected benchmark paths block the first keep baseline", async () =
     const nextPayload = JSON.parse(next.stdout);
     assert.equal(nextPayload.ok, false);
     assert.match(JSON.stringify(nextPayload), /dirty before the first baseline/i);
+  });
+});
+
+test("renaming a protected hostile path out of scope blocks the first baseline", async () => {
+  await withTempDir("protected-benchmark-hostile-rename", async (dir) => {
+    await initGit(dir);
+    const protectedRelative = process.platform === "win32" ? "bench 雪" : "bench -> 雪";
+    const protectedDir = path.join(dir, protectedRelative);
+    const original = path.join(protectedDir, "score.mjs");
+    const current = path.join(
+      dir,
+      "src",
+      process.platform === "win32" ? "score moved 雪.mjs" : "score -> moved 雪.mjs",
+    );
+    await mkdir(protectedDir, { recursive: true });
+    await mkdir(path.dirname(current), { recursive: true });
+    await writeFile(original, "console.log('METRIC seconds=1')\n", "utf8");
+    await runGit(dir, ["add", "-A"]);
+    await runGit(dir, ["commit", "-m", "protected benchmark"]);
+
+    await assertCliOk([
+      "setup",
+      "--cwd",
+      dir,
+      "--name",
+      "hostile protected rename",
+      "--metric-name",
+      "seconds",
+      "--benchmark-command",
+      `node ${quoteForShell(original)}`,
+      "--benchmark-prints-metric",
+      "true",
+      "--protected-benchmark-paths",
+      protectedRelative,
+    ]);
+    await rename(original, current);
+
+    const keep = await runCli([
+      "log",
+      "--cwd",
+      dir,
+      "--metric",
+      "1",
+      "--status",
+      "keep",
+      "--description",
+      "must not bless moved benchmark",
+    ]);
+    assert.notEqual(keep.code, 0);
+    assert.match(keep.stderr, /dirty before the first baseline/i);
   });
 });
 


### PR DESCRIPTION
## Context

Issue #293 tracks a trust-boundary bug: several Git path consumers parsed human-oriented, line-delimited output by trimming, unquoting, or splitting on ` -> `. Adversarial but valid filenames could therefore bypass protected-path, dirty-scope, fingerprint, finalization, or source-freshness decisions.

## What Changed

- Added one shared parser for NUL-delimited path lists, porcelain v1 `-z`, and `--name-status -z`, including Git's rename/copy field ordering and both source and destination paths.
- Migrated trust-driving `status`, `diff`/`show`, `diff-tree`, and `ls-files` consumers across the CLI, truth signals, finalization, source checks, lane status, and runtime freshness.
- Removed manual trimming, C-style unquoting, backslash rewriting on POSIX, and literal-arrow parsing from those paths.
- Made process output UTF-8 chunk-safe and made oversized Git trust output fail closed instead of accepting a truncated tail.
- Added real temporary-repository fixtures for Unicode, literal arrows, spaces, leading/trailing whitespace, newlines, quotes, backslashes, and protected/write-scope renames.

## How To Review

1. Start with `lib/git-paths.ts` and verify porcelain v1 `-z` rename ordering versus `--name-status -z` ordering.
2. Review `scripts/autoresearch.ts` for protected benchmark paths, dirty/write scopes, tracked paths, and fingerprints.
3. Follow finalization path grouping through `lib/finalize-preview.ts` and `scripts/finalize-autoresearch.ts`.
4. Check runtime/source-check/lane consumers and then the hostile real-Git fixtures.

## Verification

- Exact base: head `ece82b31b3e3154620d45b02a8dc66dc85550640` has parent `origin/dev` `17fc29f12dd7786c6db09a7a455ca2a231e18f3b`.
- Targeted hostile-path, protected-rename, write-scope, fingerprint, finalization grouping, bootstrap, source-hygiene, check-runner, and lane tests passed.
- `npm run check` passed: 241 CLI tests, 127 dashboard tests, 37 finalizer tests, 328 core tests, `quality_gap=0`, and package/runtime smoke.
- `git diff --check` passed and the worktree was clean before publication.

## Risk

- Paths are decoded as chunk-safe UTF-8 strings. Arbitrary invalid-UTF-8 POSIX filename bytes cannot round-trip through Node's string/path APIs and remain an explicit limitation.
- Rename/copy parsing is deliberately fail-closed if Git emits an incomplete NUL record.

Tracks #293
