### PR TITLE
release: prepare v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+## 2.7.0 - 2026-07-11
+
+### Highlights
+
+- Reworked Autoresearch around one canonical operator decision shared by state, doctor, terminal reports, recommendations, finalization, and the read-only dashboard.
+- Hardened packet execution, process-tree termination, Git path handling, ledger streaming, runtime replacement, installed-cache discovery, and finalization revalidation for hostile and interrupted workflows.
+- Rebuilt the dashboard evidence path for bounded long histories, decision-first desktop/mobile use, explicit payload failures, keyboard and touch navigation, cross-browser release checks, and a populated 100-run public demo.
+- Replaced the self-referential perfection gate with six portable operator tasks plus a real-browser geometry task. These checks prove named workflows and release contracts; they do not claim permanent or universal product quality.
+
+### Migration and compatibility
+
+- The plugin remains CLI/skill-only. Removed MCP launchers, MCP configuration, dashboard control-plane behavior, old dashboard/finalizer subskills, and tracked generated dashboard bundles are not restored by this release.
+- Removed compatibility commands `init`, `run`, and `integrations` fail before mutation with their exact replacement commands. Their migration aliases are scheduled for removal after 2026-10-01.
+- The dashboard is a read-only live readout or static export. Setup, packet execution, logging, and finalization stay in the CLI.
+- Source checkouts rebuild or hydrate their local runtime; installed behavior is authoritative only after canonical cache version and entrypoint-fingerprint proof.
+
+### Verification and known limits
+
+- The release candidate is gated on Node 24, full package checks, hostile workflow regressions, package/extracted-launcher smoke, Chrome geometry evidence, and sequential Chromium, Firefox, and WebKit checks on Linux, plus Ubuntu, Windows, macOS, workflow-policy, and CodeQL CI.
+- Automated keyboard, modal focus, forced-colors, reduced-motion, zoom/reflow, and emulated-touch checks are included. Manual Narrator and physical-device evidence remain follow-up proof rather than a broader accessibility certification.
+
 ### Fixed
 
 - Runtime hydration and preserved research-directory restoration now stage and verify complete replacements before moving active targets, retain ownership-marked rollback directories until every rename succeeds, restore originals in reverse order on failure, and refuse unsafe stale or reparse-point cleanup.
@@ -18,6 +39,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 - Autoresearch and finalizer CLI parsing now rejects unknown root and command options, validates explicit boolean values, supports root and command `-h`/`--help`, preserves camel/kebab aliases plus repeated list and `--` passthrough behavior, and reports expected usage failures without stack traces unless `--debug` is explicit.
 - Dashboard exports and live readouts now reject missing, malformed, or version-incompatible payloads instead of substituting polished demo evidence. Demo data requires an explicit development/showcase marker, failure states show safe recovery guidance and provenance, and failed live refreshes visibly retain only the last validated readout.
 - Timed-out benchmark and checks commands now await bounded process-tree shutdown, escalate stubborn descendants, and verify termination before releasing packet state. Unproven cleanup is retained as a `termination_failed` trust blocker with safe PID evidence, partial output and artifacts, and no sentinel metric.
+- Windows process-tree proof now asks CIM only for process identity and parentage fields, keeping fail-closed timeout cleanup responsive on hosts with many active Codex and MCP processes.
 - Installed-runtime checks now honor `CODEX_HOME`, resolve the canonical `publisher/plugin/version` cache from plugin metadata, report the selected path and provenance, distinguish source-shaped packages from hydrated runtimes, and fail closed when multiple cache versions lack active-launcher proof. The obsolete combined marketplace namespace remains a labelled fallback only.
 - Finalization now revalidates accepted-current evidence immediately before review-branch creation, uses validated Git hash prefixes consistently, ignores same-commit audit-only rows, and rejects stale plans when kept membership, exclusions, evidence status, ledger ordering, or product-claim inputs change.
 - Read-only scout lanes now parse commands without a shell and execute only a strict Git read-only argv allowlist. Interpreters, shells, mutation-capable Git forms, network/process-spawning surfaces, and the old `--allow-non-git-command` escape are refused before execution; Git porcelain is reported only as best-effort post-run detection, not containment.

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Measured Codex loops with benchmark output, local evidence, live readouts, and reviewable branch previews.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/lib/runner.ts
+++ b/plugins/codex-autoresearch/lib/runner.ts
@@ -12,6 +12,7 @@ const PROCESS_OUTPUT_CAPTURE_BYTES = 32768;
 const METRIC_LINE_MAX_CHARS = 4096;
 const PROCESS_TREE_GRACE_MS = 500;
 const PROCESS_TREE_VERIFY_MS = 3000;
