### PR TITLE
Promote Codex Autoresearch 2.7.1 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 
 ## Unreleased
 
+## 2.7.1 - 2026-07-11
+
+### Fixed
+
+- Source-shaped marketplace installs now accept the packaged operator-task benchmark launchers during verified release hydration. The package gate also checks every explicit source and compiled launcher against the bootstrap archive allowlist, closing the gap that made the v2.7.0 artifact valid but unusable from a fresh marketplace cache.
+
 ## 2.7.0 - 2026-07-11
 
 ### Highlights

--- a/plugins/codex-autoresearch/.codex-plugin/plugin.json
+++ b/plugins/codex-autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Measured Codex loops with benchmark output, local evidence, live readouts, and reviewable branch previews.",
   "author": {
     "name": "Albert Najjar",

--- a/plugins/codex-autoresearch/package-lock.json
+++ b/plugins/codex-autoresearch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-autoresearch",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/plugins/codex-autoresearch/package.json
+++ b/plugins/codex-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-autoresearch",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "description": "Codex plugin for bounded, measured benchmark and optimization loops.",
   "homepage": "https://github.com/TheGreenCedar/codex-autoresearch",

--- a/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
+++ b/plugins/codex-autoresearch/scripts/bootstrap-runtime.mjs
@@ -352,13 +352,15 @@ function isExpectedRuntimeArchiveFile(name) {
   if (name === "assets/template.html") return true;
   if (/^dist\/lib\/.+\.mjs$/.test(name)) return true;
   if (
-    /^dist\/scripts\/(?:autoresearch|check|check-runner|finalize-autoresearch)\.mjs$/.test(name)
+    /^dist\/scripts\/(?:autoresearch|check|check-runner|finalize-autoresearch|operator-task-benchmark)\.mjs$/.test(
+      name,
+    )
   ) {
     return true;
   }
   if (/^docs\/.+\.md$/.test(name)) return true;
   if (
-    /^scripts\/(?:autoresearch|bootstrap-runtime|check|directory-swap|finalize-autoresearch|release-integrity)\.mjs$/.test(
+    /^scripts\/(?:autoresearch|bootstrap-runtime|check|directory-swap|finalize-autoresearch|operator-task-benchmark|release-integrity)\.mjs$/.test(
       name,
     )
   ) {

--- a/plugins/codex-autoresearch/tests/bootstrap-runtime.test.ts
+++ b/plugins/codex-autoresearch/tests/bootstrap-runtime.test.ts
@@ -535,6 +535,26 @@ test("runtime archive validation accepts only regular package files and director
   }
 });
 
+test("runtime archive validation accepts every explicitly packaged launcher", async () => {
+  const packageJson = JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as {
+    files?: unknown;
+  };
+  const packagedLaunchers = Array.isArray(packageJson.files)
+    ? packageJson.files.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && /^(?:dist\/)?scripts\/[^/*]+\.mjs$/.test(entry),
+      )
+    : [];
+
+  assert.ok(packagedLaunchers.includes("dist/scripts/operator-task-benchmark.mjs"));
+  assert.ok(packagedLaunchers.includes("scripts/operator-task-benchmark.mjs"));
+  assert.doesNotThrow(() =>
+    validateRuntimeArchiveEntries(
+      packagedLaunchers.map((name) => ({ name: `package/${name}`, type: "-" })),
+    ),
+  );
+});
+
 test("runtime archive preflight rejects malicious tar fixtures before extraction", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "autoresearch-runtime-tar-"));
   try {

--- a/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
+++ b/plugins/codex-autoresearch/tests/decision-guidance-runtime-drift.test.ts
@@ -14,7 +14,7 @@ const ABSOLUTE_DOCTOR_COMMAND =
   /node ".*codex autoresearch.*scripts[\\/]autoresearch\.mjs" doctor --cwd ".*codex autoresearch" --explain/;
 const SOURCE_FINGERPRINT = "a".repeat(64);
 
-const FIXTURE_VERSION = "2.7.0";
+const FIXTURE_VERSION = "2.7.1";
 const RUNTIME_CONTENT = "export const runtimeFixture = true;\n";
 const runtimePath = (cacheRoot: string, version: string) =>
   path.join(cacheRoot, "TheGreenCedar", "codex-autoresearch", version);
@@ -87,7 +87,7 @@ test("multiple versions fail closed unless the running launcher selects one", as
     const cacheRoot = path.join(dir, "cache");
     const activeRoot = runtimePath(cacheRoot, FIXTURE_VERSION);
     await writeSource(sourceRoot);
-    await writeRuntimePackage(runtimePath(cacheRoot, "2.6.0"), "2.6.0", {
+    await writeRuntimePackage(runtimePath(cacheRoot, "2.7.0"), "2.7.0", {
       runtimeContent: RUNTIME_CONTENT,
     });
     await writeRuntimePackage(activeRoot, FIXTURE_VERSION, {
@@ -140,7 +140,7 @@ test("source-shaped, package, missing, and stale surfaces stay distinct", async 
     assert.equal(missing.installedRuntime, "missing");
 
     const staleCache = path.join(dir, "stale-cache");
-    await writeRuntimePackage(runtimePath(staleCache, "2.6.0"), "2.6.0", {
+    await writeRuntimePackage(runtimePath(staleCache, "2.7.0"), "2.7.0", {
       runtimeContent: RUNTIME_CONTENT,
     });
     const stale = await inspectRuntimeDrift({
@@ -149,7 +149,7 @@ test("source-shaped, package, missing, and stale surfaces stay distinct", async 
       pluginCacheRoot: staleCache,
     });
     assert.equal(stale.installedRuntime, "stale");
-    assert.equal(stale.installedRuntimeVersion, "2.6.0");
+    assert.equal(stale.installedRuntimeVersion, "2.7.0");
 
     const packageRoot = path.join(dir, "package");
     await writeSource(packageRoot, true);


### PR DESCRIPTION
## Context

Immediate patch promotion for P1 #336. The v2.7.0 release artifact was valid and attested, but source-shaped marketplace hydration rejected its newly packaged operator benchmark launchers. PR #337 fixes the archive contract and passed exact-head CI.

## What Changed

- promote the source/compiled operator benchmark hydration allowlist repair
- promote the package-derived launcher regression
- publish synchronized version 2.7.1 and repair notes

## How To Review

1. Confirm this PR is exactly `dev` into `main`.
2. Review #337 and #336 for the failure transcript and regression.

## Verification

- PR #337 exact-head Ubuntu, Windows, macOS, workflow policy, and both CodeQL analyzers passed
- npm run check passed: 796 executable tests, 1 intentional performance skip
- actual 2.7.1 npm-packed tarball passed verifyRuntimeArchive
- independent review found no blockers

## Risk

The archive validator remains fail-closed and adds only the already packaged operator benchmark launchers. #307 stays open until the released 2.7.1 artifact hydrates and executes from the canonical Codex cache.

Tracks #336, #307, and #283.