### PR TITLE
fix: make directory replacement rollback safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ### Fixed
 
+- Runtime hydration and preserved research-directory restoration now stage and verify complete replacements before moving active targets, retain ownership-marked rollback directories until every rename succeeds, restore originals in reverse order on failure, and refuse unsafe stale or reparse-point cleanup.
 - Git-derived trust paths now use NUL-delimited porcelain, name-status, and tracked-file output, preserving hostile filenames and both sides of renames across protected benchmark checks, dirty/write scopes, fingerprints, source hygiene, runtime freshness, and finalization.
 - State, terminal report, `recommend-next`, and dashboard readouts now agree on one strongest next action and command; stale progress, stale packets, artifact recovery, setup, and failed-check decisions remain distinct, weaker portfolio advice is suppressed while blocked, session continuation is separated from packet permission, and absent or metricless kept evidence no longer masquerades as an incumbent.
 - Autoresearch and finalizer CLI parsing now rejects unknown root and command options, validates explicit boolean values, supports root and command `-h`/`--help`, preserves camel/kebab aliases plus repeated list and `--` passthrough behavior, and reports expected usage failures without stack traces unless `--debug` is explicit.

--- a/plugins/codex-autoresearch/docs/maintainers.md
+++ b/plugins/codex-autoresearch/docs/maintainers.md
@@ -99,7 +99,7 @@ node scripts/autoresearch.mjs export --cwd examples/demo-session --output autore
 
 `npm run check` builds the runtime and dashboard, checks the generated assets, packs the plugin, extracts it, and smokes both the launcher and dashboard export. `prepack` is the single publish-time build path.
 
-If a Git marketplace checkout lacks `dist/`, `scripts/bootstrap-runtime.mjs` downloads the matching GitHub release tarball and adjacent `codex-autoresearch-<version>.tgz.sha256`. Hydration requires `gh` and network access, verifies the checksum and release attestation for this repository's release workflow, validates every archive entry before extraction, checks package name/version, and only then hydrates the plugin cache. There is no unverified fallback.
+If a Git marketplace checkout lacks `dist/`, `scripts/bootstrap-runtime.mjs` downloads the matching GitHub release tarball and adjacent `codex-autoresearch-<version>.tgz.sha256`. Hydration requires `gh` and network access, verifies the checksum and release attestation for this repository's release workflow, validates every archive entry before extraction, checks package name/version, and only then hydrates the plugin cache. Hydration stages and verifies both the runtime and dashboard beside their targets, retains ownership-marked rollback directories until both installs succeed, and restores the prior pair if either install fails. There is no unverified fallback.
 
 A release tarball must:
 

--- a/plugins/codex-autoresearch/docs/troubleshooting.md
+++ b/plugins/codex-autoresearch/docs/troubleshooting.md
@@ -7,6 +7,7 @@ Find the broken layer before repeating the command. A retry with the same precon
 | Symptom | Failing layer | What to do |
 | --- | --- | --- |
 | Source checkout missing `dist/` | Source launcher hydration | Install `gh`, confirm GitHub network access, then run `node scripts/autoresearch.mjs --help` from the plugin directory. Hydration stops if checksum, release attestation, or archive validation fails. |
+| Hydration reports a retained rollback directory | Runtime replacement recovery | Inspect the named active and rollback directories. Do not delete an unmarked or linked path; retry only after restoring the marked rollback when the active target is missing, or removing the obsolete marked rollback after verifying the active target. |
 | Source behavior differs from Codex | Installed runtime drift | Run `doctor --check-installed --explain`. Read `installedRuntimePath`, `installedRuntimeShape`, and `installedRuntimeProvenance`; hydrate a source-shaped package, refresh a stale cache, or remove ambiguity between multiple canonical versions before changing source again. |
 | Setup wrapper calls itself | Scaffold health | Replace the recursive wrapper or rerun setup with the real `--benchmark-command`. |
 

--- a/plugins/codex-autoresearch/lib/checked-write.ts
+++ b/plugins/codex-autoresearch/lib/checked-write.ts
@@ -2,8 +2,10 @@ import fs from "node:fs";
 import fsp, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
+import { pathToFileURL } from "node:url";
 
 import { isPathInside } from "./path-containment.js";
+import { resolvePackageRoot } from "./runtime-paths.js";
 
 type WriteData = string | Uint8Array;
 