+const WINDOWS_PROCESS_QUERY_MS = 10_000;
 const PROCESS_TREE_PID_LIMIT = 256;
 const PROCESS_TREE_HANDLER_TIMEOUT_MS = 20_000;
 
@@ -27,7 +28,10 @@ type WindowsProcessIdentitySnapshot = {
   proven: boolean;
   reason: string;
 };
-type WindowsProcessIdentityQuery = (pids: number[]) => Promise<WindowsProcessIdentitySnapshot>;
+type WindowsProcessIdentityQuery = (
+  pids: number[],
+  signal?: AbortSignal,
+) => Promise<WindowsProcessIdentitySnapshot>;
 type WindowsProcessIdentityVerification = {
   pids: number[];
   proven: boolean;
@@ -46,7 +50,10 @@ export interface ProcessTreeTermination {
   trackedPids: number[];
 }
 
-export type ProcessTreeTerminator = (pid?: number) => Promise<ProcessTreeTermination>;
+export type ProcessTreeTerminator = (
+  pid?: number,
+  signal?: AbortSignal,
+) => Promise<ProcessTreeTermination>;
 
 export interface MetricParseOptions {
   maxMetrics?: number;
@@ -676,13 +683,17 @@ function retainedMetricText(lines: Map<string, string>): string {
   return [...lines.values()].map((line) => `${line}\n`).join("");
 }
 
-export async function terminateProcessTree(pid?: number): Promise<ProcessTreeTermination> {
+export async function terminateProcessTree(
+  pid?: number,
+  signal?: AbortSignal,
+): Promise<ProcessTreeTermination> {
   if (!Number.isSafeInteger(pid) || Number(pid) <= 0) {
     return terminationResult(pid, false, false, "none", "missing_root_pid");
   }
+  if (signal?.aborted) return abortedTermination(pid);
   return process.platform === "win32"
-    ? await terminateWindowsTree(Number(pid))
-    : await terminatePosixProcessGroup(Number(pid));
+    ? await terminateWindowsTree(Number(pid), signal)
+    : await terminatePosixProcessGroup(Number(pid), signal);
 }
 
 export async function terminateAfterTimeout(
@@ -691,9 +702,10 @@ export async function terminateAfterTimeout(
   timeoutMs = PROCESS_TREE_HANDLER_TIMEOUT_MS,
 ): Promise<ProcessTreeTermination> {
   const boundedMs = Math.max(1, Number(timeoutMs) || PROCESS_TREE_HANDLER_TIMEOUT_MS);
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | null = null;
   const handled = Promise.resolve()
-    .then(() => terminate(pid))
+    .then(() => terminate(pid, controller.signal))
     .then((result) =>
       validTerminationResult(result)
         ? result
@@ -701,21 +713,31 @@ export async function terminateAfterTimeout(
     )
     .catch(() => terminationResult(pid, true, false, "none", "termination_handler_failed"));
   const timedOut = new Promise<ProcessTreeTermination>((resolve) => {
-    timer = setTimeout(
-      () => resolve(terminationResult(pid, true, false, "none", "termination_handler_timeout")),
-      boundedMs,
-    );
+    timer = setTimeout(() => {
+      controller.abort();
+      resolve(terminationResult(pid, true, false, "none", "termination_handler_timeout"));
+    }, boundedMs);
   });
   const result = await Promise.race([handled, timedOut]);
   if (timer) clearTimeout(timer);
   return result;
 }
 
-async function terminatePosixProcessGroup(pid: number): Promise<ProcessTreeTermination> {
-  const initial = await posixProcessTreeSnapshot(pid);
+async function terminatePosixProcessGroup(
+  pid: number,
+  signal?: AbortSignal,
+): Promise<ProcessTreeTermination> {
+  if (signal?.aborted) return abortedTermination(pid, "posix-process-group");
+  const initial = await posixProcessTreeSnapshot(pid, signal);
+  if (signal?.aborted) return abortedTermination(pid, "posix-process-group");
   const graceful = signalProcessGroup(pid, "SIGTERM");
   signalTrackedPosix(initial.entries, "SIGTERM");
-  const gracefulRemaining = await waitForPidsGone(initial.trackedPids, PROCESS_TREE_GRACE_MS);
+  const gracefulRemaining = await waitForPidsGone(
+    initial.trackedPids,
+    PROCESS_TREE_GRACE_MS,
+    signal,
+  );
+  if (signal?.aborted) return abortedTermination(pid, "posix-process-group");
   if (
     initial.proven &&
     graceful !== "failed" &&
@@ -733,12 +755,14 @@ async function terminatePosixProcessGroup(pid: number): Promise<ProcessTreeTermi
       [],
     );
   }
-  const second = await posixProcessTreeSnapshot(pid);
+  const second = await posixProcessTreeSnapshot(pid, signal);
+  if (signal?.aborted) return abortedTermination(pid, "posix-process-group");
   const entries = mergeProcessEntries(initial.entries, second.entries);
   const trackedPids = entries.map((entry) => entry.pid);
   const forced = signalProcessGroup(pid, "SIGKILL");
   signalTrackedPosix(entries, "SIGKILL");
-  const remainingPids = await waitForPidsGone(trackedPids, PROCESS_TREE_VERIFY_MS);
+  const remainingPids = await waitForPidsGone(trackedPids, PROCESS_TREE_VERIFY_MS, signal);
+  if (signal?.aborted) return abortedTermination(pid, "posix-process-group");
   const proven =
     initial.proven &&
     second.proven &&
@@ -757,13 +781,21 @@ async function terminatePosixProcessGroup(pid: number): Promise<ProcessTreeTermi
   );
 }
 
-async function terminateWindowsTree(pid: number): Promise<ProcessTreeTermination> {
-  let snapshot = await windowsProcessTreeSnapshot(pid);
+async function terminateWindowsTree(
+  pid: number,
+  signal?: AbortSignal,
+): Promise<ProcessTreeTermination> {
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
+  let snapshot = await windowsProcessTreeSnapshot(pid, [], true, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   if (!snapshot.proven && pidState(pid) !== "gone") {
-    snapshot = await windowsProcessTreeSnapshot(pid);
+    snapshot = await windowsProcessTreeSnapshot(pid, [], true, signal);
+    if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   }
-  const gracefulCode = await taskkill(pid, false);
-  let remainingPids = await waitForPidsGone(snapshot.trackedPids, PROCESS_TREE_GRACE_MS);
+  const gracefulCode = await taskkill(pid, false, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
+  let remainingPids = await waitForPidsGone(snapshot.trackedPids, PROCESS_TREE_GRACE_MS, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   if (snapshot.proven && remainingPids.length === 0) {
     return terminationResult(
       pid,
@@ -776,7 +808,8 @@ async function terminateWindowsTree(pid: number): Promise<ProcessTreeTermination
       [],
     );
   }
-  const refreshed = await windowsProcessTreeSnapshot(pid, snapshot.entries, false);
+  const refreshed = await windowsProcessTreeSnapshot(pid, snapshot.entries, false, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   const originalRoot = snapshot.entries.find((entry) => entry.pid === pid);
   const refreshedRoot = refreshed.entries.find((entry) => entry.pid === pid);
   const rootIdentityChanged = Boolean(
@@ -793,18 +826,34 @@ async function terminateWindowsTree(pid: number): Promise<ProcessTreeTermination
       };
   const entries = mergeProcessEntries(snapshot.entries, second.entries);
   const trackedPids = entries.map((entry) => entry.pid);
-  const forcedCode = rootIdentityChanged ? null : await taskkill(pid, true);
-  const forcedRemaining = await waitForPidsGone(trackedPids, PROCESS_TREE_GRACE_MS);
+  const forcedCode = rootIdentityChanged ? null : await taskkill(pid, true, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
+  const forcedRemaining = await waitForPidsGone(trackedPids, PROCESS_TREE_GRACE_MS, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   if (forcedRemaining.length > 0) {
-    const preForceVerification = await verifyWindowsProcessIdentities(entries, forcedRemaining);
+    const preForceVerification = await verifyWindowsProcessIdentities(
+      entries,
+      forcedRemaining,
+      windowsProcessIdentities,
+      signal,
+    );
+    if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
     if (preForceVerification.proven && preForceVerification.pids.length > 0) {
-      await taskkillPids(preForceVerification.pids, true);
+      await taskkillPids(preForceVerification.pids, true, signal);
+      if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
     }
   }
-  const finalCandidates = await waitForPidsGone(trackedPids, PROCESS_TREE_VERIFY_MS);
+  const finalCandidates = await waitForPidsGone(trackedPids, PROCESS_TREE_VERIFY_MS, signal);
+  if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   let finalVerification: WindowsProcessIdentityVerification | null = null;
   if (finalCandidates.length > 0) {
-    finalVerification = await verifyWindowsProcessIdentities(entries, finalCandidates);
+    finalVerification = await verifyWindowsProcessIdentities(
+      entries,
+      finalCandidates,
+      windowsProcessIdentities,
+      signal,
+    );
+    if (signal?.aborted) return abortedTermination(pid, "windows-taskkill-tree");
   }
   const identityVerification = authoritativeWindowsIdentityVerification(
     finalCandidates,
@@ -833,11 +882,15 @@ async function terminateWindowsTree(pid: number): Promise<ProcessTreeTermination
   );
 }
 
-async function posixProcessTreeSnapshot(pid: number): Promise<ProcessTreeSnapshot> {
+async function posixProcessTreeSnapshot(
+  pid: number,
+  signal?: AbortSignal,
+): Promise<ProcessTreeSnapshot> {
   const result = await execFileResult(
     "ps",
     ["-axo", "pid=,ppid=,pgid=,lstart="],
     PROCESS_TREE_VERIFY_MS,
+    signal,
   );
   if (result.code !== 0) {
     return {
@@ -920,6 +973,7 @@ async function windowsProcessTreeSnapshot(
   pid: number,
   seeds: ProcessIdentity[] = [],
   requireRoot = true,
+  signal?: AbortSignal,
 ): Promise<ProcessTreeSnapshot> {
   const fallbackPids = [...new Set([pid, ...seeds.map((entry) => entry.pid)])].slice(
     0,
@@ -928,7 +982,7 @@ async function windowsProcessTreeSnapshot(
   const script = [
     "& {",
     "param([int]$RootProcessId, [string]$SeedsBase64, [int]$RequireRoot)",
-    "$all = @(Get-CimInstance Win32_Process -ErrorAction Stop | Select-Object ProcessId, ParentProcessId, CreationDate)",
+    "$all = @(Get-CimInstance Win32_Process -Property ProcessId, ParentProcessId, CreationDate -ErrorAction Stop)",
     "$rootPresent = @($all | Where-Object { [int]$_.ProcessId -eq $RootProcessId }).Count -gt 0",
     "if ($RequireRoot -eq 1 -and -not $rootPresent) { throw 'root_missing' }",
     "$seeds = @((ConvertFrom-Json ([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($SeedsBase64)))))",
@@ -962,7 +1016,8 @@ async function windowsProcessTreeSnapshot(
       ).toString("base64"),
       requireRoot ? "1" : "0",
     ],
-    PROCESS_TREE_VERIFY_MS,
+    WINDOWS_PROCESS_QUERY_MS,
+    signal,
   );
   if (result.code !== 0) {
     return {
@@ -1010,7 +1065,10 @@ async function windowsProcessTreeSnapshot(
   }
 }
 
-async function windowsProcessIdentities(pids: number[]): Promise<WindowsProcessIdentitySnapshot> {
+async function windowsProcessIdentities(
+  pids: number[],
+  signal?: AbortSignal,
+): Promise<WindowsProcessIdentitySnapshot> {
   if (pids.length === 0) {
     return {
       identities: new Map(),
@@ -1022,13 +1080,14 @@ async function windowsProcessIdentities(pids: number[]): Promise<WindowsProcessI
     "& {",
     "param([string]$IdsJson)",
     "$ids = @((ConvertFrom-Json $IdsJson) | ForEach-Object { [int]$_ })",
-    "@(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object { $ids -contains [int]$_.ProcessId } | ForEach-Object { [pscustomobject]@{ pid = [int]$_.ProcessId; started = $_.CreationDate.ToUniversalTime().ToString('o') } }) | ConvertTo-Json -Compress",
+    "@(Get-CimInstance Win32_Process -Property ProcessId, CreationDate -ErrorAction Stop | Where-Object { $ids -contains [int]$_.ProcessId } | ForEach-Object { [pscustomobject]@{ pid = [int]$_.ProcessId; started = $_.CreationDate.ToUniversalTime().ToString('o') } }) | ConvertTo-Json -Compress",
     "}",
   ].join("\n");
   const result = await execFileResult(
     "powershell.exe",
     ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script, JSON.stringify(pids)],
-    PROCESS_TREE_VERIFY_MS,
+    WINDOWS_PROCESS_QUERY_MS,
+    signal,
   );
   if (result.code !== 0) {
     return {
@@ -1078,9 +1137,10 @@ export async function verifyWindowsProcessIdentities(
   entries: Array<Pick<ProcessIdentity, "pid" | "started">>,
   pids: number[],
   query: WindowsProcessIdentityQuery = windowsProcessIdentities,
+  signal?: AbortSignal,
 ): Promise<WindowsProcessIdentityVerification> {
   const candidates = [...new Set(pids)];
-  const snapshot = await query(candidates);
+  const snapshot = await query(candidates, signal);
   if (!snapshot.proven) {
     return { pids: candidates, proven: false, reason: snapshot.reason };
   }
@@ -1110,15 +1170,20 @@ export function authoritativeWindowsIdentityVerification(
   };
 }
 
-function taskkill(pid: number, force: boolean): Promise<number | null> {
-  return taskkillPids([pid], force);
+function taskkill(pid: number, force: boolean, signal?: AbortSignal): Promise<number | null> {
+  return taskkillPids([pid], force, signal);
 }
 
-function taskkillPids(pids: number[], force: boolean): Promise<number | null> {
+function taskkillPids(
+  pids: number[],
+  force: boolean,
+  signal?: AbortSignal,
+): Promise<number | null> {
   return execFileResult(
     "taskkill",
     [...pids.flatMap((pid) => ["/pid", String(pid)]), "/t", ...(force ? ["/f"] : [])],
     force ? PROCESS_TREE_VERIFY_MS : PROCESS_TREE_GRACE_MS,
+    signal,
   ).then((result) => result.code);
 }
 
@@ -1126,19 +1191,28 @@ function execFileResult(
   command: string,
   args: string[],
   timeout: number,
+  signal?: AbortSignal,
 ): Promise<{ code: number | null; stdout: string }> {
   return new Promise((resolve) => {
-    execFile(
-      command,
-      args,
-      { maxBuffer: 64 * 1024, timeout, windowsHide: true },
-      (error, stdout) => {
-        resolve({
-          code: error ? (typeof error.code === "number" ? error.code : null) : 0,
-          stdout: String(stdout || ""),
-        });
-      },
-    );
+    if (signal?.aborted) {
+      resolve({ code: null, stdout: "" });
+      return;
+    }
+    try {
+      execFile(
+        command,
+        args,
+        { maxBuffer: 64 * 1024, signal, timeout, windowsHide: true },
+        (error, stdout) => {
+          resolve({
+            code: error ? (typeof error.code === "number" ? error.code : null) : 0,
+            stdout: String(stdout || ""),
+          });
+        },
+      );
+    } catch {
+      resolve({ code: null, stdout: "" });
+    }
   });
 }
 
@@ -1151,10 +1225,14 @@ function signalProcessGroup(pid: number, signal: NodeJS.Signals): "sent" | "gone
   }
 }
 
-async function waitForPidsGone(pids: number[], timeoutMs: number): Promise<number[]> {
+async function waitForPidsGone(
+  pids: number[],
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<number[]> {
   const deadline = Date.now() + timeoutMs;
   let remaining = pids.filter((pid) => pidState(pid) !== "gone");
-  while (remaining.length > 0 && Date.now() < deadline) {
+  while (remaining.length > 0 && Date.now() < deadline && !signal?.aborted) {
     await new Promise((resolve) => setTimeout(resolve, 25));
     remaining = remaining.filter((pid) => pidState(pid) !== "gone");
   }
@@ -1204,6 +1282,13 @@ function terminationResult(
     remainingPids: remainingPids.slice(0, PROCESS_TREE_PID_LIMIT),
     trackedPids: trackedPids.slice(0, PROCESS_TREE_PID_LIMIT),
   };
+}
+
+function abortedTermination(
+  pid: number | undefined,
+  method: ProcessTreeTermination["method"] = "none",
+): ProcessTreeTermination {
+  return terminationResult(pid, true, false, method, "termination_handler_aborted");
 }
 
 function validTerminationResult(value: unknown): value is ProcessTreeTermination {

--- a/plugins/codex-autoresearch/package-lock.json
+++ b/plugins/codex-autoresearch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-autoresearch",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "description": "Codex plugin for bounded, measured benchmark and optimization loops.",
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",

--- a/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
+++ b/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
@@ -14,7 +14,7 @@ const ABSOLUTE_DOCTOR_COMMAND =
   /node ".*codex autoresearch.*scripts[\\/]autoresearch\.mjs" doctor --cwd ".*codex autoresearch" --explain/;
 const SOURCE_FINGERPRINT = "a".repeat(64);
 
-const FIXTURE_VERSION = "2.6.0";
+const FIXTURE_VERSION = "2.7.0";
 const RUNTIME_CONTENT = "export const runtimeFixture = true;\n";
 const runtimePath = (cacheRoot: string, version: string) =>
   path.join(cacheRoot, "TheGreenCedar", "codex-autoresearch", version);
@@ -87,7 +87,7 @@ test("multiple versions fail closed unless the running launcher selects one", as
     const cacheRoot = path.join(dir, "cache");
     const activeRoot = runtimePath(cacheRoot, FIXTURE_VERSION);
     await writeSource(sourceRoot);
-    await writeRuntimePackage(runtimePath(cacheRoot, "2.5.0"), "2.5.0", {
+    await writeRuntimePackage(runtimePath(cacheRoot, "2.6.0"), "2.6.0", {
       runtimeContent: RUNTIME_CONTENT,
     });
     await writeRuntimePackage(activeRoot, FIXTURE_VERSION, {
@@ -140,7 +140,7 @@ test("source-shaped, package, missing, and stale surfaces stay distinct", async 
     assert.equal(missing.installedRuntime, "missing");
 
     const staleCache = path.join(dir, "stale-cache");
-    await writeRuntimePackage(runtimePath(staleCache, "2.5.0"), "2.5.0", {
+    await writeRuntimePackage(runtimePath(staleCache, "2.6.0"), "2.6.0", {
       runtimeContent: RUNTIME_CONTENT,
     });
     const stale = await inspectRuntimeDrift({
@@ -149,7 +149,7 @@ test("source-shaped, package, missing, and stale surfaces stay distinct", async 
       pluginCacheRoot: staleCache,
     });
     assert.equal(stale.installedRuntime, "stale");
-    assert.equal(stale.installedRuntimeVersion, "2.5.0");
+    assert.equal(stale.installedRuntimeVersion, "2.6.0");
 
     const packageRoot = path.join(dir, "package");
     await writeSource(packageRoot, true);

--- a/plugins/codex-autoresearch/tests/evidence-core.test.ts
+++ b/plugins/codex-autoresearch/tests/evidence-core.test.ts
@@ -291,6 +291,49 @@ test("termination wrapper rejects an invalid hook result", async () => {
   assert.deepEqual(result.remainingPids, [4242]);
 });
 
+test("termination wrapper aborts a timed-out hook before it can mutate later", async () => {
+  let observedAbort = false;
+  let mutatedAfterTimeout = false;
+  const result = await terminateAfterTimeout(
+    4242,
+    async (pid, signal) => {
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) {
+          observedAbort = true;
+          resolve();
+          return;
+        }
+        signal?.addEventListener(
+          "abort",
+          () => {
+            observedAbort = true;
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      if (!signal?.aborted) mutatedAfterTimeout = true;
+      return {
+        attempted: true,
+        escalated: false,
+        method: "none",
+        pid: pid ?? null,
+        platform: process.platform,
+        proven: false,
+        reason: "hook_finished",
+        remainingPids: pid ? [pid] : [],
+        trackedPids: pid ? [pid] : [],
+      };
+    },
+    10,
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(result.reason, "termination_handler_timeout");
+  assert.equal(observedAbort, true);
+  assert.equal(mutatedAfterTimeout, false);
+});
+
 test("Windows identity-query failure keeps every candidate PID unproven", async () => {
   const requested: number[][] = [];
   const result = await verifyWindowsProcessIdentities(


### PR DESCRIPTION
## Context

This is the protected release-preparation change for v2.7.0 and the final implementation dependency of #307. It synchronizes version metadata, publishes honest release notes for the completed v2.7 roadmap, and hardens Windows process-tree proof under busy Codex/MCP hosts.

## What Changed

- bumped package, lockfile, and plugin manifest to 2.7.0
- added v2.7.0 highlights, migrations, verification scope, and known limits to the changelog
- bounded Windows CIM queries to process identity/parentage fields
- cancelled losing process-tree cleanup work when its outer timeout expires, across Windows and POSIX paths
- added a regression proving timed-out cleanup hooks cannot mutate after the timeout result
- advanced runtime-drift fixtures from 2.6.0 current / 2.5.0 stale to 2.7.0 current / 2.6.0 stale

## How To Review

1. Review the release contract and known limits in CHANGELOG.md.
2. Confirm all three version surfaces are 2.7.0.
3. Trace terminateAfterTimeout through the AbortSignal checks in lib/runner.ts.
4. Review the cooperative post-timeout mutation regression in tests/evidence-core.test.ts.

## Verification

- npm run check: passed; 795 executable tests passed, 1 intentional performance skip
- real Chrome dashboard/demo gate: passed with 20 visible plotted points and populated Run #100 details
- Chromium, Firefox, and WebKit dashboard checks: passed sequentially
- npm audit --omit=dev and npm audit: 0 vulnerabilities
- exact packed candidate smoke: passed; 170 files; SHA-256 08840f2669cf41636d836004de8a11cbc9f26e2a733bdcf47bfdca95d7971bf7
- git diff --check: passed
- independent release diff review: no blockers

## Risk

Process cleanup remains deliberately fail-closed: if enumeration, identity proof, or cancellation cannot be proven, Autoresearch records a termination blocker instead of releasing trusted packet state. Manual Narrator and physical-device accessibility proof remain explicit follow-up evidence rather than release certification.

Tracks #307.