### PR TITLE
test: parse fragmented Chrome startup output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Current package contract: Codex Autoresearch is a CLI/skill-only plugin. Older e
 ### Fixed
 
 - Source-shaped marketplace installs now accept the packaged operator-task benchmark launchers during verified release hydration. The package gate also checks every explicit source and compiled launcher against the bootstrap archive allowlist, closing the gap that made the v2.7.0 artifact valid but unusable from a fresh marketplace cache.
+- The required Chrome release smoke now recognizes DevTools endpoint lines split across stderr chunks, avoiding false startup timeouts while preserving the same real-browser geometry assertions.
 
 ## 2.7.0 - 2026-07-11
 

--- a/plugins/codex-autoresearch/tests/dashboard-browser-a11y.test.mjs
+++ b/plugins/codex-autoresearch/tests/dashboard-browser-a11y.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dashboardHtml, serveHtml } from "./dashboard-browser-fixture.mjs";
@@ -32,6 +34,18 @@ test("dashboard geometry evidence rejects an empty demo", () => {
     () => validateDashboardGeometryEvidence(emptyDashboardGeometryObservations(true)),
     (error) => error?.code === "V27_DASHBOARD_GEOMETRY_EMPTY",
   );
+});
+
+test("Chrome startup recognizes a DevTools endpoint split across stderr chunks", async () => {
+  const browser = new EventEmitter();
+  browser.stderr = new PassThrough();
+  const endpoint = waitForDevToolsEndpoint(browser);
+
+  browser.stderr.write("DevTools listen");
+  browser.stderr.write("ing on ws://127.0.0.1:9222/devtools/browser/test\n");
+
+  assert.equal(await endpoint, "ws://127.0.0.1:9222/devtools/browser/test");
+  browser.stderr.destroy();
 });
 
 test("real browser covers dashboard focus, live refresh, motion, mobile, and large ledgers", async () => {
@@ -1097,6 +1111,7 @@ async function launchBrowser(executable) {
 function waitForDevToolsEndpoint(browser) {
   return new Promise((resolve, reject) => {
     let settled = false;
+    let stderrTail = "";
     const timeout = setTimeout(() => {
       finish(reject, new Error("Timed out waiting for Chrome DevTools endpoint."));
     }, 15000);
@@ -1119,7 +1134,8 @@ function waitForDevToolsEndpoint(browser) {
       finish(reject, error);
     };
     const onData = (chunk) => {
-      const match = String(chunk).match(/DevTools listening on (ws:\/\/[^\s]+)/);
+      stderrTail = `${stderrTail}${String(chunk)}`.slice(-8192);
+      const match = stderrTail.match(/DevTools listening on (ws:\/\/[^\s]+)/);
       if (match) finish(resolve, match[1]);
     };
 


### PR DESCRIPTION
## Context

The 2.7.1 Auto Release Chrome smoke failed twice with `Timed out waiting for Chrome DevTools endpoint` even though Chrome stayed alive. The harness matched each stderr chunk independently, so a fragmented `DevTools listening on ...` line was invisible.

## What Changed

- retain a bounded 8 KiB Chrome stderr tail while waiting for the DevTools endpoint
- match the endpoint across chunk boundaries
- add a deterministic split-chunk regression
- record the release-gate correction in the 2.7.1 changelog

## How To Review

Review waitForDevToolsEndpoint and the fake split-stderr test in tests/dashboard-browser-a11y.test.mjs.

## Verification

- split-chunk regression passed
- full local real Chrome dashboard gate passed with 20 visible points and populated Run #100 details
- dashboard build passed
- git diff --check passed

## Risk

The buffer is capped at 8 KiB and only changes endpoint discovery. All geometry, accessibility, contrast, interaction, and payload assertions are unchanged.

Tracks #336, #307, and #283.