@@ -135,28 +137,33 @@ export async function checkedReplaceDirectory(
   root: string,
   target: string,
   source: string,
+  options: DirectorySwapOptions = {},
 ): Promise<void> {
-  const safeTarget = await assertSafeDirectoryTree(root, target);
+  await assertSafeDirectoryTree(root, target);
   await assertTreeContainsNoLinks(source);
-  const parent = path.dirname(safeTarget);
-  const staging = path.join(parent, `.${path.basename(safeTarget)}.${randomUUID()}.tmp`);
-  let committed = false;
-  try {
-    await fsp.cp(source, staging, {
-      recursive: true,
-      dereference: false,
-      errorOnExist: true,
-      force: false,
-    });
-    if ((await assertSafeDirectoryTree(root, target)) !== safeTarget) {
-      throw new Error(`Session root changed while replacing directory: ${root}`);
-    }
-    await fsp.rm(safeTarget, { recursive: true, force: true });
-    await fsp.rename(staging, safeTarget);
-    committed = true;
-  } finally {
-    if (!committed) await fsp.rm(staging, { recursive: true, force: true }).catch(() => {});
-  }
+  const helperUrl = pathToFileURL(
+    path.join(resolvePackageRoot(import.meta.url), "scripts", "directory-swap.mjs"),
+  ).href;
+  const { replaceDirectoriesRollbackSafe } = (await import(helperUrl)) as DirectorySwapModule;
+  await replaceDirectoriesRollbackSafe(root, [{ source, target }], options);
+}
+
+export interface DirectorySwapOptions {
+  onPhase?: (phase: string, details: Record<string, unknown>) => Promise<void> | void;
+  operations?: {
+    copy?: typeof fsp.cp;
+    readDirectory?: typeof fsp.readdir;
+    remove?: typeof fsp.rm;
+    rename?: typeof fsp.rename;
+  };
+}
+
+interface DirectorySwapModule {
+  replaceDirectoriesRollbackSafe: (
+    root: string,
+    replacements: Array<{ source: string; target: string }>,
+    options?: DirectorySwapOptions,
+  ) => Promise<void>;
 }
 
 export async function checkedEnsureDirectory(root: string, target: string): Promise<void> {

--- a/plugins/codex-autoresearch/lib/checks/package-smoke.ts
+++ b/plugins/codex-autoresearch/lib/checks/package-smoke.ts
@@ -33,6 +33,7 @@ const ALLOWED_PACKAGED_SOURCE_SCRIPTS = new Set([
   "scripts/autoresearch.mjs",
   "scripts/bootstrap-runtime.mjs",
   "scripts/check.mjs",
+  "scripts/directory-swap.mjs",
   "scripts/finalize-autoresearch.mjs",
   "scripts/release-integrity.mjs",
 ]);
@@ -105,6 +106,7 @@ export async function runPackageArtifactCheck() {
       "scripts/bootstrap-runtime.mjs",
       "scripts/autoresearch.mjs",
       "scripts/check.mjs",
+      "scripts/directory-swap.mjs",
       "scripts/release-integrity.mjs",
       "scripts/finalize-autoresearch.mjs",
       "skills/codex-autoresearch/SKILL.md",

--- a/plugins/codex-autoresearch/lib/checks/source-checkout-launcher.ts
+++ b/plugins/codex-autoresearch/lib/checks/source-checkout-launcher.ts
@@ -5,6 +5,7 @@ import { indent, REPO_ROOT, ROOT, runCommand } from "./check-common.js";
 
 const sourceCheckoutLauncherPaths = [
   "plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs",
+  "plugins/codex-autoresearch/scripts/directory-swap.mjs",
   "plugins/codex-autoresearch/scripts/autoresearch.mjs",
   "plugins/codex-autoresearch/scripts/release-integrity.mjs",
 ];

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -33,6 +33,7 @@
     "scripts/autoresearch.mjs",
     "scripts/bootstrap-runtime.mjs",
     "scripts/check.mjs",
+    "scripts/directory-swap.mjs",
     "scripts/finalize-autoresearch.mjs",
     "scripts/release-integrity.mjs",
     "skills/"

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -7,7 +7,14 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { pipeline } from "node:stream/promises";
 import { StringDecoder } from "node:string_decoder";
+import {
+  hasDirectorySwapArtifacts,
+  recoverDirectorySwapArtifacts,
+  replaceDirectoriesRollbackSafe,
+} from "./directory-swap.mjs";
 import { parseSha256Manifest } from "./release-integrity.mjs";
+
+export { hasDirectorySwapArtifacts, replaceDirectoriesRollbackSafe };
 
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 const LOCK_TIMEOUT_MS = 120_000;
@@ -26,12 +33,19 @@ export async function ensureRuntime(entrypoint, importerUrl, options = {}) {
   const target = path.join(pluginRoot, "dist", "scripts", entrypoint);
 
   await rebuildStaleSourceRuntime(pluginRoot, target);
-  if ((await fileExists(target)) && (await dashboardRuntimeReady(pluginRoot))) {
-    return pathToFileURL(target).href;
+  const replacementTargets = runtimeReplacementTargets(pluginRoot);
+  const ready = (await fileExists(target)) && (await dashboardRuntimeReady(pluginRoot));
+  const recoveryPending = await hasDirectorySwapArtifacts(replacementTargets);
+  if (ready && !recoveryPending) return pathToFileURL(target).href;
+  if (!install) {
+    if (!ready) throw missingRuntimeError(pluginRoot, target);
+    throw new Error(
+      "Codex Autoresearch runtime has unfinished replacement artifacts. Run the launcher once with hydration enabled to recover or inspect them safely.",
+    );
   }
-  if (!install) throw missingRuntimeError(pluginRoot, target);
 
   await withRuntimeInstallLock(pluginRoot, async () => {
+    await recoverDirectorySwapArtifacts(pluginRoot, replacementTargets);
     if ((await fileExists(target)) && (await dashboardRuntimeReady(pluginRoot))) return;
     await installRuntimeFromRelease(pluginRoot, options);
     if (!(await fileExists(target))) {
@@ -43,6 +57,10 @@ export async function ensureRuntime(entrypoint, importerUrl, options = {}) {
   });
 
   return pathToFileURL(target).href;
+}
+
+function runtimeReplacementTargets(pluginRoot) {
+  return [path.join(pluginRoot, "dist"), path.join(pluginRoot, "assets", "dashboard-build")];
 }
 
 async function dashboardRuntimeReady(pluginRoot) {
@@ -145,18 +163,51 @@ async function installRuntimeFromRelease(pluginRoot, options = {}) {
     }
     await verifyReleasePackageManifest(extractedPackage, version);
 
-    await fs.rm(path.join(pluginRoot, "dist"), { recursive: true, force: true });
-    await fs.cp(extractedDist, path.join(pluginRoot, "dist"), { recursive: true });
-    await fs.rm(path.join(pluginRoot, "assets", "dashboard-build"), {
-      recursive: true,
-      force: true,
-    });
     await fs.mkdir(path.join(pluginRoot, "assets"), { recursive: true });
-    await fs.cp(extractedDashboardBuild, path.join(pluginRoot, "assets", "dashboard-build"), {
-      recursive: true,
-    });
+    await replaceDirectoriesRollbackSafe(
+      pluginRoot,
+      [
+        {
+          target: path.join(pluginRoot, "dist"),
+          source: extractedDist,
+          verify: verifyHydratedDist,
+        },
+        {
+          target: path.join(pluginRoot, "assets", "dashboard-build"),
+          source: extractedDashboardBuild,
+          verify: verifyHydratedDashboardBuild,
+        },
+      ],
+      options.directorySwap,
+    );
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function verifyHydratedDist(distDir) {
+  const required = [
+    "lib/runtime-paths.mjs",
+    "scripts/autoresearch.mjs",
+    "scripts/check.mjs",
+    "scripts/finalize-autoresearch.mjs",
+  ];
+  const missing = [];
+  for (const relative of required) {
+    if (!(await fileExists(path.join(distDir, relative)))) missing.push(relative);
+  }
+  if (missing.length) {
+    throw new Error(`Release runtime is missing required built files: ${missing.join(", ")}.`);
+  }
+}
+
+async function verifyHydratedDashboardBuild(buildDir) {
+  const missing = [];
+  for (const asset of DASHBOARD_BUILD_ASSETS) {
+    if (!(await fileExists(path.join(buildDir, asset)))) missing.push(asset);
+  }
+  if (missing.length) {
+    throw new Error(`Release dashboard build is missing required assets: ${missing.join(", ")}.`);
   }
 }
 
@@ -307,7 +358,7 @@ function isExpectedRuntimeArchiveFile(name) {
   }
   if (/^docs\/.+\.md$/.test(name)) return true;
   if (
-    /^scripts\/(?:autoresearch|bootstrap-runtime|check|finalize-autoresearch|release-integrity)\.mjs$/.test(
+    /^scripts\/(?:autoresearch|bootstrap-runtime|check|directory-swap|finalize-autoresearch|release-integrity)\.mjs$/.test(
       name,
     )
   ) {

--- a/plugins/codex-autoresearch/scripts/directory-swap.mjs
+++ b/plugins/codex-autoresearch/scripts/directory-swap.mjs
@@ -1,0 +1,542 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const MARKER_FILE = ".codex-autoresearch-swap-owner.json";
+const OWNER = "codex-autoresearch";
+const SCHEMA = 1;
+
+export async function hasDirectorySwapArtifacts(targets) {
+  for (const target of targets) {
+    if (await pathExists(path.join(path.resolve(target), MARKER_FILE))) return true;
+    const parent = path.dirname(path.resolve(target));
+    const prefix = `.${path.basename(target)}.codex-autoresearch-`;
+    const entries = await fs.readdir(parent).catch((error) => {
+      if (error?.code === "ENOENT") return [];
+      throw error;
+    });
+    if (entries.some((entry) => nameStartsWith(entry, prefix))) return true;
+  }
+  return false;
+}
+
+export async function recoverDirectorySwapArtifacts(root, targets, options = {}) {
+  const operations = resolveOperations(options);
+  const onPhase = options.onPhase || (async () => {});
+  const rootInfo = await canonicalRoot(root);
+  for (const input of targets) {
+    const target = await canonicalTarget(rootInfo, input);
+    await recoverStaleArtifacts(rootInfo, target, operations, onPhase);
+  }
+}
+
+/**
+ * Replace one or more directories as a transaction. Each replacement is staged and verified
+ * before any active target moves. Existing targets are then retained as rollback directories
+ * until every staged directory has been installed and verified.
+ */
+export async function replaceDirectoriesRollbackSafe(root, replacements, options = {}) {
+  if (!Array.isArray(replacements) || replacements.length === 0) {
+    throw new Error("Directory replacement requires at least one target and source.");
+  }
+
+  const operations = resolveOperations(options);
+  const onPhase = options.onPhase || (async () => {});
+  const rootInfo = await canonicalRoot(root);
+  const states = [];
+  const targetKeys = new Set();
+
+  for (const replacement of replacements) {
+    const target = await canonicalTarget(rootInfo, replacement.target);
+    const targetKey = process.platform === "win32" ? target.toLowerCase() : target;
+    if (targetKeys.has(targetKey)) {
+      throw new Error(`Directory replacement target is duplicated: ${target}`);
+    }
+    targetKeys.add(targetKey);
+    const source = path.resolve(replacement.source);
+    await assertPlainDirectory(source, "Replacement source");
+    await assertTreeContainsNoLinks(source, "Replacement source tree");
+    await assertMarkerAbsent(source, "Replacement source");
+    await recoverStaleArtifacts(rootInfo, target, operations, onPhase);
+
+    const token = randomUUID();
+    const parent = path.dirname(target);
+    const base = path.basename(target);
+    const stage = path.join(parent, `.${base}.codex-autoresearch-stage-${token}`);
+    const rollback = path.join(parent, `.${base}.codex-autoresearch-rollback-${token}`);
+    const state = {
+      backedUp: false,
+      installed: false,
+      marker: { owner: OWNER, root: rootInfo.real, schema: SCHEMA, target, token },
+      replacement,
+      rollback,
+      stage,
+      target,
+      token,
+    };
+    states.push(state);
+  }
+
+  try {
+    for (const state of states) {
+      await fs.mkdir(state.stage);
+      await writeMarker(state.stage, { ...state.marker, kind: "stage" });
+      await onPhase("before-copy", phaseDetails(state));
+      await operations.copy(state.replacement.source, stagePayload(state), {
+        recursive: true,
+        dereference: false,
+        errorOnExist: true,
+        force: false,
+      });
+      await assertTreeContainsNoLinks(stagePayload(state), "Staged replacement tree");
+      await state.replacement.verify?.(stagePayload(state));
+      await onPhase("after-copy", phaseDetails(state));
+    }
+    await onPhase("after-stage", transactionDetails(states));
+
+    for (const state of states) {
+      await onPhase("before-backup", phaseDetails(state));
+      if (await pathExists(state.target)) {
+        await assertSafeTarget(rootInfo, state.target);
+        await assertMarkerAbsent(state.target, "Active target");
+        await operations.rename(state.target, state.rollback);
+        state.backedUp = true;
+        try {
+          await assertPlainDirectory(state.rollback, "Rollback target");
+          await assertTreeContainsNoLinks(state.rollback, "Rollback target");
+          await writeMarker(state.rollback, { ...state.marker, kind: "rollback" });
+        } catch (error) {
+          await restoreAfterMarkerFailure(state, operations, error);
+        }
+      }
+      await onPhase("after-backup", phaseDetails(state));
+    }
+    await onPhase("after-all-backups", transactionDetails(states));
+
+    for (const state of states) {
+      await onPhase("before-install", phaseDetails(state));
+      await operations.rename(stagePayload(state), state.target);
+      state.installed = true;
+      await assertSafeTarget(rootInfo, state.target);
+      await state.replacement.verify?.(state.target);
+      await onPhase("after-install", phaseDetails(state));
+    }
+    await onPhase("after-all-installs", transactionDetails(states));
+  } catch (error) {
+    const restoreErrors = await restoreTransaction(rootInfo, states, operations, onPhase);
+    const cleanupErrors = await cleanupStages(rootInfo, states, operations);
+    if (restoreErrors.length || cleanupErrors.length) {
+      const evidence = states
+        .flatMap((state) =>
+          state.backedUp ? [state.rollback] : state.recoveryPath ? [state.recoveryPath] : [],
+        )
+        .join(", ");
+      throw new Error(
+        [
+          `Directory replacement failed: ${errorMessage(error)}`,
+          restoreErrors.length
+            ? `Directory restoration needs attention: ${restoreErrors.join("; ")}.`
+            : "The original target was restored.",
+          cleanupErrors.length
+            ? `Owned staging cleanup also failed: ${cleanupErrors.join("; ")}.`
+            : "",
+          evidence ? `Recovery evidence was retained at: ${evidence}.` : "",
+          "Inspect the named paths before retrying; no unowned path was removed.",
+        ]
+          .filter(Boolean)
+          .join(" "),
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+
+  const cleanupErrors = [];
+  for (const state of states) {
+    if (state.backedUp) {
+      try {
+        await removeOwnedArtifact(rootInfo, state.rollback, state, "rollback", operations);
+      } catch (error) {
+        cleanupErrors.push(errorMessage(error));
+      }
+    }
+    try {
+      await removeOwnedArtifact(rootInfo, state.stage, state, "stage", operations);
+    } catch (error) {
+      cleanupErrors.push(errorMessage(error));
+    }
+  }
+  if (cleanupErrors.length) {
+    throw new Error(
+      `Replacement was installed and verified, but owned swap cleanup failed: ${cleanupErrors.join("; ")}. Inspect the retained rollback path before retrying.`,
+    );
+  }
+}
+
+function phaseDetails(state) {
+  return {
+    rollback: state.rollback,
+    stage: state.stage,
+    target: state.target,
+    token: state.token,
+  };
+}
+
+function transactionDetails(states) {
+  return { replacements: states.map(phaseDetails) };
+}
+
+function stagePayload(state) {
+  return path.join(state.stage, "payload");
+}
+
+async function restoreAfterMarkerFailure(state, operations, markerError) {
+  try {
+    await operations.rename(state.rollback, state.target);
+    state.backedUp = false;
+  } catch (restoreError) {
+    throw new Error(
+      `Could not mark rollback directory ${state.rollback}: ${errorMessage(markerError)}. Restoring ${state.target} also failed: ${errorMessage(restoreError)}. Recover the original directory from the rollback path before retrying.`,
+      { cause: markerError },
+    );
+  }
+  throw markerError;
+}
+
+async function restoreTransaction(rootInfo, states, operations, onPhase) {
+  const errors = [];
+  for (const state of [...states].reverse()) {
+    try {
+      await onPhase("before-restore", phaseDetails(state));
+      if (state.installed) {
+        await operations.rename(state.target, stagePayload(state));
+        state.installed = false;
+      }
+      if (state.backedUp) {
+        await validateOwnedArtifact(rootInfo, state.rollback, state, "rollback");
+        await operations.rename(state.rollback, state.target);
+        state.backedUp = false;
+        state.recoveryPath = state.target;
+        await assertSafeTarget(rootInfo, state.target);
+        await removeActiveRollbackMarker(rootInfo, state.target, operations, state.marker);
+        state.recoveryPath = "";
+      }
+      await onPhase("after-restore", phaseDetails(state));
+    } catch (error) {
+      errors.push(`${state.target}: ${errorMessage(error)}`);
+    }
+  }
+  return errors;
+}
+
+async function cleanupStages(rootInfo, states, operations) {
+  const errors = [];
+  for (const state of states) {
+    try {
+      if (await pathExists(state.stage)) {
+        await removeOwnedArtifact(rootInfo, state.stage, state, "stage", operations);
+      }
+    } catch (error) {
+      errors.push(`${state.stage}: ${errorMessage(error)}`);
+    }
+  }
+  return errors;
+}
+
+async function recoverStaleArtifacts(rootInfo, target, operations, onPhase) {
+  const parent = path.dirname(target);
+  await assertSafeParent(rootInfo, parent);
+  const base = escapeRegExp(path.basename(target));
+  const pattern = new RegExp(
+    `^\\.${base}\\.codex-autoresearch-(stage|rollback)-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`,
+    "i",
+  );
+  const entries = await operations.readDirectory(parent, { withFileTypes: true });
+  const artifacts = [];
+  for (const entry of entries) {
+    const prefix = `.${path.basename(target)}.codex-autoresearch-`;
+    if (!nameStartsWith(entry.name, prefix)) continue;
+    const match = pattern.exec(entry.name);
+    if (!match) {
+      throw new Error(
+        `Unrecognized directory swap artifact ${path.join(parent, entry.name)} does not use the expected owned name. It was not deleted.`,
+      );
+    }
+    const kind = match[1].toLowerCase();
+    const token = match[2];
+    const artifact = path.join(parent, entry.name);
+    const state = {
+      marker: { owner: OWNER, root: rootInfo.real, schema: SCHEMA, target, token },
+      rollback: kind === "rollback" ? artifact : "",
+      stage: kind === "stage" ? artifact : "",
+      target,
+      token,
+    };
+    await validateOwnedArtifact(rootInfo, artifact, state, kind);
+    artifacts.push({ artifact, kind, state, token });
+  }
+
+  const rollbacks = artifacts.filter((artifact) => artifact.kind === "rollback");
+  if (rollbacks.length > 1) {
+    throw new Error(
+      `Multiple owned rollback directories exist for ${target}: ${rollbacks.map((item) => item.artifact).join(", ")}. Inspect them before choosing recovery; none were deleted.`,
+    );
+  }
+  if (rollbacks.length === 1) {
+    const rollback = rollbacks[0];
+    if (await pathExists(target)) {
+      throw new Error(
+        `Stale owned rollback directory ${rollback.artifact} exists beside active target ${target}. Inspect both paths and remove only the obsolete owned copy before retrying.`,
+      );
+    }
+    await operations.rename(rollback.artifact, target);
+    await assertSafeTarget(rootInfo, target);
+    await removeActiveRollbackMarker(rootInfo, target, operations, rollback.state.marker);
+    await onPhase("after-stale-rollback-recovery", {
+      artifact: rollback.artifact,
+      kind: rollback.kind,
+      target,
+      token: rollback.token,
+    });
+  } else {
+    await recoverActiveRollbackMarker(rootInfo, target, operations, onPhase);
+  }
+
+  for (const stage of artifacts.filter((artifact) => artifact.kind === "stage")) {
+    if (!(await pathExists(target))) {
+      throw new Error(
+        `Stale owned staging directory ${stage.artifact} exists while ${target} is missing. Inspect the staged payload before choosing recovery; it was not deleted.`,
+      );
+    }
+    await removeOwnedArtifact(rootInfo, stage.artifact, stage.state, stage.kind, operations);
+    await onPhase("after-stale-stage-cleanup", {
+      artifact: stage.artifact,
+      kind: stage.kind,
+      target,
+      token: stage.token,
+    });
+  }
+}
+
+async function recoverActiveRollbackMarker(rootInfo, target, operations, onPhase) {
+  if (!(await pathExists(path.join(target, MARKER_FILE)))) return;
+  await assertSafeTarget(rootInfo, target);
+  await removeActiveRollbackMarker(rootInfo, target, operations);
+  await onPhase("after-stale-active-marker-cleanup", { target });
+}
+
+async function removeActiveRollbackMarker(rootInfo, target, operations, expected = null) {
+  if (!isPathInside(rootInfo.real, target)) {
+    throw new Error(`Active rollback marker target escapes the trusted root: ${target}`);
+  }
+  const marker = await readMarker(target, "Active restored target");
+  const expectedMarker = expected
+    ? { ...expected, kind: "rollback" }
+    : {
+        kind: "rollback",
+        owner: OWNER,
+        root: rootInfo.real,
+        schema: SCHEMA,
+        target,
+      };
+  for (const [key, value] of Object.entries(expectedMarker)) {
+    if (marker?.[key] !== value) {
+      throw new Error(`Active restored target marker does not match ${key}: ${target}`);
+    }
+  }
+  if (
+    typeof marker.token !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(marker.token)
+  ) {
+    throw new Error(`Active restored target marker has an invalid token: ${target}`);
+  }
+  try {
+    await operations.remove(path.join(target, MARKER_FILE), { force: false });
+  } catch (error) {
+    throw new Error(
+      `The original directory is active at ${target}, but its ownership marker could not be removed: ${errorMessage(error)}. Retry recovery before using this target.`,
+      { cause: error },
+    );
+  }
+}
+
+async function removeOwnedArtifact(rootInfo, artifact, state, kind, operations) {
+  if (!(await pathExists(artifact))) return;
+  await validateOwnedArtifact(rootInfo, artifact, state, kind);
+  await operations.remove(artifact, { recursive: true, force: false });
+}
+
+async function validateOwnedArtifact(rootInfo, artifact, state, kind) {
+  const expected =
+    kind === "stage"
+      ? path.join(
+          path.dirname(state.target),
+          `.${path.basename(state.target)}.codex-autoresearch-stage-${state.token}`,
+        )
+      : path.join(
+          path.dirname(state.target),
+          `.${path.basename(state.target)}.codex-autoresearch-rollback-${state.token}`,
+        );
+  if (!samePath(path.resolve(artifact), expected) || !isPathInside(rootInfo.real, expected)) {
+    throw new Error(`Refusing cleanup outside the expected owned ${kind} path: ${artifact}`);
+  }
+  await assertPlainDirectory(expected, `Owned ${kind} directory`);
+  await assertTreeContainsNoLinks(expected, `Owned ${kind} directory`);
+  const marker = await readMarker(expected, `Owned ${kind} directory`);
+  const expectedMarker = { ...state.marker, kind };
+  for (const [key, value] of Object.entries(expectedMarker)) {
+    if (marker?.[key] !== value) {
+      throw new Error(`Owned ${kind} directory marker does not match ${key}: ${expected}`);
+    }
+  }
+}
+
+async function readMarker(directory, label) {
+  const markerPath = path.join(directory, MARKER_FILE);
+  const markerStat = await fs.lstat(markerPath).catch(() => null);
+  if (!markerStat?.isFile() || markerStat.isSymbolicLink()) {
+    throw new Error(`${label} is missing a regular ownership marker: ${directory}`);
+  }
+  try {
+    return JSON.parse(await fs.readFile(markerPath, "utf8"));
+  } catch (error) {
+    throw new Error(`${label} has an invalid ownership marker: ${errorMessage(error)}`);
+  }
+}
+
+async function writeMarker(directory, marker) {
+  const markerPath = path.join(directory, MARKER_FILE);
+  const handle = await fs.open(markerPath, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(marker)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function assertMarkerAbsent(directory, label) {
+  if (await pathExists(path.join(directory, MARKER_FILE))) {
+    throw new Error(`${label} contains reserved ownership marker ${MARKER_FILE}: ${directory}`);
+  }
+}
+
+async function canonicalRoot(root) {
+  const absolute = path.resolve(root);
+  await assertPlainDirectory(absolute, "Directory replacement root");
+  return { absolute, real: await fs.realpath(absolute) };
+}
+
+async function canonicalTarget(rootInfo, target) {
+  const absolute = path.resolve(target);
+  if (!isPathInside(rootInfo.absolute, absolute) || samePath(rootInfo.absolute, absolute)) {
+    throw new Error(`Refusing directory replacement outside the trusted root: ${absolute}`);
+  }
+  const safe = path.join(rootInfo.real, path.relative(rootInfo.absolute, absolute));
+  await assertSafeParent(rootInfo, path.dirname(safe));
+  if (await pathExists(safe)) await assertSafeTarget(rootInfo, safe);
+  return safe;
+}
+
+async function assertSafeParent(rootInfo, parent) {
+  if (!isPathInside(rootInfo.real, parent) && !samePath(rootInfo.real, parent)) {
+    throw new Error(`Directory replacement parent escapes the trusted root: ${parent}`);
+  }
+  let cursor = rootInfo.real;
+  for (const segment of path.relative(rootInfo.real, parent).split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, segment);
+    let stat;
+    try {
+      stat = await fs.lstat(cursor);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      await fs.mkdir(cursor);
+      stat = await fs.lstat(cursor);
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error(
+        `Directory replacement parent must not be a symlink, junction, or file: ${cursor}`,
+      );
+    }
+  }
+  const realParent = await fs.realpath(parent);
+  if (!isPathInside(rootInfo.real, realParent) && !samePath(rootInfo.real, realParent)) {
+    throw new Error(`Directory replacement parent resolves outside the trusted root: ${parent}`);
+  }
+}
+
+async function assertSafeTarget(rootInfo, target) {
+  if (!isPathInside(rootInfo.real, target)) {
+    throw new Error(`Directory replacement target escapes the trusted root: ${target}`);
+  }
+  await assertPlainDirectory(target, "Directory replacement target");
+  await assertTreeContainsNoLinks(target, "Directory replacement target");
+}
+
+async function assertPlainDirectory(directory, label) {
+  const stat = await fs.lstat(directory);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(
+      `${label} must be a real directory, not a symlink, junction, or file: ${directory}`,
+    );
+  }
+}
+
+async function assertTreeContainsNoLinks(root, label) {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const child = path.join(root, entry.name);
+    const stat = await fs.lstat(child);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${label} must not contain symlinks or junctions: ${child}`);
+    }
+    if (stat.isDirectory()) await assertTreeContainsNoLinks(child, label);
+  }
+}
+
+async function pathExists(target) {
+  try {
+    await fs.lstat(target);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function isPathInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== "" &&
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== ".." &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function samePath(left, right) {
+  return process.platform === "win32" ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+function nameStartsWith(value, prefix) {
+  return process.platform === "win32"
+    ? value.toLowerCase().startsWith(prefix.toLowerCase())
+    : value.startsWith(prefix);
+}
+
+function resolveOperations(options) {
+  return {
+    copy: options.operations?.copy || fs.cp,
+    readDirectory: options.operations?.readDirectory || fs.readdir,
+    remove: options.operations?.remove || fs.rm,
+    rename: options.operations?.rename || fs.rename,
+  };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
+++ b/plugins/codex-autoresearch/scripts/perfection-benchmark.ts
@@ -432,7 +432,7 @@ const checks = [
   },
   {
     id: "release-tarball-runtime",
-    file: ".gitignore, package.json, scripts/autoresearch.mjs, scripts/bootstrap-runtime.mjs, scripts/release-integrity.mjs, .github/workflows/release.yml",
+    file: ".gitignore, package.json, scripts/autoresearch.mjs, scripts/bootstrap-runtime.mjs, scripts/directory-swap.mjs, scripts/release-integrity.mjs, .github/workflows/release.yml",
     description:
       "Source checkouts keep generated dist out of Git while release tarballs include the built runtime used by public launchers.",
     run: async () => {
@@ -461,6 +461,7 @@ const checks = [
           "scripts/autoresearch.mjs",
           "scripts/bootstrap-runtime.mjs",
           "scripts/check.mjs",
+          "scripts/directory-swap.mjs",
           "scripts/finalize-autoresearch.mjs",
           "scripts/release-integrity.mjs",
           ".codex-plugin/",

--- a/plugins/codex-autoresearch/tests/bootstrap-runtime.test.ts
+++ b/plugins/codex-autoresearch/tests/bootstrap-runtime.test.ts
@@ -1,12 +1,28 @@
 import assert from "node:assert/strict";
 import { gzipSync } from "node:zlib";
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import test from "node:test";
+import { PLUGIN_VERSION } from "../lib/plugin-version.js";
 
 import {
+  ensureRuntime,
+  hasDirectorySwapArtifacts,
   isRuntimeSourcePath,
+  replaceDirectoriesRollbackSafe,
   runtimeRecoveryLockPath,
   runtimeAttestationArgs,
   validateRuntimeArchiveEntries,
@@ -15,6 +31,457 @@ import {
   verifyReleasePackageManifest,
   withRuntimeInstallLock,
 } from "../scripts/bootstrap-runtime.mjs";
+
+const SWAP_ARTIFACT = /\.codex-autoresearch-(?:stage|rollback)-/;
+
+async function seedDirectory(directory: string, value: string): Promise<void> {
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "value.txt"), value, "utf8");
+}
+
+async function directoryValue(directory: string): Promise<string> {
+  return await readFile(path.join(directory, "value.txt"), "utf8");
+}
+
+async function swapArtifacts(root: string): Promise<string[]> {
+  return (await readdir(root, { recursive: true })).filter((entry) => SWAP_ARTIFACT.test(entry));
+}
+
+test("runtime directory transaction stages both surfaces and swaps them together", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-swap-"));
+  try {
+    const dist = path.join(root, "dist");
+    const dashboard = path.join(root, "assets", "dashboard-build");
+    const newDist = path.join(root, "sources", "dist");
+    const newDashboard = path.join(root, "sources", "dashboard");
+    await Promise.all([
+      seedDirectory(dist, "old-dist"),
+      seedDirectory(dashboard, "old-dashboard"),
+      seedDirectory(newDist, "new-dist"),
+      seedDirectory(newDashboard, "new-dashboard"),
+    ]);
+
+    const verified: string[] = [];
+    await replaceDirectoriesRollbackSafe(root, [
+      {
+        source: newDist,
+        target: dist,
+        verify: async (directory: string) => verified.push(await directoryValue(directory)),
+      },
+      {
+        source: newDashboard,
+        target: dashboard,
+        verify: async (directory: string) => verified.push(await directoryValue(directory)),
+      },
+    ]);
+
+    assert.equal(await directoryValue(dist), "new-dist");
+    assert.equal(await directoryValue(dashboard), "new-dashboard");
+    assert.deepEqual(verified, ["new-dist", "new-dashboard", "new-dist", "new-dashboard"]);
+    assert.deepEqual(await swapArtifacts(root), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("faults after each transaction phase restore every original runtime surface", async () => {
+  for (const phase of ["after-stage", "after-all-backups", "after-install", "after-all-installs"]) {
+    const root = await mkdtemp(path.join(os.tmpdir(), `autoresearch-runtime-${phase}-`));
+    try {
+      const first = path.join(root, "dist");
+      const second = path.join(root, "assets", "dashboard-build");
+      const firstSource = path.join(root, "sources", "dist");
+      const secondSource = path.join(root, "sources", "dashboard");
+      await Promise.all([
+        seedDirectory(first, "old-first"),
+        seedDirectory(second, "old-second"),
+        seedDirectory(firstSource, "new-first"),
+        seedDirectory(secondSource, "new-second"),
+      ]);
+      let injected = false;
+      await assert.rejects(
+        replaceDirectoriesRollbackSafe(
+          root,
+          [
+            { source: firstSource, target: first },
+            { source: secondSource, target: second },
+          ],
+          {
+            onPhase: async (currentPhase: string) => {
+              if (currentPhase === phase && !injected) {
+                injected = true;
+                throw new Error(`injected ${phase}`);
+              }
+            },
+          },
+        ),
+        new RegExp(`injected ${phase}`),
+      );
+      assert.equal(await directoryValue(first), "old-first", phase);
+      assert.equal(await directoryValue(second), "old-second", phase);
+      assert.deepEqual(await swapArtifacts(root), [], phase);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("copy and destination-lock failures never expose a partial target", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-operation-failure-"));
+  try {
+    const target = path.join(root, "dist");
+    const source = path.join(root, "source");
+    await seedDirectory(target, "old");
+    await seedDirectory(source, "new");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        operations: {
+          copy: async (_source: string, destination: string) => {
+            await seedDirectory(destination, "partial");
+            throw Object.assign(new Error("injected copy failure"), { code: "ENOSPC" });
+          },
+        },
+      }),
+      /injected copy failure/,
+    );
+    assert.equal(await directoryValue(target), "old");
+    assert.deepEqual(await swapArtifacts(root), []);
+
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        operations: {
+          rename: async (from: string, to: string) => {
+            if (to.includes(".codex-autoresearch-rollback-")) {
+              throw Object.assign(new Error("active target locked"), { code: "EPERM" });
+            }
+            await rename(from, to);
+          },
+        },
+      }),
+      /active target locked/,
+    );
+    assert.equal(await directoryValue(target), "old");
+    assert.deepEqual(await swapArtifacts(root), []);
+
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        operations: {
+          rename: async (from: string, to: string) => {
+            if (path.basename(from) === "payload") {
+              throw Object.assign(new Error("destination locked"), { code: "EPERM" });
+            }
+            await rename(from, to);
+          },
+        },
+      }),
+      /destination locked/,
+    );
+    assert.equal(await directoryValue(target), "old");
+    assert.deepEqual(await swapArtifacts(root), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("successful install with locked cleanup retains an actionable rollback", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-cleanup-failure-"));
+  try {
+    const target = path.join(root, "dist");
+    const source = path.join(root, "source");
+    await seedDirectory(target, "old");
+    await seedDirectory(source, "new");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        operations: {
+          remove: async (artifact: string, options: { recursive?: boolean; force?: boolean }) => {
+            if (artifact.includes(".codex-autoresearch-rollback-")) {
+              throw Object.assign(new Error("rollback cleanup locked"), { code: "EPERM" });
+            }
+            await rm(artifact, options);
+          },
+        },
+      }),
+      /installed and verified.*rollback cleanup locked.*retained rollback path/i,
+    );
+    assert.equal(await directoryValue(target), "new");
+    const rollback = (await readdir(root)).find((entry) => entry.includes("-rollback-"));
+    assert.ok(rollback);
+    assert.equal(await directoryValue(path.join(root, rollback)), "old");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }]),
+      /Stale owned rollback directory.*Inspect both paths.*remove only the obsolete owned copy/i,
+    );
+    assert.equal(await directoryValue(path.join(root, rollback)), "old");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("marker-removal failure reports the restored active target and retry removes the residue", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-marker-failure-"));
+  try {
+    const target = path.join(root, "dist");
+    const source = path.join(root, "source");
+    await seedDirectory(target, "old");
+    await seedDirectory(source, "new");
+    const canonicalTarget = await realpath(target);
+    await mkdir(path.join(root, "scripts"), { recursive: true });
+    await mkdir(path.join(target, "scripts"), { recursive: true });
+    await mkdir(path.join(source, "scripts"), { recursive: true });
+    await writeFile(
+      path.join(root, "package.json"),
+      `${JSON.stringify({ name: "codex-autoresearch", version: PLUGIN_VERSION })}\n`,
+    );
+    await writeFile(
+      path.join(target, "scripts", "autoresearch.mjs"),
+      "export const original = true;\n",
+    );
+    await writeFile(
+      path.join(source, "scripts", "autoresearch.mjs"),
+      "export const replacement = true;\n",
+    );
+    for (const asset of ["dashboard-app.js", "dashboard-app.css"]) {
+      const assetPath = path.join(root, "assets", "dashboard-build", asset);
+      await mkdir(path.dirname(assetPath), { recursive: true });
+      await writeFile(assetPath, `${asset}\n`);
+    }
+    let markerFailureInjected = false;
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        onPhase: async (phase: string) => {
+          if (phase === "after-all-backups") throw new Error("stop after backup");
+        },
+        operations: {
+          remove: async (artifact: string, options: { recursive?: boolean; force?: boolean }) => {
+            if (path.basename(artifact) === ".codex-autoresearch-swap-owner.json") {
+              markerFailureInjected = true;
+              throw Object.assign(new Error("marker locked"), { code: "EPERM" });
+            }
+            await rm(artifact, options);
+          },
+        },
+      }),
+      new RegExp(
+        `original directory is active at ${escapeRegExp(canonicalTarget)}.*marker locked.*Recovery evidence was retained at: ${escapeRegExp(canonicalTarget)}`,
+        "i",
+      ),
+    );
+    assert.equal(markerFailureInjected, true);
+    assert.equal(await directoryValue(target), "old");
+    assert.equal(await hasDirectorySwapArtifacts([target]), true);
+    assert.deepEqual(
+      (await readdir(root)).filter((entry) => entry.includes("-rollback-")),
+      [],
+    );
+
+    const runtimeHref = await ensureRuntime(
+      "autoresearch.mjs",
+      pathToFileURL(path.join(root, "scripts", "autoresearch.mjs")).href,
+      { releaseBaseUrl: "http://127.0.0.1:1" },
+    );
+    assert.equal(await directoryValue(target), "old");
+    assert.match(await readFile(new URL(runtimeHref), "utf8"), /original/);
+    assert.equal(await hasDirectorySwapArtifacts([target]), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("stale recovery restores rollback before cleaning a stage in reversed enumeration", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-recovery-order-"));
+  try {
+    const target = path.join(root, "dist");
+    const source = path.join(root, "source");
+    await seedDirectory(target, "old");
+    await seedDirectory(source, "new");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        onPhase: async (phase: string) => {
+          if (phase === "after-all-backups") throw new Error("stop after backup");
+        },
+        operations: {
+          remove: async (artifact: string, options: { recursive?: boolean; force?: boolean }) => {
+            if (artifact.includes(".codex-autoresearch-stage-")) {
+              throw Object.assign(new Error("stage cleanup locked"), { code: "EPERM" });
+            }
+            await rm(artifact, options);
+          },
+          rename: async (from: string, to: string) => {
+            if (from.includes(".codex-autoresearch-rollback-")) {
+              throw Object.assign(new Error("restore locked"), { code: "EPERM" });
+            }
+            await rename(from, to);
+          },
+        },
+      }),
+      /Directory restoration needs attention.*stage cleanup locked.*Recovery evidence was retained/i,
+    );
+    await assert.rejects(access(target));
+    assert.equal((await readdir(root)).filter((entry) => SWAP_ARTIFACT.test(entry)).length, 2);
+
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        onPhase: async (phase: string) => {
+          if (phase === "before-copy") throw new Error("stop after ordered recovery");
+        },
+        operations: {
+          readDirectory: async (directory: string) =>
+            (await readdir(directory, { withFileTypes: true })).reverse(),
+        },
+      }),
+      /stop after ordered recovery/,
+    );
+    assert.equal(await directoryValue(target), "old");
+    assert.deepEqual(await swapArtifacts(root), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("runtime readiness does not bypass stale rollback evidence", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-ready-rollback-"));
+  try {
+    const pluginDir = path.join(root, "plugin");
+    const dist = path.join(pluginDir, "dist");
+    const source = path.join(root, "new-dist");
+    const importerUrl = pathToFileURL(path.join(pluginDir, "scripts", "autoresearch.mjs")).href;
+    await mkdir(path.join(pluginDir, "scripts"), { recursive: true });
+    await writeFile(
+      path.join(pluginDir, "package.json"),
+      `${JSON.stringify({ name: "codex-autoresearch", version: PLUGIN_VERSION })}\n`,
+    );
+    await mkdir(path.join(dist, "scripts"), { recursive: true });
+    await mkdir(path.join(source, "scripts"), { recursive: true });
+    await writeFile(path.join(dist, "scripts", "autoresearch.mjs"), "export const old = true;\n");
+    await writeFile(
+      path.join(source, "scripts", "autoresearch.mjs"),
+      "export const next = true;\n",
+    );
+    for (const asset of ["dashboard-app.js", "dashboard-app.css"]) {
+      const assetPath = path.join(pluginDir, "assets", "dashboard-build", asset);
+      await mkdir(path.dirname(assetPath), { recursive: true });
+      await writeFile(assetPath, `${asset}\n`);
+    }
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(pluginDir, [{ source, target: dist }], {
+        operations: {
+          remove: async (artifact: string, options: { recursive?: boolean; force?: boolean }) => {
+            if (artifact.includes(".codex-autoresearch-rollback-")) {
+              throw new Error("retain rollback for launcher probe");
+            }
+            await rm(artifact, options);
+          },
+        },
+      }),
+      /retain rollback for launcher probe/,
+    );
+
+    await assert.rejects(
+      ensureRuntime("autoresearch.mjs", importerUrl, { releaseBaseUrl: "http://127.0.0.1:1" }),
+      /Stale owned rollback directory.*Inspect both paths/i,
+    );
+    assert.match(await readFile(path.join(dist, "scripts", "autoresearch.mjs"), "utf8"), /next/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("restore failure is actionable and a later retry recovers marked rollback evidence", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-restore-failure-"));
+  try {
+    const target = path.join(root, "dist");
+    const source = path.join(root, "source");
+    await seedDirectory(target, "old");
+    await seedDirectory(source, "new");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        onPhase: async (phase: string) => {
+          if (phase === "after-all-backups") throw new Error("stop after backup");
+        },
+        operations: {
+          rename: async (from: string, to: string) => {
+            if (from.includes(".codex-autoresearch-rollback-")) {
+              throw Object.assign(new Error("restore locked"), { code: "EPERM" });
+            }
+            await rename(from, to);
+          },
+        },
+      }),
+      /Directory restoration needs attention.*Recovery evidence was retained.*Inspect the named paths/i,
+    );
+    await assert.rejects(access(target));
+    const rollback = (await readdir(root)).find((entry) => entry.includes("-rollback-"));
+    assert.ok(rollback);
+    assert.equal(await directoryValue(path.join(root, rollback)), "old");
+
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }], {
+        onPhase: async (phase: string) => {
+          if (phase === "after-stale-rollback-recovery") {
+            throw new Error("stop after stale recovery");
+          }
+        },
+      }),
+      /stop after stale recovery/,
+    );
+    assert.equal(await directoryValue(target), "old");
+    assert.deepEqual(await swapArtifacts(root), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("swap cleanup refuses unowned, out-of-root, and linked artifacts without deleting them", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-containment-"));
+  const outside = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-outside-"));
+  try {
+    const target = path.join(root, "dist");
+    const source = path.join(root, "source");
+    await seedDirectory(target, "old");
+    await seedDirectory(source, "new");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target: path.join(outside, "dist") }]),
+      /outside the trusted root/,
+    );
+    assert.equal(await directoryValue(target), "old");
+
+    const unowned = path.join(
+      root,
+      ".dist.codex-autoresearch-rollback-11111111-1111-4111-8111-111111111111",
+    );
+    await seedDirectory(unowned, "do-not-delete");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }]),
+      /missing a regular ownership marker/,
+    );
+    assert.equal(await directoryValue(unowned), "do-not-delete");
+
+    await rm(unowned, { recursive: true });
+    const invalidName = path.join(root, ".dist.codex-autoresearch-rollback-not-owned");
+    await seedDirectory(invalidName, "still-do-not-delete");
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source, target }]),
+      /does not use the expected owned name.*not deleted/,
+    );
+    assert.equal(await directoryValue(invalidName), "still-do-not-delete");
+
+    const linkedSource = path.join(root, "linked-source");
+    try {
+      await symlink(source, linkedSource, process.platform === "win32" ? "junction" : "dir");
+    } catch (error) {
+      t.diagnostic(`directory links unavailable: ${String(error)}`);
+      return;
+    }
+    await assert.rejects(
+      replaceDirectoriesRollbackSafe(root, [{ source: linkedSource, target }]),
+      /symlink, junction, or file/,
+    );
+    assert.equal(await directoryValue(invalidName), "still-do-not-delete");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
 
 test("runtime hydration pins attestation to the release repository and workflow", () => {
   assert.deepEqual(runtimeAttestationArgs("release.tgz"), [
@@ -197,4 +664,8 @@ function tarFixture(name: string, type: "0" | "2"): Buffer {
 function writeTarOctal(buffer: Buffer, offset: number, length: number, value: number): void {
   const encoded = value.toString(8).padStart(length - 2, "0");
   buffer.write(`${encoded}\0 `, offset, length, "ascii");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -76,7 +76,11 @@ import {
   progressSnapshotFromRun,
   staleProgressReason,
 } from "../lib/runner-progress.js";
-import { assertSafeWriteTarget, checkedAtomicWriteFile } from "../lib/checked-write.js";
+import {
+  assertSafeWriteTarget,
+  checkedAtomicWriteFile,
+  checkedReplaceDirectory,
+} from "../lib/checked-write.js";
 import {
   sessionMutationLockLocation,
   sessionRecoveryLockPath,
@@ -439,6 +443,63 @@ test("checked atomic writes remove temporary files after write failure", async (
     assert.deepEqual(
       (await readdir(dir)).filter((entry) => entry.endsWith(".tmp")),
       [],
+    );
+  });
+});
+
+test("research directory replacement restores the original after a post-backup failure", async () => {
+  await withTempDir("checked-directory-rollback", async (dir) => {
+    const target = path.join(dir, "autoresearch.research");
+    const source = path.join(dir, "preserved-research");
+    await mkdir(target);
+    await mkdir(source);
+    await writeFile(path.join(target, "notes.md"), "original\n");
+    await writeFile(path.join(source, "notes.md"), "replacement\n");
+
+    await assert.rejects(
+      checkedReplaceDirectory(dir, target, source, {
+        onPhase: async (phase) => {
+          if (phase === "after-all-backups") throw new Error("injected research swap failure");
+        },
+      }),
+      /injected research swap failure/,
+    );
+    assert.equal(await readFile(path.join(target, "notes.md"), "utf8"), "original\n");
+    assert.deepEqual(
+      (await readdir(dir)).filter((entry) => entry.includes(".codex-autoresearch-")),
+      [],
+    );
+
+    await checkedReplaceDirectory(dir, target, source);
+    assert.equal(await readFile(path.join(target, "notes.md"), "utf8"), "replacement\n");
+  });
+});
+
+test("research directory replacement canonicalizes an aliased root and target together", async (t) => {
+  await withTempDir("checked-directory-aliased-root", async (dir) => {
+    const realParent = path.join(dir, "real-parent");
+    const aliasParent = path.join(dir, "alias-parent");
+    const realRoot = path.join(realParent, "session");
+    const source = path.join(dir, "preserved-research");
+    await mkdir(path.join(realRoot, "autoresearch.research"), { recursive: true });
+    await mkdir(source);
+    try {
+      await symlink(realParent, aliasParent, process.platform === "win32" ? "junction" : "dir");
+    } catch (error) {
+      t.skip(`directory aliases are unavailable: ${String(error)}`);
+      return;
+    }
+    const aliasedRoot = path.join(aliasParent, "session");
+    const aliasedTarget = path.join(aliasedRoot, "autoresearch.research");
+    await writeFile(path.join(aliasedTarget, "notes.md"), "original\n");
+    await writeFile(path.join(source, "notes.md"), "replacement\n");
+
+    await checkedReplaceDirectory(aliasedRoot, aliasedTarget, source);
+
+    assert.equal(await readFile(path.join(aliasedTarget, "notes.md"), "utf8"), "replacement\n");
+    assert.equal(
+      await readFile(path.join(realRoot, "autoresearch.research", "notes.md"), "utf8"),
+      "replacement\n",
     );
   });
 });

--- a/plugins/codex-autoresearch/tests/full-product.test.ts
+++ b/plugins/codex-autoresearch/tests/full-product.test.ts
@@ -671,6 +671,7 @@ test("release workflows preserve synchronized auto-release and tarball safeguard
     "scripts/autoresearch.mjs",
     "scripts/bootstrap-runtime.mjs",
     "scripts/check.mjs",
+    "scripts/directory-swap.mjs",
     "scripts/finalize-autoresearch.mjs",
     "scripts/release-integrity.mjs",
   ]) {


### PR DESCRIPTION
## Context

Closes #294.

Runtime hydration and checked research-directory replacement could delete the active target before the replacement was safely installed. An interrupted rename, antivirus lock, permission failure, or full disk could therefore leave a missing or partial directory.

## What Changed

- Added one ownership-marked, containment-checked directory-swap primitive shared by runtime hydration and checked research-directory replacement.
- Stages and verifies every replacement before moving any active target, retains all originals until the complete transaction is installed, and restores in reverse order on failure.
- Detects and validates stale stage, rollback, and restored-target markers before recovery or cleanup; ambiguous evidence fails closed and is retained for manual inspection.
- Preserved release checksum, attestation, archive-link, package-version, and required-runtime-file verification.
- Added package/source-checkout allowlists, operator guidance, release notes, and fault-injection coverage across copy, backup, install, restore, cleanup, stale recovery, and research replacement.

## How To Review

1. Start with `scripts/directory-swap.mjs`, especially ownership validation, `recoverStaleArtifacts`, and reverse-order `restoreTransaction`.
2. Confirm `scripts/bootstrap-runtime.mjs` uses one two-target transaction for `dist` and `assets/dashboard-build`.
3. Confirm `lib/checked-write.ts` routes research-directory replacement through the same primitive.
4. Review the injected failure and stale-recovery cases in `tests/bootstrap-runtime.test.ts` and `tests/evidence-core.test.ts`.

## Verification

- Focused rollback and stale-recovery regressions passed, including the two independent-review cases for active-marker removal failure and rollback-before-stage recovery ordering.
- Isolated Windows concurrent-process-tree classification test passed 1/1 in 10.317s after an unrelated load-induced CIM cancellation in the first package-gate attempt.
- Before the canonical-path amendment, one justified quiet-precondition `npm run check` rerun passed: typecheck, lint, format, source checkout, quality 15/15, CLI 245/245, full-product 20/20, perfection, dashboard 127/127, finalizer 37/37, core 350/350, package artifact, and extracted-runtime smoke.
- On the amended exact head, the original cross-platform failing case passed 1/1, the focused rollback/canonical-alias suite passed 11/11, and node typecheck, lint, format, and `git diff --check` passed.
- Exact-head GitHub proof passed on Ubuntu, macOS, and Windows, plus workflow policy and CodeQL.
- No dashboard-visible UI changed; visual evidence is not applicable.

## Risk

- A true process crash in the narrow interval after the active target is renamed but before its rollback marker is persisted leaves an unmarked directory. Recovery deliberately stops for manual inspection rather than deleting or guessing.
- Windows antivirus or file-lock interference may still prevent rename or cleanup. Those paths retain validated recovery evidence and fail closed.
